### PR TITLE
config: test using the standard go test api

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,8 +16,8 @@ docker/dev/container/dockerfile := tools/docker/dev/Dockerfile
 go/target := $(shell go env GOOS)_$(shell go env GOARCH)
 agent/library/static := pkg/$(go/target)/sqreen/agent.a
 protobufs := $(patsubst %.proto,%.pb.go,$(shell find agent -name '*.proto'))
-ginkgo/flags := -r --randomizeAllSpecs --randomizeSuites --progress -p
 protoc/flags := -I. -Ivendor --gogo_out=google/protobuf/any.proto=github.com/gogo/protobuf/types,Mgoogle/protobuf/duration.proto=github.com/gogo/protobuf/types,Mgoogle/protobuf/struct.proto=github.com/gogo/protobuf/types,Mgoogle/protobuf/timestamp.proto=github.com/gogo/protobuf/types,Mgoogle/protobuf/wrappers.proto=github.com/gogo/protobuf/types:.
+test/packages := ./agent/... ./sdk/...
 
 define dockerize =
 if $(lib/docker/is_in_container); then $(lib/argv/1); else docker exec -i $(docker/dev/container) bash -c "$(lib/argv/1)"; fi
@@ -71,15 +71,15 @@ $(agent/library/static): $(needs-dev-container) $(needs-protobufs) $(needs-vendo
 
 .PHONY: test
 test: $(needs-dev-container) $(needs-vendors) $(needs-protobufs)
-	$(call dockerize, ginkgo $(ginkgo/flags) ./agent ./sdk)
+	$(call dockerize, go test -v $(test/packages))
 
 .PHONY: test-coverage
 test-coverage: $(needs-dev-container) $(needs-vendors) $(needs-protobufs)
-	$(call dockerize, ginkgo $(ginkgo/flags) -cover -coverprofile=coverage.txt ./agent)
+	$(call dockerize, go test -v -cover -coverprofile=coverage.txt $(test/packages))
 
 .PHONY: test-race
 test-race: $(needs-dev-container) $(needs-vendors) $(needs-protobufs)
-	$(call dockerize, ginkgo $(ginkgo/flags) -race ./agent)
+	$(call dockerize, go test -v -race $(test/packages))
 
 #-----------------------------------------------------------------------------
 # Vendor directory

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -170,7 +170,6 @@ func (m *eventManager) Loop(ctx context.Context, client *backend.Client, session
 				go func() {
 					select {
 					case <-ctx.Done():
-						return
 					case <-time.After(m.maxStaleness):
 						logger.Debug("event batch data staleness reached")
 					case <-isFull:

--- a/agent/backend/client.go
+++ b/agent/backend/client.go
@@ -108,7 +108,6 @@ func (c *Client) Do(req *http.Request, pbs ...proto.Message) error {
 			return err
 		}
 	}
-
 	req.Body = ioutil.NopCloser(&buf)
 	req.ContentLength = int64(buf.Len())
 

--- a/agent/config/config.go
+++ b/agent/config/config.go
@@ -232,6 +232,7 @@ func BackendHTTPAPIProxy() string {
 	return viper.GetString(configKeyBackendHTTPAPIProxy)
 }
 
+// Disable returns true when the agent should be disabled, false otherwise.
 func Disable() bool {
 	disable := viper.GetString(configKeyDisable)
 	return disable != "" || BackendHTTPAPIToken() == ""

--- a/agent/config/config_test.go
+++ b/agent/config/config_test.go
@@ -1,65 +1,123 @@
 package config
 
 import (
-	"math/rand"
 	"os"
 	"strings"
-	"sync"
+	"testing"
 
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/ginkgo/extensions/table"
-	. "github.com/onsi/gomega"
 	"github.com/spf13/viper"
+	"github.com/sqreen/go-agent/tools/testlib"
+	"github.com/stretchr/testify/require"
 )
 
-var lock sync.Mutex
+func TestUserConfig(t *testing.T) {
+	stringValueTests := []struct {
+		Name         string
+		GetCfgValue  func() string
+		ConfigKey    string
+		DefaultValue string
+		SomeValue    string
+	}{
+		{
+			Name:         "Backend HTTP API Base URL",
+			GetCfgValue:  BackendHTTPAPIBaseURL,
+			ConfigKey:    configKeyBackendHTTPAPIBaseURL,
+			DefaultValue: configDefaultBackendHTTPAPIBaseURL,
+			SomeValue:    "https://" + testlib.RandString(2, 50) + ":80806/is/cool",
+		},
+		{
+			Name:        "Backend HTTP API Token",
+			GetCfgValue: BackendHTTPAPIToken,
+			ConfigKey:   configKeyBackendHTTPAPIToken,
+			SomeValue:   testlib.RandString(2, 30),
+		},
+		{
+			Name:         "Log Level",
+			GetCfgValue:  LogLevel,
+			ConfigKey:    configKeyLogLevel,
+			DefaultValue: configDefaultLogLevel,
+			SomeValue:    testlib.RandString(2, 30),
+		},
+		{
+			Name:        "App Name",
+			GetCfgValue: AppName,
+			ConfigKey:   configKeyAppName,
+			SomeValue:   testlib.RandString(2, 30),
+		},
+		{
+			Name:        "IP Header",
+			GetCfgValue: HTTPClientIPHeader,
+			ConfigKey:   configKeyHTTPClientIPHeader,
+			SomeValue:   testlib.RandString(2, 30),
+		},
+		{
+			Name:        "Backend HTTP API Proxy",
+			GetCfgValue: BackendHTTPAPIProxy,
+			ConfigKey:   configKeyBackendHTTPAPIProxy,
+			SomeValue:   testlib.RandString(2, 30),
+		},
+	}
 
-var _ = Describe("Config", func() {
-	DescribeTable("User-configurable values",
-		func(getCfgValue func() string, envKey, defaultValue, someValue string) {
-			// Specs are run in parallel and this test is not concurrency-safe because of
-			// shared env vars and the shared configuration file. This global mutex allows
-			// to enforce one test at a time to execute.
-			lock.Lock()
-			defer lock.Unlock()
+	for _, tc := range stringValueTests {
+		testStringValue(t, tc.Name, tc.GetCfgValue, tc.ConfigKey, tc.DefaultValue, tc.SomeValue)
+	}
 
-			By("default")
-			Expect(getCfgValue()).To(Equal(defaultValue))
+	t.Run("Disable", func(t *testing.T) {
+		os.Setenv("SQREEN_TOKEN", testlib.RandString(2, 30))
+		defer os.Unsetenv("SQREEN_TOKEN")
 
-			By("environment variable")
+		getCfgValue := Disable
+		defaultValue := false
+		envKey := configKeyDisable
+		someValue := testlib.RandString(2, 30)
+
+		t.Run("Default value", func(t *testing.T) {
+			require.Equal(t, getCfgValue(), defaultValue)
+		})
+
+		t.Run("Set through environment variable", func(t *testing.T) {
 			envVar := strings.ToUpper(configEnvPrefix) + "_" + strings.ToUpper(envKey)
 			os.Setenv(envVar, someValue)
 			defer os.Unsetenv(envVar)
-			Expect(getCfgValue()).To(Equal(someValue))
+			require.NotEqual(t, getCfgValue(), defaultValue)
+		})
 
-			By("configuration file")
-			filename := newCfgFile(`url: ` + someValue)
+		t.Run("Set through configuration file", func(t *testing.T) {
+			filename := newCfgFile(t, envKey+`: `+someValue)
 			defer os.Remove(filename)
 			viper.ReadInConfig()
-			Expect(getCfgValue()).To(Equal(someValue))
-		},
-		Entry("Backend HTTP API Base URL", BackendHTTPAPIBaseURL, configKeyBackendHTTPAPIBaseURL, configDefaultBackendHTTPAPIBaseURL, "https://"+randString(2+rand.Intn(50))+":80806/is/cool"),
-		Entry("Backend HTTP API Token", BackendHTTPAPIToken, configKeyBackendHTTPAPIToken, "", randString(2+rand.Intn(30))),
-		Entry("Log Level", LogLevel, configKeyLogLevel, configDefaultLogLevel, randString(2+rand.Intn(30))),
-		Entry("App Name", AppName, configKeyAppName, "", randString(2+rand.Intn(30))),
-		Entry("IP Header", HTTPClientIPHeader, configKeyHTTPClientIPHeader, "", randString(2+rand.Intn(30))),
-	)
-})
-
-func newCfgFile(content string) string {
-	cfg, err := os.Create("sqreen.yml")
-	Expect(err).NotTo(HaveOccurred())
-	defer cfg.Close()
-	_, err = cfg.WriteString(content)
-	Expect(err).NotTo(HaveOccurred())
-	return cfg.Name()
+			require.Equal(t, getCfgValue(), !defaultValue)
+		})
+	})
 }
 
-func randString(n int) string {
-	letterRunes := []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
-	b := make([]rune, n)
-	for i := range b {
-		b[i] = letterRunes[rand.Intn(len(letterRunes))]
-	}
-	return string(b)
+func testStringValue(t *testing.T, name string, getCfgValue func() string, envKey, defaultValue, someValue string) {
+	t.Run(name, func(t *testing.T) {
+		t.Run("Default value", func(t *testing.T) {
+			require.Equal(t, getCfgValue(), defaultValue)
+		})
+
+		t.Run("Set through environment variable", func(t *testing.T) {
+			envVar := strings.ToUpper(configEnvPrefix) + "_" + strings.ToUpper(envKey)
+			os.Setenv(envVar, someValue)
+			defer os.Unsetenv(envVar)
+			require.Equal(t, getCfgValue(), someValue)
+		})
+
+		t.Run("Set through configuration file", func(t *testing.T) {
+			filename := newCfgFile(t, envKey+`: `+someValue)
+			defer os.Remove(filename)
+			viper.ReadInConfig()
+			require.Equal(t, getCfgValue(), someValue)
+		})
+	})
+}
+
+func newCfgFile(t *testing.T, content string) string {
+	cfg, err := os.Create("sqreen.yml")
+	require.Equal(t, err, nil)
+	defer cfg.Close()
+	_, err = cfg.WriteString(content)
+	require.Equal(t, err, nil)
+	return cfg.Name()
 }


### PR DESCRIPTION
No longer use ginkgo and rather replace it by the simple standard Go's test
APIs, along with testify for assertions. It makes much easier to write
table-driven tests and control test parallelism. For example, configuration
tests cannot run in parallel and are perfectly suitable for table-driven tests.