### PR TITLE
SDK middleware naming

### DIFF
--- a/sdk/middleware/sqgin/gin.go
+++ b/sdk/middleware/sqgin/gin.go
@@ -1,4 +1,4 @@
-package gin
+package sqgin
 
 import (
 	"context"
@@ -38,7 +38,7 @@ func Sqreen() gingonic.HandlerFunc {
 // context by the middleware function.
 //
 //	router.GET("/", func(c *gin.Context) {
-//		sqreen_middleware.GetHTTPContextFromGin(c).Track("my.event")
+//		sqgin.GetHTTPContextFromGin(c).Track("my.event")
 //		// ...
 //	}
 //
@@ -62,7 +62,7 @@ func GetHTTPContextFromGin(c *gingonic.Context) *sqreen_sdk.HTTPRequestContext {
 //	}
 //
 //	func aFunction(ctx context.Context) {
-//		sqreen_middleware.GetHTTPContext(ctx).Track("my.event")
+//		sqgin.GetHTTPContext(ctx).Track("my.event")
 //		// ...
 //	}
 //


### PR DESCRIPTION
To avoid name collisions with gin's package, rename it to `sqgin`. Now users no longer need to rename their middleware import to `sqreen_middleware` as documented. Another benefit is with tools such as `goimport` which will be able to automatically find the package.

Elegant naming idea taken New Relic ;)

Related to SQR-5344.