### PR TITLE
agent: organization token

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -53,7 +53,9 @@ func agent() {
 		return
 	}
 
-	appLoginRes, err := appLogin(ctx, client)
+	token := config.BackendHTTPAPIToken()
+	appName := config.AppName()
+	appLoginRes, err := appLogin(ctx, client, token, appName)
 	if checkErr(err) {
 		return
 	}

--- a/agent/backend/client.go
+++ b/agent/backend/client.go
@@ -49,12 +49,15 @@ func NewClient(backendURL string) (*Client, error) {
 	return client, nil
 }
 
-func (c *Client) AppLogin(req *api.AppLoginRequest, token string) (*api.AppLoginResponse, error) {
+func (c *Client) AppLogin(req *api.AppLoginRequest, token string, appName string) (*api.AppLoginResponse, error) {
 	httpReq, err := c.newRequest(&config.BackendHTTPAPIEndpoint.AppLogin)
 	if err != nil {
 		return nil, err
 	}
 	httpReq.Header.Set(config.BackendHTTPAPIHeaderToken, token)
+	if appName != "" {
+		httpReq.Header.Set(config.BackendHTTPAPIHeaderAppName, appName)
+	}
 	res := new(api.AppLoginResponse)
 	if err := c.Do(httpReq, req, res); err != nil {
 		return nil, err

--- a/agent/backend/client_test.go
+++ b/agent/backend/client_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/sqreen/go-agent/agent/backend"
 	"github.com/sqreen/go-agent/agent/backend/api"
 	"github.com/sqreen/go-agent/agent/config"
+	"github.com/sqreen/go-agent/tools/testlib"
 )
 
 var (
@@ -59,7 +60,10 @@ var _ = Describe("The backend client", func() {
 		})
 
 		Describe("AppLogin", func() {
-			var token string = "my-token"
+			var (
+				token   string = "my-token"
+				appName string = testlib.RandString(2, 50)
+			)
 
 			BeforeEach(func() {
 				endpointCfg = &config.BackendHTTPAPIEndpoint.AppLogin
@@ -73,12 +77,13 @@ var _ = Describe("The backend client", func() {
 				Expect(err).ToNot(HaveOccurred())
 
 				headers = http.Header{
-					config.BackendHTTPAPIHeaderToken: []string{token},
+					config.BackendHTTPAPIHeaderToken:   []string{token},
+					config.BackendHTTPAPIHeaderAppName: []string{appName},
 				}
 			})
 
 			It("should perform the API call", func() {
-				res, err := client.AppLogin(request.(*api.AppLoginRequest), token)
+				res, err := client.AppLogin(request.(*api.AppLoginRequest), token, appName)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(res).Should(Equal(response))
 			})

--- a/agent/config/config.go
+++ b/agent/config/config.go
@@ -8,6 +8,7 @@ package config
 import (
 	"net"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/sqreen/go-agent/agent/plog"
@@ -44,6 +45,11 @@ var (
 
 	// Header name of the API session.
 	BackendHTTPAPIHeaderSession = "X-Session-Key"
+
+	// Header name of the App name.
+	BackendHTTPAPIHeaderAppName = "X-App-Name"
+
+	BackendHTTPAPIOrganizationTokenPrefix = "org_"
 
 	// BackendHTTPAPIRequestRetryPeriod is the time period to retry failed backend
 	// HTTP requests.
@@ -204,36 +210,40 @@ func init() {
 
 // BackendHTTPAPIBaseURL returns the base URL of the backend HTTP API.
 func BackendHTTPAPIBaseURL() string {
-	return viper.GetString(configKeyBackendHTTPAPIBaseURL)
+	return sanitizeString(viper.GetString(configKeyBackendHTTPAPIBaseURL))
 }
 
 // BackendHTTPAPIToken returns the access token to the backend API.
 func BackendHTTPAPIToken() string {
-	return viper.GetString(configKeyBackendHTTPAPIToken)
+	return sanitizeString(viper.GetString(configKeyBackendHTTPAPIToken))
 }
 
 // LogLevel returns the log level.
 func LogLevel() string {
-	return viper.GetString(configKeyLogLevel)
+	return sanitizeString(viper.GetString(configKeyLogLevel))
 }
 
 // AppName returns the app name.
 func AppName() string {
-	return viper.GetString(configKeyAppName)
+	return sanitizeString(viper.GetString(configKeyAppName))
 }
 
 // HTTPClientIPHeader IPHeader returns the header to first lookup to find the client ip of a HTTP request.
 func HTTPClientIPHeader() string {
-	return viper.GetString(configKeyHTTPClientIPHeader)
+	return sanitizeString(viper.GetString(configKeyHTTPClientIPHeader))
 }
 
 // Proxy returns the proxy configuration to use for backend HTTP calls.
 func BackendHTTPAPIProxy() string {
-	return viper.GetString(configKeyBackendHTTPAPIProxy)
+	return sanitizeString(viper.GetString(configKeyBackendHTTPAPIProxy))
 }
 
 // Disable returns true when the agent should be disabled, false otherwise.
 func Disable() bool {
-	disable := viper.GetString(configKeyDisable)
+	disable := sanitizeString(viper.GetString(configKeyDisable))
 	return disable != "" || BackendHTTPAPIToken() == ""
+}
+
+func sanitizeString(s string) string {
+	return strings.TrimSpace(s)
 }


### PR DESCRIPTION
The organization token is similar to existing app tokens, but they start with
`org_` and must go with an app name. The backend registers this logging app
under the given name and returns a session token for subsequent calls.

Regular app tokens are still supported.