### PR TITLE
Fast and dynamically programmable agent logger

### DIFF
--- a/src/sqreen/agent/plog/plog.go
+++ b/src/sqreen/agent/plog/plog.go
@@ -1,0 +1,251 @@
+// Implementation of simple logging interfaces efficient in production
+// environments, aiming at being as fast as possible when disabled. The trick
+// consists in changing the underlying implementation pointer with a disabled
+// logger which does nothing when called. The call when disabled costs the
+// underlying interface call indirection, equivalent to 2 method calls.
+
+package plog
+
+import (
+	"fmt"
+	"io"
+	"log"
+)
+
+// LogLevel represents the log level. Higher levels include lowers.
+type LogLevel int
+
+const (
+	// Disabled value.
+	Disabled LogLevel = iota
+	// Fatal logs.
+	Fatal
+	// Error and Fatal logs.
+	Error
+	// Warn to Fatal logs.
+	Warn
+	// Info to Fatal logs.
+	Info
+)
+
+// LogLevel type stringer.
+func (l LogLevel) String() string {
+	switch l {
+	case Fatal:
+		return "fatal"
+	case Error:
+		return "error"
+	case Warn:
+		return "warn"
+	case Info:
+		return "info"
+	}
+	return ""
+}
+
+// Logger structure wrapping logger interfaces, one per level.
+type Logger struct {
+	FatalLogger
+	ErrorLogger
+	WarnLogger
+	InfoLogger
+
+	output    io.Writer
+	namespace string
+	cache     struct {
+		fatal, error, warn, info logger
+	}
+}
+
+type FatalLogger interface {
+	Fatal(v ...interface{})
+	Fatalf(format string, v ...interface{})
+	OutputSetter
+}
+
+type ErrorLogger interface {
+	Error(v ...interface{})
+	Errorf(format string, v ...interface{})
+	OutputSetter
+}
+
+type WarnLogger interface {
+	Warn(v ...interface{})
+	Warnf(format string, v ...interface{})
+	OutputSetter
+}
+
+type InfoLogger interface {
+	Info(v ...interface{})
+	Infof(format string, v ...interface{})
+	OutputSetter
+}
+
+type OutputSetter interface {
+	SetOutput(output io.Writer)
+}
+
+// NewLogger returns a Logger instance wrapping one logger instance per level.
+// They can thus be individually enabled or disabled.
+func NewLogger(namespace string) *Logger {
+	logger := &Logger{
+		FatalLogger: disabledLogger{},
+		ErrorLogger: disabledLogger{},
+		WarnLogger:  disabledLogger{},
+		InfoLogger:  disabledLogger{},
+		namespace:   namespace,
+	}
+	loggers[namespace] = logger
+	return logger
+}
+
+// SetOutput sets the output of the logger. When `nil`, the logger is disabled
+// and equivalent to `SetLevel(Disabled)`.
+func (l *Logger) SetOutput(output io.Writer) {
+	l.output = output
+	if output == nil {
+		l.SetLevel(Disabled)
+		return
+	}
+	l.FatalLogger.SetOutput(output)
+	l.ErrorLogger.SetOutput(output)
+	l.WarnLogger.SetOutput(output)
+	l.InfoLogger.SetOutput(output)
+}
+
+// SetLevel changes the level of the logger to `level`, possibly disabling it
+// when `Disabled` is passed.
+func (l *Logger) SetLevel(level LogLevel) {
+	switch level {
+	case Disabled:
+		l.InfoLogger = disabledLogger{}
+		l.WarnLogger = disabledLogger{}
+		l.ErrorLogger = disabledLogger{}
+		l.FatalLogger = disabledLogger{}
+		break
+	case Info:
+		l.InfoLogger = l.getLogger(Info)
+		l.WarnLogger = l.getLogger(Warn)
+		l.ErrorLogger = l.getLogger(Error)
+		l.FatalLogger = l.getLogger(Fatal)
+		break
+	case Warn:
+		l.InfoLogger = disabledLogger{}
+		l.WarnLogger = l.getLogger(Warn)
+		l.ErrorLogger = l.getLogger(Error)
+		l.FatalLogger = l.getLogger(Fatal)
+		break
+	case Error:
+		l.InfoLogger = disabledLogger{}
+		l.WarnLogger = disabledLogger{}
+		l.ErrorLogger = l.getLogger(Error)
+		l.FatalLogger = l.getLogger(Fatal)
+		break
+	case Fatal:
+		l.InfoLogger = disabledLogger{}
+		l.WarnLogger = disabledLogger{}
+		l.ErrorLogger = disabledLogger{}
+		l.FatalLogger = l.getLogger(Fatal)
+		break
+	}
+}
+
+// *log.Logger format prefix: UTC time, date of the day and time with microseconds.
+const flags = log.LUTC | log.Ldate | log.Lmicroseconds
+
+// Map of loggers.
+var loggers = make(map[string]*Logger)
+
+// Enabled logger instance.
+type logger struct {
+	logger *log.Logger
+}
+
+// Return the logger instance. Create a new one if first time.
+func (l *Logger) getLogger(level LogLevel) logger {
+	cache := l.getCachedLogger(level)
+	if cache.logger == nil {
+		*cache = newLogger(l.namespace, level, l.output)
+	} else {
+		cache.SetOutput(l.output)
+	}
+	return *cache
+}
+
+// Return a new logger.
+func newLogger(namespace string, level LogLevel, output io.Writer) logger {
+	return logger{log.New(output, namespace+":"+level.String()+": ", flags)}
+}
+
+// Return the pointer to the cache entry.
+func (l *Logger) getCachedLogger(level LogLevel) *logger {
+	switch level {
+	case Info:
+		return &l.cache.info
+	case Warn:
+		return &l.cache.warn
+	case Error:
+		return &l.cache.error
+	case Fatal:
+		return &l.cache.fatal
+	}
+	return nil
+}
+
+func (l logger) Fatal(v ...interface{}) {
+	l.logger.Output(3, fmt.Sprint(v...))
+}
+
+func (l logger) Fatalf(format string, v ...interface{}) {
+	l.logger.Output(3, fmt.Sprintf(format, v...))
+}
+
+func (l logger) Info(v ...interface{}) {
+	l.logger.Output(3, fmt.Sprint(v...))
+}
+
+func (l logger) Infof(format string, v ...interface{}) {
+	l.logger.Output(3, fmt.Sprintf(format, v...))
+}
+
+func (l logger) Warn(v ...interface{}) {
+	l.logger.Output(3, fmt.Sprint(v...))
+}
+
+func (l logger) Warnf(format string, v ...interface{}) {
+	l.logger.Output(3, fmt.Sprintf(format, v...))
+}
+
+func (l logger) Error(v ...interface{}) {
+	l.logger.Output(3, fmt.Sprint(v...))
+}
+
+func (l logger) Errorf(format string, v ...interface{}) {
+	l.logger.Output(3, fmt.Sprintf(format, v...))
+}
+
+func (l logger) SetOutput(output io.Writer) {
+	l.logger.SetOutput(output)
+}
+
+type disabledLogger struct {
+}
+
+func (_ disabledLogger) Fatal(_ ...interface{}) {
+}
+func (_ disabledLogger) Fatalf(_ string, _ ...interface{}) {
+}
+func (_ disabledLogger) Error(_ ...interface{}) {
+}
+func (_ disabledLogger) Errorf(_ string, _ ...interface{}) {
+}
+func (_ disabledLogger) Warn(_ ...interface{}) {
+}
+func (_ disabledLogger) Warnf(_ string, _ ...interface{}) {
+}
+func (_ disabledLogger) Info(_ ...interface{}) {
+}
+func (_ disabledLogger) Infof(_ string, _ ...interface{}) {
+}
+func (_ disabledLogger) SetOutput(_ io.Writer) {
+}

