### PR TITLE
sdk: ignore SDK calls when disabled or context is nil

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,7 @@ $(agent/library/static): $(needs-dev-container) $(needs-protobufs) $(needs-vendo
 
 .PHONY: test
 test: $(needs-dev-container) $(needs-vendors) $(needs-protobufs)
-	$(call dockerize, ginkgo $(ginkgo/flags) ./agent)
+	$(call dockerize, ginkgo $(ginkgo/flags) ./agent ./sdk)
 
 .PHONY: test-coverage
 test-coverage: $(needs-dev-container) $(needs-vendors) $(needs-protobufs)

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -205,7 +205,7 @@ func (m *eventManager) send(client *backend.Client, sessionID string) {
 }
 
 func addEvent(r *httpRequestRecord) {
-	if eventMng == nil {
+	if config.Disable() || eventMng == nil {
 		// Disabled or not yet initialized agent
 		return
 	}

--- a/agent/request.go
+++ b/agent/request.go
@@ -28,10 +28,6 @@ type HTTPRequestContext struct {
 }
 
 func NewHTTPRequestContext(req HTTPRequest) *HTTPRequestContext {
-	if config.Disable() {
-		return nil
-	}
-
 	return &HTTPRequestContext{
 		request: req,
 	}
@@ -47,10 +43,6 @@ type HTTPRequestEvent struct {
 type EventPropertyMap map[string]interface{}
 
 func (ctx *HTTPRequestContext) Track(event string) *HTTPRequestEvent {
-	if ctx == nil {
-		return nil
-	}
-
 	evt := &HTTPRequestEvent{
 		method:     "track",
 		event:      event,
@@ -62,16 +54,10 @@ func (ctx *HTTPRequestContext) Track(event string) *HTTPRequestEvent {
 }
 
 func (ctx *HTTPRequestContext) Close() {
-	if ctx == nil {
-		return
-	}
 	addEvent(newHTTPRequestRecord(ctx))
 }
 
 func (ctx *HTTPRequestContext) addEvent(event *HTTPRequestEvent) {
-	if ctx == nil {
-		return
-	}
 	ctx.eventsLock.Lock()
 	defer ctx.eventsLock.Unlock()
 	ctx.events = append(ctx.events, event)

--- a/agent/request.go
+++ b/agent/request.go
@@ -28,6 +28,10 @@ type HTTPRequestContext struct {
 }
 
 func NewHTTPRequestContext(req HTTPRequest) *HTTPRequestContext {
+	if config.Disable() {
+		return nil
+	}
+
 	return &HTTPRequestContext{
 		request: req,
 	}
@@ -43,6 +47,10 @@ type HTTPRequestEvent struct {
 type EventPropertyMap map[string]interface{}
 
 func (ctx *HTTPRequestContext) Track(event string) *HTTPRequestEvent {
+	if ctx == nil {
+		return nil
+	}
+
 	evt := &HTTPRequestEvent{
 		method:     "track",
 		event:      event,
@@ -54,21 +62,33 @@ func (ctx *HTTPRequestContext) Track(event string) *HTTPRequestEvent {
 }
 
 func (ctx *HTTPRequestContext) Close() {
+	if ctx == nil {
+		return
+	}
 	addEvent(newHTTPRequestRecord(ctx))
 }
 
 func (ctx *HTTPRequestContext) addEvent(event *HTTPRequestEvent) {
+	if ctx == nil {
+		return
+	}
 	ctx.eventsLock.Lock()
 	defer ctx.eventsLock.Unlock()
 	ctx.events = append(ctx.events, event)
 }
 
 func (e *HTTPRequestEvent) WithTimestamp(t time.Time) *HTTPRequestEvent {
+	if e == nil {
+		return nil
+	}
 	e.timestamp = t
 	return e
 }
 
 func (e *HTTPRequestEvent) WithProperties(p EventPropertyMap) *HTTPRequestEvent {
+	if e == nil {
+		return nil
+	}
 	e.properties = p
 	return e
 }

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,8 @@ require (
 	github.com/onsi/ginkgo v1.7.0
 	github.com/onsi/gomega v1.4.3
 	github.com/spf13/viper v1.3.1
+	github.com/stretchr/testify v1.2.2
+	golang.org/x/net v0.0.0-20180906233101-161cd47e91fd
 	gopkg.in/go-playground/assert.v1 v1.2.1 // indirect
 	gopkg.in/go-playground/validator.v8 v8.18.2 // indirect
 )

--- a/sdk/context.go
+++ b/sdk/context.go
@@ -30,6 +30,9 @@ func NewHTTPRequestContext(req HTTPRequest) *HTTPRequestContext {
 // Close signals the request handling is now done. Every collected security
 // event can thus be considered by the agnt.
 func (ctx *HTTPRequestContext) Close() {
+	if ctx == nil {
+		return
+	}
 	ctx.ctx.Close()
 }
 
@@ -37,5 +40,8 @@ func (ctx *HTTPRequestContext) Close() {
 // Additional options can be set using the returned value's methods, such
 // WithProperties() or WithTimestamp().
 func (ctx *HTTPRequestContext) Track(event string) *HTTPRequestEvent {
+	if ctx == nil {
+		return nil
+	}
 	return (ctx.ctx.Track(event))
 }

--- a/sdk/context_test.go
+++ b/sdk/context_test.go
@@ -1,43 +1,30 @@
 package sdk_test
 
 import (
+	"testing"
 	"time"
-
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
 
 	"github.com/sqreen/go-agent/sdk"
 	"github.com/sqreen/go-agent/tools/testlib"
+	"github.com/stretchr/testify/require"
 )
 
-func performSDKCalls(ctx *sdk.HTTPRequestContext) func() {
-	return func() {
-		event := ctx.Track(testlib.RandString(0, 50))
-		Expect(event).To(BeNil())
-		event = event.WithTimestamp(time.Now())
-		Expect(event).To(BeNil())
-		event = event.WithProperties(nil)
-		Expect(event).To(BeNil())
-		event = ctx.Track(testlib.RandString(0, 50))
-		Expect(event).To(BeNil())
-		event = event.WithProperties(nil)
-		Expect(event).To(BeNil())
-		event = event.WithTimestamp(time.Now())
-		Expect(event).To(BeNil())
-		ctx.Close()
-	}
+func TestSDK(t *testing.T) {
+	testDisabledSDKCalls(t, nil)
 }
 
-var _ = Describe("SDK", func() {
-	var ctx *sdk.HTTPRequestContext
-	Context("when used with zero value (nil)", func() {
-		It("should not panic", func() {
-			Expect(performSDKCalls(ctx)).ToNot(Panic())
-		})
-	})
-	Context("when used with zero value (nil)", func() {
-		It("should not panic", func() {
-			Expect(performSDKCalls(ctx)).ToNot(Panic())
-		})
-	})
-})
+func testDisabledSDKCalls(t *testing.T, ctx *sdk.HTTPRequestContext) {
+	event := ctx.Track(testlib.RandString(0, 50))
+	require.Nil(t, event)
+	event = event.WithTimestamp(time.Now())
+	require.Nil(t, event)
+	event = event.WithProperties(nil)
+	require.Nil(t, event)
+	event = ctx.Track(testlib.RandString(0, 50))
+	require.Nil(t, event)
+	event = event.WithProperties(nil)
+	require.Nil(t, event)
+	event = event.WithTimestamp(time.Now())
+	require.Nil(t, event)
+	ctx.Close()
+}

--- a/sdk/context_test.go
+++ b/sdk/context_test.go
@@ -1,0 +1,43 @@
+package sdk_test
+
+import (
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/sqreen/go-agent/sdk"
+	"github.com/sqreen/go-agent/tools/testlib"
+)
+
+func performSDKCalls(ctx *sdk.HTTPRequestContext) func() {
+	return func() {
+		event := ctx.Track(testlib.RandString(0, 50))
+		Expect(event).To(BeNil())
+		event = event.WithTimestamp(time.Now())
+		Expect(event).To(BeNil())
+		event = event.WithProperties(nil)
+		Expect(event).To(BeNil())
+		event = ctx.Track(testlib.RandString(0, 50))
+		Expect(event).To(BeNil())
+		event = event.WithProperties(nil)
+		Expect(event).To(BeNil())
+		event = event.WithTimestamp(time.Now())
+		Expect(event).To(BeNil())
+		ctx.Close()
+	}
+}
+
+var _ = Describe("SDK", func() {
+	var ctx *sdk.HTTPRequestContext
+	Context("when used with zero value (nil)", func() {
+		It("should not panic", func() {
+			Expect(performSDKCalls(ctx)).ToNot(Panic())
+		})
+	})
+	Context("when used with zero value (nil)", func() {
+		It("should not panic", func() {
+			Expect(performSDKCalls(ctx)).ToNot(Panic())
+		})
+	})
+})

--- a/sdk/sdk_suite_test.go
+++ b/sdk/sdk_suite_test.go
@@ -1,0 +1,13 @@
+package sdk_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestMiddleware(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "SDK Suite")
+}

--- a/tools/testlib/rand.go
+++ b/tools/testlib/rand.go
@@ -1,0 +1,14 @@
+package testlib
+
+import "math/rand"
+
+func RandString(from, to int) string {
+	letterRunes := []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
+
+	n := from + rand.Intn(to-from)
+	b := make([]rune, n)
+	for i := range b {
+		b[i] = letterRunes[rand.Intn(len(letterRunes))]
+	}
+	return string(b)
+}


### PR DESCRIPTION
Ignore SDK calls when:
- the agent is disabled.
- the sdk context is nil (eg. the middleware wasn't used).