### PR TITLE
agent/backend: use *_PROXY environment variables proxy settings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,7 +86,7 @@ test-race: $(needs-dev-container) $(needs-vendors) $(needs-protobufs)
 #-----------------------------------------------------------------------------
 
 $(needs-vendors): go.mod $(global-deps) $(needs-dev-container)
-	$(call dockerize, go mod vendor)
+	$(call dockerize, go mod vendor -v)
 	mkdir -p $(@D) && touch $@
 
 .PHONY: vendor

--- a/agent/backend/client.go
+++ b/agent/backend/client.go
@@ -8,12 +8,11 @@ import (
 	"net/http/httputil"
 	"net/url"
 
-	"github.com/sqreen/go-agent/agent/config"
-	"github.com/sqreen/go-agent/agent/plog"
-
 	"github.com/gogo/protobuf/jsonpb"
 	"github.com/gogo/protobuf/proto"
 	"github.com/sqreen/go-agent/agent/backend/api"
+	"github.com/sqreen/go-agent/agent/config"
+	"github.com/sqreen/go-agent/agent/plog"
 	"golang.org/x/net/http/httpproxy"
 )
 
@@ -26,21 +25,32 @@ type Client struct {
 }
 
 func NewClient(backendURL string) (*Client, error) {
-	proxyCfg := httpproxy.Config{
-		HTTPSProxy: config.BackendHTTPAPIProxy(),
+	var transport *http.Transport
+	if proxySettings := config.BackendHTTPAPIProxy(); proxySettings == "" {
+		// No user settings. The default transport uses standard global proxy
+		// settings *_PROXY environment variables.
+		logger.Info("using proxy settings as indicated by the environment variables HTTP_PROXY, HTTPS_PROXY and NO_PROXY (or the lowercase versions)")
+		transport = (http.DefaultTransport).(*http.Transport)
+	} else {
+		// Use the settings.
+		logger.Info("using configured https proxy ", proxySettings)
+		proxyCfg := httpproxy.Config{
+			HTTPSProxy: proxySettings,
+		}
+		proxyURL := proxyCfg.ProxyFunc()
+		proxy := func(req *http.Request) (*url.URL, error) {
+			return proxyURL(req.URL)
+		}
+		// Shallow copy the default transport and overwrite its proxy settings.
+		transportCopy := *(http.DefaultTransport).(*http.Transport)
+		transport = &transportCopy
+		transport.Proxy = proxy
 	}
-	proxyURL := proxyCfg.ProxyFunc()
-	proxy := func(req *http.Request) (*url.URL, error) {
-		return proxyURL(req.URL)
-	}
-
-	transport := *(http.DefaultTransport).(*http.Transport)
-	transport.Proxy = proxy
 
 	client := &Client{
 		client: &http.Client{
 			Timeout:   config.BackendHTTPAPIRequestTimeout,
-			Transport: &transport,
+			Transport: transport,
 		},
 		backendURL:  backendURL,
 		pbMarshaler: api.DefaultJSONPBMarshaler,

--- a/agent/backend/client_test.go
+++ b/agent/backend/client_test.go
@@ -31,6 +31,7 @@ func TestClient(t *testing.T) {
 
 	t.Run("AppLogin", func(t *testing.T) {
 		token := testlib.RandString(2, 50)
+		appName := testlib.RandString(2, 50)
 
 		statusCode := http.StatusOK
 
@@ -45,7 +46,8 @@ func TestClient(t *testing.T) {
 		g.Expect(err).ToNot(HaveOccurred())
 
 		headers := http.Header{
-			config.BackendHTTPAPIHeaderToken: []string{token},
+			config.BackendHTTPAPIHeaderToken:   []string{token},
+			config.BackendHTTPAPIHeaderAppName: []string{appName},
 		}
 
 		server := initFakeServer(endpointCfg, request, response, statusCode, headers)
@@ -54,7 +56,7 @@ func TestClient(t *testing.T) {
 		client, err := backend.NewClient(server.URL())
 		g.Expect(err).NotTo(HaveOccurred())
 
-		res, err := client.AppLogin(request, token)
+		res, err := client.AppLogin(request, token, appName)
 		g.Expect(err).NotTo(HaveOccurred())
 		// A request has been received
 		g.Expect(len(server.ReceivedRequests())).ToNot(Equal(0))
@@ -267,7 +269,7 @@ func testProxy(t *testing.T, envVar string) {
 	require.Equal(t, err, nil)
 	// Perform a request that should go through the proxy.
 	request := api.NewPopulatedAppLoginRequest(popr, false)
-	_, err = client.AppLogin(request, "my-token")
+	_, err = client.AppLogin(request, "my-token", "my-app")
 	// A request has been received:
 	//require.NotEqual(t, len(back.ReceivedRequests()), 0, "0 request received")
 	require.NotEqual(t, len(proxy.ReceivedRequests()), 0, "0 request received")


### PR DESCRIPTION
Take into account `{HTTPS,HTTP,NO}_PROXY` environment variables (and their lowercase alternatives) when `SQREEN_PROXY` is not set. This way, the system's configuration is taken into account when defined.

Users not yet using proxies and not willing to impact their normal http requests can just use `SQREEN_PROXY` to explicitly tell the agent to use a given proxy.

Closes SQR-5316