--- a/src/sqreen/agent/plog/plog_suite_test.go
+++ b/src/sqreen/agent/plog/plog_suite_test.go
@@ -1,0 +1,13 @@
+package plog_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestPlog(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Plog Suite")
+}

--- a/src/sqreen/agent/plog/plog_test.go
+++ b/src/sqreen/agent/plog/plog_test.go
@@ -1,0 +1,164 @@
+package plog_test
+
+import (
+	"fmt"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/gbytes"
+
+	"sqreen/agent/plog"
+)
+
+var _ = Describe("plog", func() {
+	Describe("a logger", func() {
+		var (
+			logger *plog.Logger
+			re     = "ns:%s: [0-9]{4}(/[0-9]{2}){2} ([0-9]{2}:){2}[0-9]{2}.[0-9]{6} %[1]s"
+		)
+
+		JustBeforeEach(func() {
+			logger = plog.NewLogger("ns")
+		})
+
+		Context("setting its output", func() {
+			var output *gbytes.Buffer
+
+			JustBeforeEach(func() {
+				output = gbytes.NewBuffer()
+				logger.SetOutput(output)
+			})
+
+			Measure("it should be faster when disabled, slower when enabled", func(b Benchmarker) {
+				doLog := func() {
+					logger.Info("info")
+					logger.Warn("warn")
+					logger.Error("error")
+					logger.Fatal("fatal")
+				}
+
+				var allDurationAvg, disabledDurationAvg uint64
+				for n := uint64(1); n <= 1000; n++ {
+					logger.SetLevel(plog.Info)
+					allDuration := b.Time("info log level", doLog)
+					Expect(output).Should(gbytes.Say(fmt.Sprintf(re, "info")))
+					Expect(output).Should(gbytes.Say(fmt.Sprintf(re, "warn")))
+					Expect(output).Should(gbytes.Say(fmt.Sprintf(re, "error")))
+					Expect(output).Should(gbytes.Say(fmt.Sprintf(re, "fatal")))
+					allDurationAvg = allDurationAvg*(n-1)/n + uint64(allDuration)/n
+
+					logger.SetLevel(plog.Disabled)
+					disabledDuration := b.Time("back to disabled", doLog)
+					Expect(output).ShouldNot(gbytes.Say(fmt.Sprintf(re, "info")))
+					Expect(output).ShouldNot(gbytes.Say(fmt.Sprintf(re, "warn")))
+					Expect(output).ShouldNot(gbytes.Say(fmt.Sprintf(re, "error")))
+					Expect(output).ShouldNot(gbytes.Say(fmt.Sprintf(re, "fatal")))
+					disabledDurationAvg = disabledDurationAvg*(n-1)/n + uint64(disabledDuration)/n
+				}
+
+				Expect(allDurationAvg).Should(BeNumerically(">", disabledDurationAvg))
+			}, 1)
+
+			It("should be disabled", func() {
+				logger.Info("info")
+				logger.Warn("warn")
+				logger.Error("error")
+				logger.Fatal("fatal")
+				Expect(output).ShouldNot(gbytes.Say(fmt.Sprintf(re, "info")))
+				Expect(output).ShouldNot(gbytes.Say(fmt.Sprintf(re, "warn")))
+				Expect(output).ShouldNot(gbytes.Say(fmt.Sprintf(re, "error")))
+				Expect(output).ShouldNot(gbytes.Say(fmt.Sprintf(re, "fatal")))
+			})
+
+			Context("toggling from info to disabled", func() {
+				It("should log and no longer log", func() {
+					logger.SetLevel(plog.Info)
+					logger.Info("info")
+					logger.Warn("warn")
+					logger.Error("error")
+					logger.Fatal("fatal")
+					logger.SetLevel(plog.Disabled)
+					logger.Info("info")
+					logger.Warn("warn")
+					logger.Error("error")
+					logger.Fatal("fatal")
+					Expect(output).Should(gbytes.Say(fmt.Sprintf(re, "info")))
+					Expect(output).Should(gbytes.Say(fmt.Sprintf(re, "warn")))
+					Expect(output).Should(gbytes.Say(fmt.Sprintf(re, "error")))
+					Expect(output).Should(gbytes.Say(fmt.Sprintf(re, "fatal")))
+					Expect(output).ShouldNot(gbytes.Say(fmt.Sprintf(re, "info")))
+					Expect(output).ShouldNot(gbytes.Say(fmt.Sprintf(re, "warn")))
+					Expect(output).ShouldNot(gbytes.Say(fmt.Sprintf(re, "error")))
+					Expect(output).ShouldNot(gbytes.Say(fmt.Sprintf(re, "fatal")))
+				})
+			})
+
+			Context("enabling it", func() {
+				var level plog.LogLevel
+
+				JustBeforeEach(func() {
+					logger.SetLevel(level)
+				})
+
+				JustBeforeEach(func() {
+					logger.Info("info")
+					logger.Warn("warn")
+					logger.Error("error")
+					logger.Fatal("fatal")
+				})
+
+				Context("to info level", func() {
+					BeforeEach(func() {
+						level = plog.Info
+					})
+
+					It("should log", func() {
+						Expect(output).Should(gbytes.Say(fmt.Sprintf(re, "info")))
+						Expect(output).Should(gbytes.Say(fmt.Sprintf(re, "warn")))
+						Expect(output).Should(gbytes.Say(fmt.Sprintf(re, "error")))
+						Expect(output).Should(gbytes.Say(fmt.Sprintf(re, "fatal")))
+					})
+				})
+
+				Context("to warn level", func() {
+					BeforeEach(func() {
+						level = plog.Warn
+					})
+
+					It("should log", func() {
+						Expect(output).ShouldNot(gbytes.Say(fmt.Sprintf(re, "info")))
+						Expect(output).Should(gbytes.Say(fmt.Sprintf(re, "warn")))
+						Expect(output).Should(gbytes.Say(fmt.Sprintf(re, "error")))
+						Expect(output).Should(gbytes.Say(fmt.Sprintf(re, "fatal")))
+					})
+				})
+
+				Context("to error level", func() {
+					BeforeEach(func() {
+						level = plog.Error
+					})
+
+					It("should log", func() {
+						Expect(output).ShouldNot(gbytes.Say(fmt.Sprintf(re, "info")))
+						Expect(output).ShouldNot(gbytes.Say(fmt.Sprintf(re, "warn")))
+						Expect(output).Should(gbytes.Say(fmt.Sprintf(re, "error")))
+						Expect(output).Should(gbytes.Say(fmt.Sprintf(re, "fatal")))
+					})
+				})
+
+				Context("to fatal level", func() {
+					BeforeEach(func() {
+						level = plog.Fatal
+					})
+
+					It("should log", func() {
+						Expect(output).ShouldNot(gbytes.Say(fmt.Sprintf(re, "info")))
+						Expect(output).ShouldNot(gbytes.Say(fmt.Sprintf(re, "warn")))
+						Expect(output).ShouldNot(gbytes.Say(fmt.Sprintf(re, "error")))
+						Expect(output).Should(gbytes.Say(fmt.Sprintf(re, "fatal")))
+					})
+				})
+			})
+		})
+	})
+})

--- a/src/sqreen/go.mod
+++ b/src/sqreen/go.mod
@@ -1,0 +1,10 @@
+module github.com/sqreen/AgentGo
+
+require (
+	github.com/gogo/protobuf v1.1.1
+	github.com/golang/protobuf v1.2.0
+	github.com/onsi/ginkgo v1.7.0
+	github.com/onsi/gomega v1.4.3
+	golang.org/x/net v0.0.0-20181106065722-10aee1819953 // indirect
+	gopkg.in/yaml.v2 v2.2.2 // indirect
+)


### PR DESCRIPTION
Implement a logger targeting agent needs:

- fast when disabled.

- provide several logger domains to individually enable/disable them (eg. hookpoint
  logger, rules logger, etc.).

- provide several log levels, from Info to Fatal, to be able to scale the
  verbosity accordingly.

- programmable logger outputs: use the `io.Writer` interface to be able to log
  to such objects.

The approach for now only uses Go pointers to interfaces to replace them by
either a disabled or enabled logger. The disabled one is made of empty methods,
while the enable one really performs logs to the provided output.

Test the logger package when enabled and disabled, along with relative
performance comparison of enabled vs disabled to make sure it goes faster when
disabled.