### PR TITLE
SQR-5066 agent/config: user-configuration management

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -14,8 +14,6 @@ import (
 	"github.com/sqreen/AgentGo/agent/plog"
 )
 
-var token = os.Getenv("SQREEN_TOKEN")
-
 func init() {
 	start()
 }
@@ -26,10 +24,10 @@ func start() {
 
 func agent() {
 	logger := plog.NewLogger("sqreen/agent")
-	logger.SetLevel(plog.Info)
+	logger.SetLevelFromString(config.LogLevel())
 	logger.SetOutput(os.Stderr)
 
-	client, err := backend.NewClient(config.BackendHTTPAPIBaseURL)
+	client, err := backend.NewClient(config.BackendHTTPAPIBaseURL())
 	if err != nil {
 		logger.Fatal(err)
 	}
@@ -64,7 +62,7 @@ func agent() {
 		RuntimeVersion:  runtime.Version(),
 	}
 
-	appLoginRes, err := client.AppLogin(&appLoginReq, token)
+	appLoginRes, err := client.AppLogin(&appLoginReq, config.BackendHTTPAPIToken())
 	if err != nil {
 		logger.Fatal(err)
 	}

--- a/agent/config/config.go
+++ b/agent/config/config.go
@@ -1,8 +1,16 @@
+// Agent configuration package.
+
+// This package includes both compile-time and run-time configuration of the
+// agent. Variables are made configurable at run-time when necessary for users.
+
 package config
 
 import (
 	"net/http"
 	"time"
+
+	"github.com/spf13/viper"
+	"github.com/sqreen/AgentGo/agent/plog"
 )
 
 type HTTPAPIEndpoint struct {
@@ -19,9 +27,6 @@ var (
 	// Timeout value of a HTTP request. See http.Client.Timeout.
 	BackendHTTPAPIRequestTimeout = DefaultNetworkTimeout
 
-	// Base URL of the backend HTTP API.
-	BackendHTTPAPIBaseURL = "https://back.sqreen.io/sqreen"
-
 	// List of endpoint addresses, relative to the base URL.
 	BackendHTTPAPIEndpoint = struct {
 		AppLogin, AppLogout, AppBeat HTTPAPIEndpoint
@@ -37,3 +42,52 @@ var (
 	// Header name of the API session.
 	BackendHTTPAPIHeaderSession = "X-Session-Key"
 )
+
+const (
+	configEnvPrefix    = `sqreen`
+	configFileBasename = `sqreen`
+	configFilePath     = `.`
+)
+
+const (
+	configKeyBackendHTTPAPIBaseURL = `url`
+	configKeyBackendHTTPAPIToken   = `token`
+	configKeyLogLevel              = `log_level`
+)
+
+const (
+	configDefaultBackendHTTPAPIBaseURL = `https://back.sqreen.io/sqreen`
+	configDefaultLogLevel              = `debug`
+)
+
+func init() {
+	viper.SetEnvPrefix(configEnvPrefix)
+	viper.AutomaticEnv()
+	viper.SetConfigName(configFileBasename)
+	viper.AddConfigPath(configFilePath)
+
+	viper.SetDefault(configKeyBackendHTTPAPIBaseURL, configDefaultBackendHTTPAPIBaseURL)
+	viper.SetDefault(configKeyLogLevel, configDefaultLogLevel)
+
+	logger := plog.NewLogger("sqreen/agent/config")
+
+	err := viper.ReadInConfig()
+	if err != nil {
+		logger.Error("configuration file read error:", err)
+	}
+}
+
+// BackendHTTPAPIBaseURL returns the base URL of the backend HTTP API.
+func BackendHTTPAPIBaseURL() string {
+	return viper.GetString(configKeyBackendHTTPAPIBaseURL)
+}
+
+// BackendHTTPAPIToken returns the access token to the backend API.
+func BackendHTTPAPIToken() string {
+	return viper.GetString(configKeyBackendHTTPAPIToken)
+}
+
+// LogLevel returns the default log level.
+func LogLevel() string {
+	return viper.GetString(configKeyLogLevel)
+}

--- a/agent/config/config_suite_test.go
+++ b/agent/config/config_suite_test.go
@@ -1,0 +1,13 @@
+package config_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestConfig(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Config Suite")
+}

--- a/agent/config/config_test.go
+++ b/agent/config/config_test.go
@@ -1,0 +1,62 @@
+package config
+
+import (
+	"math/rand"
+	"os"
+	"strings"
+	"sync"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+	"github.com/spf13/viper"
+)
+
+var _ = Describe("Config", func() {
+	DescribeTable("User-configurable values",
+		func(getCfgValue func() string, envKey, defaultValue, someValue string) {
+			// Specs are run in parallel and this test is not concurrency-safe because of
+			// shared env vars and the shared configuration file. This global mutex allows
+			// to enforce one test at a time to execute.
+			var lock sync.Mutex
+			lock.Lock()
+			defer lock.Unlock()
+
+			By("default")
+			Expect(getCfgValue()).To(Equal(defaultValue))
+
+			By("environment variable")
+			envVar := strings.ToUpper(configEnvPrefix) + "_" + strings.ToUpper(envKey)
+			os.Setenv(envVar, someValue)
+			defer os.Unsetenv(envVar)
+			Expect(getCfgValue()).To(Equal(someValue))
+
+			By("configuration file")
+			filename := newCfgFile(`url: ` + someValue)
+			defer os.Remove(filename)
+			viper.ReadInConfig()
+			Expect(getCfgValue()).To(Equal(someValue))
+		},
+		Entry("Backend HTTP API Base URL", BackendHTTPAPIBaseURL, configKeyBackendHTTPAPIBaseURL, configDefaultBackendHTTPAPIBaseURL, "https://"+randString(2+rand.Intn(50))+":80806/is/cool"),
+		Entry("Backend HTTP API Token", BackendHTTPAPIToken, configKeyBackendHTTPAPIToken, "", randString(2+rand.Intn(30))),
+		Entry("Log Level", LogLevel, configKeyLogLevel, configDefaultLogLevel, randString(2+rand.Intn(30))),
+	)
+})
+
+func newCfgFile(content string) string {
+	cfg, err := os.Create("sqreen.yml")
+	Expect(err).NotTo(HaveOccurred())
+	defer cfg.Close()
+	_, err = cfg.WriteString(content)
+	Expect(err).NotTo(HaveOccurred())
+	return cfg.Name()
+}
+
+func randString(n int) string {
+	letterRunes := []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
+	b := make([]rune, n)
+	for i := range b {
+		b[i] = letterRunes[rand.Intn(len(letterRunes))]
+	}
+	return string(b)
+}

--- a/agent/plog/plog.go
+++ b/agent/plog/plog.go
@@ -30,6 +30,21 @@ const (
 	Debug
 )
 
+const (
+	// Disabled value.
+	DisabledString = "disabled"
+	// Fatal logs.
+	FatalString = "fatal"
+	// Error and Fatal logs.
+	ErrorString = "error"
+	// Warn to Fatal logs.
+	WarnString = "warn"
+	// Info to Fatal logs.
+	InfoString = "info"
+	// Debug to Fatal logs.
+	DebugString = "debug"
+)
+
 // LogLevel type stringer.
 func (l LogLevel) String() string {
 	switch l {
@@ -124,6 +139,30 @@ func (l *Logger) SetOutput(output io.Writer) {
 	l.WarnLogger.SetOutput(output)
 	l.InfoLogger.SetOutput(output)
 	l.DebugLogger.SetOutput(output)
+}
+
+// SetLevelFromString change the level of the logger to `level`, possibly
+// disabling it when the "disabled" string is passed.
+func (l *Logger) SetLevelFromString(level string) {
+	lvl := Disabled
+	switch level {
+	case DebugString:
+		lvl = Debug
+		break
+	case InfoString:
+		lvl = Info
+		break
+	case WarnString:
+		lvl = Warn
+		break
+	case ErrorString:
+		lvl = Error
+		break
+	case FatalString:
+		lvl = Fatal
+		break
+	}
+	l.SetLevel(lvl)
 }
 
 // SetLevel changes the level of the logger to `level`, possibly disabling it

--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,11 @@
 module github.com/sqreen/AgentGo
 
 require (
+	github.com/BurntSushi/toml v0.3.1 // indirect
 	github.com/gogo/protobuf v1.2.0
 	github.com/golang/protobuf v1.2.0
 	github.com/onsi/ginkgo v1.7.0
 	github.com/onsi/gomega v1.4.3
+	github.com/spf13/viper v1.3.1
 	golang.org/x/net v0.0.0-20181106065722-10aee1819953 // indirect
-	gopkg.in/yaml.v2 v2.2.2 // indirect
 )


### PR DESCRIPTION
Simple global package managing the user-configuration variables. Each
configurable variable can:

- Have a default value when unset.
- Can be set by environment variable.
- Can be set by configuration file.

To start, the package provides:

- The backend API base url: modified for test purposes, such as using a local
  backend.
- The backend API token.
- The agent log level.