### PR TITLE
sdk: cleaner api

### DIFF
--- a/agent/request.go
+++ b/agent/request.go
@@ -15,7 +15,7 @@ import (
 	"github.com/sqreen/go-agent/agent/config"
 )
 
-type HTTPRequestContext struct {
+type HTTPRequestRecord struct {
 	// Copy of the request, safe to be asynchronously read, even after the request
 	// was terminated.
 	request    *http.Request
@@ -23,8 +23,8 @@ type HTTPRequestContext struct {
 	events     []*HTTPRequestEvent
 }
 
-func NewHTTPRequestContext(req *http.Request) *HTTPRequestContext {
-	return &HTTPRequestContext{
+func NewHTTPRequestRecord(req *http.Request) *HTTPRequestRecord {
+	return &HTTPRequestRecord{
 		request: req,
 	}
 }
@@ -102,7 +102,7 @@ type EventPropertyMap map[string]string
 
 type EventUserIdentifierMap map[string]string
 
-func (ctx *HTTPRequestContext) Track(event string) *HTTPRequestEvent {
+func (ctx *HTTPRequestRecord) Track(event string) *HTTPRequestEvent {
 	evt := &HTTPRequestEvent{
 		method:    "track",
 		event:     event,
@@ -112,7 +112,7 @@ func (ctx *HTTPRequestContext) Track(event string) *HTTPRequestEvent {
 	return evt
 }
 
-func (ctx *HTTPRequestContext) TrackAuth(loginSuccess bool, id EventUserIdentifierMap) {
+func (ctx *HTTPRequestRecord) TrackAuth(loginSuccess bool, id EventUserIdentifierMap) {
 	if len(id) == 0 {
 		logger.Warn("TrackAuth(): user id is nil or empty")
 		return
@@ -129,7 +129,7 @@ func (ctx *HTTPRequestContext) TrackAuth(loginSuccess bool, id EventUserIdentifi
 	ctx.addUserEvent(event)
 }
 
-func (ctx *HTTPRequestContext) TrackSignup(id EventUserIdentifierMap) {
+func (ctx *HTTPRequestRecord) TrackSignup(id EventUserIdentifierMap) {
 	if len(id) == 0 {
 		logger.Warn("TrackSignup(): user id is nil or empty")
 		return
@@ -145,17 +145,17 @@ func (ctx *HTTPRequestContext) TrackSignup(id EventUserIdentifierMap) {
 	ctx.addUserEvent(event)
 }
 
-func (ctx *HTTPRequestContext) Close() {
+func (ctx *HTTPRequestRecord) Close() {
 	addTrackEvent(newHTTPRequestRecord(ctx))
 }
 
-func (ctx *HTTPRequestContext) addTrackEvent(event *HTTPRequestEvent) {
+func (ctx *HTTPRequestRecord) addTrackEvent(event *HTTPRequestEvent) {
 	ctx.eventsLock.Lock()
 	defer ctx.eventsLock.Unlock()
 	ctx.events = append(ctx.events, event)
 }
 
-func (ctx *HTTPRequestContext) addUserEvent(event userEventFace) {
+func (ctx *HTTPRequestRecord) addUserEvent(event userEventFace) {
 	addUserEvent(event)
 }
 
@@ -209,11 +209,11 @@ func (e *HTTPRequestEvent) Proto() proto.Message {
 }
 
 type httpRequestRecord struct {
-	ctx         *HTTPRequestContext
+	ctx         *HTTPRequestRecord
 	rulespackID string
 }
 
-func newHTTPRequestRecord(event *HTTPRequestContext) *httpRequestRecord {
+func newHTTPRequestRecord(event *HTTPRequestRecord) *httpRequestRecord {
 	return &httpRequestRecord{
 		ctx: event,
 	}

--- a/sdk/context.go
+++ b/sdk/context.go
@@ -6,10 +6,12 @@ package sdk
 // be of type *HTTPRequestRecord.
 var HTTPRequestRecordContextKey = &ContextKey{"sqreen.rr"}
 
-// ContextKey allows to insert context values with comparable keys that are not
-// strings, as documented by context.WithValue(), to avoid string collisions.
+// ContextKey allows to insert context values avoiding string collisions. Cf.
+// `context.WithValue()`.
 type ContextKey struct {
-	// This string value must be used by middelware function whose framework
-	// expects context keys of type string, such as Gin.
+	// This string value must be used by middelware functions whose framework
+	// expects context keys of type string, such as Gin. `sdk.FromContext()`
+	// expect this behaviour to fallback to string keys when getting the value
+	// from the pointer address returned null.
 	String string
 }

--- a/sdk/context.go
+++ b/sdk/context.go
@@ -1,0 +1,15 @@
+package sdk
+
+// HTTPRequestRecordContextKey is a context key. It can be used in HTTP
+// handlers with context.Context.Value() to access the HTTPRequestRecord that
+// was associated with the request by the middleware. The associated value will
+// be of type *HTTPRequestRecord.
+var HTTPRequestRecordContextKey = &ContextKey{"sqreen.rr"}
+
+// ContextKey allows to insert context values with comparable keys that are not
+// strings, as documented by context.WithValue(), to avoid string collisions.
+type ContextKey struct {
+	// This string value must be used by middelware function whose framework
+	// expects context keys of type string, such as Gin.
+	String string
+}

--- a/sdk/context.go
+++ b/sdk/context.go
@@ -1,14 +1,39 @@
 package sdk
 
 import (
+	"context"
+
 	"github.com/sqreen/go-agent/agent"
 )
+
+const HTTPRequestContextKey = "sqctx"
 
 // HTTPRequestContext is the context associated to a single HTTP request. It
 // collects every security event happening during the HTTP handling, until the
 // Close() method is called to signal the request is done.
 type HTTPRequestContext struct {
 	ctx *agent.HTTPRequestContext
+}
+
+// GetHTTPContext returns the sdk's context associated to the request's context
+// by the middleware function.
+//
+//	router.GET("/", func(c *gin.Context) {
+//		sqgin.GetHTTPContext(c).TrackEvent("my.event.one")
+//		aFunction(c.Request.Context())
+//	}
+//
+//	func aFunction(ctx context.Context) {
+//		sqgin.GetHTTPContext(ctx).TrackEvent("my.event.two")
+//		// ...
+//	}
+//
+func GetHTTPContext(ctx context.Context) *HTTPRequestContext {
+	sqreen := ctx.Value(HTTPRequestContextKey)
+	if sqreen == nil {
+		return nil
+	}
+	return sqreen.(*HTTPRequestContext)
 }
 
 // HTTPRequest is the request interface to access request information. Usually

--- a/sdk/context.go
+++ b/sdk/context.go
@@ -70,9 +70,9 @@ func (ctx *HTTPRequestContext) Close() {
 //	uid := sdk.EventUserIdentifierMap{"uid": "my-uid"}
 //	props := sdk.EventPropertyMap{"key": "value"}
 //	sqreen := middleware.GetHTTPContext(ctx)
-//	sqreen.Track("my.event").WithUserIdentifier(uid).WithProperties(props)
+//	sqreen.TrackEvent("my.event").WithUserIdentifier(uid).WithProperties(props)
 //
-func (ctx *HTTPRequestContext) Track(event string) *HTTPRequestEvent {
+func (ctx *HTTPRequestContext) TrackEvent(event string) *HTTPRequestEvent {
 	if ctx == nil {
 		return nil
 	}

--- a/sdk/context_test.go
+++ b/sdk/context_test.go
@@ -1,26 +1,19 @@
-package sdk_test
+package sdk
 
 import (
 	"net/http"
 	"testing"
 	"time"
 
+	"github.com/sqreen/go-agent/agent"
 	"github.com/sqreen/go-agent/agent/backend/api"
-	"github.com/sqreen/go-agent/sdk"
 	"github.com/sqreen/go-agent/tools/testlib"
 	"github.com/stretchr/testify/require"
 )
 
-type fakeRequest struct {
-}
-
-func (_ fakeRequest) StdRequest() *http.Request {
+func newFakeRequest() *http.Request {
 	req, _ := http.NewRequest("GET", "https://sqreen.com", nil)
 	return req
-}
-
-func (_ fakeRequest) ClientIP() string {
-	return ""
 }
 
 func TestSDK(t *testing.T) {
@@ -29,52 +22,52 @@ func TestSDK(t *testing.T) {
 	})
 
 	t.Run("Track", func(t *testing.T) {
-		ctx := sdk.NewHTTPRequestContext(fakeRequest{})
+		ctx := NewHTTPRequestContext(newFakeRequest())
 		eventId := testlib.RandString(2, 50)
 		uid := testlib.RandString(2, 50)
-		idMap := sdk.EventUserIdentifierMap{"uid": uid}
-		event := ctx.Track(eventId)
-		require.Equal(t, event.GetName(), "track")
+		idMap := EventUserIdentifierMap{"uid": uid}
+		event := ctx.TrackEvent(eventId)
+		require.Equal(t, event.impl.GetName(), "track")
 
 		t.Run("with user identifier", func(t *testing.T) {
 			event.WithUserIdentifier(idMap)
-			args := event.GetArgs()
+			args := event.impl.GetArgs()
 			require.Equal(t, 2, len(args))
 			require.Equal(t, args[0].(string), eventId)
-			require.Equal(t, args[1].(*api.RequestRecord_Observed_SDKEvent_Options).GetUserIdentifiers().Value, idMap)
+			require.Equal(t, args[1].(*api.RequestRecord_Observed_SDKEvent_Options).GetUserIdentifiers().Value, agent.EventUserIdentifierMap(idMap))
 		})
 	})
 
 	t.Run("TrackAuth", func(t *testing.T) {
-		ctx := sdk.NewHTTPRequestContext(fakeRequest{})
+		ctx := NewHTTPRequestContext(newFakeRequest())
 		uid := testlib.RandString(2, 50)
-		idMap := sdk.EventUserIdentifierMap{"uid": uid}
+		idMap := EventUserIdentifierMap{"uid": uid}
 		success := true
 		ctx.TrackAuth(success, idMap)
 	})
 
 	t.Run("TrackSignup", func(t *testing.T) {
-		ctx := sdk.NewHTTPRequestContext(fakeRequest{})
+		ctx := NewHTTPRequestContext(newFakeRequest())
 		uid := testlib.RandString(2, 50)
-		idMap := sdk.EventUserIdentifierMap{"uid": uid}
+		idMap := EventUserIdentifierMap{"uid": uid}
 		ctx.TrackSignup(idMap)
 	})
 }
 
-func testDisabledSDKCalls(t *testing.T, ctx *sdk.HTTPRequestContext) {
-	event := ctx.Track(testlib.RandString(0, 50))
+func testDisabledSDKCalls(t *testing.T, ctx *HTTPRequestContext) {
+	event := ctx.TrackEvent(testlib.RandString(0, 50))
 	require.Nil(t, event)
 	event = event.WithTimestamp(time.Now())
 	require.Nil(t, event)
 	event = event.WithProperties(nil)
 	require.Nil(t, event)
-	event = ctx.Track(testlib.RandString(0, 50))
+	event = ctx.TrackEvent(testlib.RandString(0, 50))
 	require.Nil(t, event)
 	event = event.WithProperties(nil)
 	require.Nil(t, event)
 	event = event.WithTimestamp(time.Now())
 	require.Nil(t, event)
-	uid := sdk.EventUserIdentifierMap{"uid": "uid"}
+	uid := EventUserIdentifierMap{"uid": "uid"}
 	ctx.TrackAuth(true, uid)
 	ctx.TrackAuthSuccess(uid)
 	ctx.TrackAuthFailure(uid)

--- a/sdk/event.go
+++ b/sdk/event.go
@@ -1,0 +1,37 @@
+package sdk
+
+import (
+	"time"
+
+	"github.com/sqreen/go-agent/agent"
+)
+
+type HTTPRequestEvent struct {
+	impl *agent.HTTPRequestEvent
+}
+
+type EventPropertyMap map[string]string
+
+func (e *HTTPRequestEvent) WithTimestamp(t time.Time) *HTTPRequestEvent {
+	if e == nil {
+		return nil
+	}
+	e.impl.WithTimestamp(t)
+	return e
+}
+
+func (e *HTTPRequestEvent) WithProperties(p EventPropertyMap) *HTTPRequestEvent {
+	if e == nil {
+		return nil
+	}
+	e.impl.WithProperties(agent.EventPropertyMap(p))
+	return e
+}
+
+func (e *HTTPRequestEvent) WithUserIdentifier(id EventUserIdentifierMap) *HTTPRequestEvent {
+	if e == nil {
+		return nil
+	}
+	e.impl.WithUserIdentifier(agent.EventUserIdentifierMap(id))
+	return e
+}

--- a/sdk/event.go
+++ b/sdk/event.go
@@ -6,12 +6,28 @@ import (
 	"github.com/sqreen/go-agent/agent"
 )
 
+// HTTPRequestEvent is a SDK event. Its methods allow request handlers to add
+// options further specifying the event, such as a unique user identifier, extra
+// properties, etc.
 type HTTPRequestEvent struct {
 	impl *agent.HTTPRequestEvent
 }
 
+// EventPropertyMap is the type used to represent extra custom event properties.
+//
+//	props := sdk.EventPropertyMap{
+//		"key1": "value1",
+//		"key2": "value2",
+//	}
+//	sdk.FromContext(ctx).TrackEvent("my.event").WithProperties(props)
+//
 type EventPropertyMap map[string]string
 
+// WithTimestamp adds a custom timestamp to the event. By default, the timestamp
+// is set to `time.Now()` value at the time of the call to the event creation.
+//
+//	sdk.FromContext(ctx).TrackEvent("my.event").WithTimestamp(yourTimestamp)
+//
 func (e *HTTPRequestEvent) WithTimestamp(t time.Time) *HTTPRequestEvent {
 	if e == nil {
 		return nil
@@ -20,6 +36,14 @@ func (e *HTTPRequestEvent) WithTimestamp(t time.Time) *HTTPRequestEvent {
 	return e
 }
 
+// WithProperties adds custom properties to the event.
+//
+//	props := sdk.EventPropertyMap{
+//		"key1": "value1",
+//		"key2": "value2",
+//	}
+//	sdk.FromContext(ctx).TrackEvent("my.event").WithProperties(prop)
+//
 func (e *HTTPRequestEvent) WithProperties(p EventPropertyMap) *HTTPRequestEvent {
 	if e == nil {
 		return nil
@@ -28,6 +52,12 @@ func (e *HTTPRequestEvent) WithProperties(p EventPropertyMap) *HTTPRequestEvent 
 	return e
 }
 
+// WithUserIdentifier associates the given user identifier map `id` to the
+// event.
+//
+//	uid := sdk.EventUserIdentifierMap{"uid": "my-uid"}
+//	sdk.FromContext(ctx).Identify(uid)
+//
 func (e *HTTPRequestEvent) WithUserIdentifier(id EventUserIdentifierMap) *HTTPRequestEvent {
 	if e == nil {
 		return nil

--- a/sdk/middleware/sqgin/gin.go
+++ b/sdk/middleware/sqgin/gin.go
@@ -8,23 +8,28 @@ import (
 )
 
 // Middleware is Sqreen's middleware function for Gin to monitor and protect the
-// requests Gin receives. It creates and stores the HTTP request record into the
-// Gin and request contexts so that it can be later retrieved from handlers
-// using sdk.FromContext() to perform sdk calls.
+// requests Gin receives. It creates and stores the HTTP request record both
+// into the Gin and request contexts so that it can be later accessed from
+// handlers using `sdk.FromContext()` to perform SDK calls.
+//
+// Note that Gin's context implements the `context.Context` interface, so
+// `sdk.FromContext()` can be used both with the Gin and request contexts.
 //
 //	router := gin.Default()
 //	router.Use(sqgin.Middleware())
 //
 //	router.GET("/", func(c *gin.Context) {
+//		// Accessing the SDK through Gin's context
 //		sdk.FromContext(c).TrackEvent("my.event.one")
-//		foo(c)
-//		// or foo(c.Request.Context())
+//		foo(c.Request)
 //	}
 //
-//	func foo(ctx context.Context) {
-//		sdk.FromContext(ctx).TrackEvent("my.event.two")
+//	func foo(req *http.Request) {
+//		// Accessing the SDK through the request context
+//		sdk.FromContext(req.Context()).TrackEvent("my.event.two")
 //		// ...
 //	}
+//
 func Middleware() gingonic.HandlerFunc {
 	return func(c *gingonic.Context) {
 		// Create a new request record for this request.

--- a/sdk/middleware/sqgin/gin.go
+++ b/sdk/middleware/sqgin/gin.go
@@ -27,15 +27,15 @@ import (
 func Middleware() gingonic.HandlerFunc {
 	return func(c *gingonic.Context) {
 		// Create a sqreen context for this request.
-		sqreen := sdk.NewHTTPRequestContext(c.Request)
+		sqreen := sdk.NewHTTPRequestRecord(c.Request)
 
 		// Store it into Go's context.
 		ctx := c.Request.Context()
-		ctx = context.WithValue(ctx, sdk.HTTPRequestContextKey, sqreen)
+		ctx = context.WithValue(ctx, sdk.HTTPRequestRecordKey, sqreen)
 		c.Request = c.Request.WithContext(ctx)
 
 		// Store it into Gin's context.
-		c.Set(sdk.HTTPRequestContextKey, sqreen)
+		c.Set(sdk.HTTPRequestRecordKey, sqreen)
 
 		c.Next()
 

--- a/sdk/middleware/sqgin/gin.go
+++ b/sdk/middleware/sqgin/gin.go
@@ -27,7 +27,7 @@ import (
 func Middleware() gingonic.HandlerFunc {
 	return func(c *gingonic.Context) {
 		// Create a sqreen context for this request.
-		sqreen := sdk.NewHTTPRequestContext(request{c.Copy()})
+		sqreen := sdk.NewHTTPRequestContext(c.Request)
 
 		// Store it into Go's context.
 		ctx := c.Request.Context()
@@ -42,12 +42,4 @@ func Middleware() gingonic.HandlerFunc {
 		// Close the sqreen context
 		sqreen.Close()
 	}
-}
-
-type request struct {
-	*gingonic.Context
-}
-
-func (r request) StdRequest() *http.Request {
-	return r.Context.Request
 }

--- a/sdk/middleware/sqgin/gin.go
+++ b/sdk/middleware/sqgin/gin.go
@@ -2,76 +2,46 @@ package sqgin
 
 import (
 	"context"
-	"net/http"
 
 	gingonic "github.com/gin-gonic/gin"
-	sqreen_sdk "github.com/sqreen/go-agent/sdk"
+	"github.com/sqreen/go-agent/sdk"
 )
 
-const agentCtxGinKey = "sq.ctx"
-
-// Sqreen is the middleware function for Gin so that it monitors and protects
-// received requests. It creates and stores the sdk's context into the Gin's and
-// request's contextes so that they can be retrieved from handlers to perform
-// sdk calls using GetHTTPContextFromGin() or GetHTTPContext().
-func Sqreen() gingonic.HandlerFunc {
+// Middleware is Sqreen's middleware function for Gin to monitor and protect the
+// requests Gin receives. It creates and stores the sdk's context into Gin's so
+// that they can be retrieved from handlers to perform sdk calls using
+// `GetHTTPContext()`.
+//
+//	router := gin.Default()
+//	router.Use(sqgin.Middleware())
+//
+//	router.GET("/", func(c *gin.Context) {
+//		sqgin.GetHTTPContext(c).TrackEvent("my.event.one")
+//		aFunction(c.Request.Context())
+//	}
+//
+//	func aFunction(ctx context.Context) {
+//		sqgin.GetHTTPContext(ctx).TrackEvent("my.event.two")
+//		// ...
+//	}
+func Middleware() gingonic.HandlerFunc {
 	return func(c *gingonic.Context) {
 		// Create a sqreen context for this request.
-		sqreen := sqreen_sdk.NewHTTPRequestContext(request{c.Copy()})
+		sqreen := sdk.NewHTTPRequestContext(request{c.Copy()})
 
 		// Store it into Go's context.
 		ctx := c.Request.Context()
-		ctx = context.WithValue(ctx, agentCtxGinKey, sqreen)
+		ctx = context.WithValue(ctx, sdk.HTTPRequestContextKey, sqreen)
 		c.Request = c.Request.WithContext(ctx)
 
 		// Store it into Gin's context.
-		c.Set(agentCtxGinKey, sqreen)
+		c.Set(sdk.HTTPRequestContextKey, sqreen)
 
 		c.Next()
 
 		// Close the sqreen context
 		sqreen.Close()
 	}
-}
-
-// GetHTTPContextFromGin returns the sdk's context associated to the Gin's
-// context by the middleware function.
-//
-//	router.GET("/", func(c *gin.Context) {
-//		sqgin.GetHTTPContextFromGin(c).Track("my.event")
-//		// ...
-//	}
-//
-func GetHTTPContextFromGin(c *gingonic.Context) *sqreen_sdk.HTTPRequestContext {
-	ctx, exists := c.Get(agentCtxGinKey)
-	if !exists {
-		return nil
-	}
-	return ctx.(*sqreen_sdk.HTTPRequestContext)
-}
-
-// GetHTTPContext returns the sdk's context associated to the request's context by the
-// middleware function.
-//
-// It allows to retrieve it out of a Go context when the Gin context is not
-// accessible in the current function scope. So instead of using
-// GetHTTPContextFromGin(), you can use this function:
-//
-//	router.GET("/", func(c *gin.Context) {
-//		aFunction(c.Request.Context())
-//	}
-//
-//	func aFunction(ctx context.Context) {
-//		sqgin.GetHTTPContext(ctx).Track("my.event")
-//		// ...
-//	}
-//
-func GetHTTPContext(ctx context.Context) *sqreen_sdk.HTTPRequestContext {
-	sqreen := ctx.Value(agentCtxGinKey)
-	if sqreen == nil {
-		return nil
-	}
-	return sqreen.(*sqreen_sdk.HTTPRequestContext)
 }
 
 type request struct {

--- a/sdk/middleware/sqgin/gin_test.go
+++ b/sdk/middleware/sqgin/gin_test.go
@@ -19,7 +19,7 @@ func TestMiddleware(t *testing.T) {
 	router := gin.New()
 	// Attach our middelware
 	router.Use(sqgin.Middleware())
-	// Add a endpoint accessing the SDK handle
+	// Add an endpoint accessing the SDK handle
 	router.GET("/", func(c *gin.Context) {
 		require.NotNil(sdk.FromContext(c), "The middleware should attach its handle object to Gin's context")
 		require.NotNil(sdk.FromContext(c.Request.Context()), "The middleware should attach its handle object to the request's context")

--- a/sdk/middleware/sqgin/gin_test.go
+++ b/sdk/middleware/sqgin/gin_test.go
@@ -1,0 +1,35 @@
+package sqgin_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/sqreen/go-agent/sdk"
+	"github.com/sqreen/go-agent/sdk/middleware/sqgin"
+	"github.com/sqreen/go-agent/tools/testlib"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMiddleware(t *testing.T) {
+	require := require.New(t)
+	hw := testlib.RandString(1, 100)
+	// Create a Gin router
+	router := gin.New()
+	// Attach our middelware
+	router.Use(sqgin.Middleware())
+	// Add a endpoint accessing the SDK handle
+	router.GET("/", func(c *gin.Context) {
+		require.NotNil(sdk.FromContext(c), "The middleware should attach its handle object to Gin's context")
+		require.NotNil(sdk.FromContext(c.Request.Context()), "The middleware should attach its handle object to the request's context")
+		c.String(http.StatusOK, hw)
+	})
+	// Perform the request and record the output
+	rec := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/", nil)
+	router.ServeHTTP(rec, req)
+	// Check the request was performed as expected
+	require.Equal(http.StatusOK, rec.Code)
+	require.Equal(hw, rec.Body.String())
+}

--- a/sdk/record.go
+++ b/sdk/record.go
@@ -7,16 +7,21 @@ import (
 	"github.com/sqreen/go-agent/agent"
 )
 
-// HTTPRequestRecord is the context associated to a single HTTP request. It
-// collects every security event happening during the HTTP handling, until the
-// Close() method is called to signal the request is done.
+// HTTPRequestRecord is the SDK record associated to a HTTP request. Its methods
+// allow request handlers to signal security events, identify users, etc.
 type HTTPRequestRecord struct {
 	ctx *agent.HTTPRequestRecord
 }
 
+// EventUserIdentifierMap is the type used to represent user identifiers in
+// collected events.
+//
+//	uid := sdk.EventUserIdentifierMap{"uid": "my-uid"}
+//	sdk.FromContext(ctx).Identify(uid)
+//
 type EventUserIdentifierMap map[string]string
 
-// NewHTTPRequestRecord returns a new HTTP request context for the given HTTP
+// NewHTTPRequestRecord returns a new HTTP request record for the given HTTP
 // request.
 func NewHTTPRequestRecord(req *http.Request) *HTTPRequestRecord {
 	return &HTTPRequestRecord{
@@ -26,15 +31,19 @@ func NewHTTPRequestRecord(req *http.Request) *HTTPRequestRecord {
 
 // FromContext allows to access the HTTPRequestRecord from request handlers if
 // present, and nil otherwise. The value is stored in handler contexts by the
-// middleware function for the framework and is of type *HTTPRequestRecord.
+// middleware function of the framework, and is of type *HTTPRequestRecord. It
+// is possible to use it with framework's contexts when they implement Go's
+// `context.Context` interface.
 //
 //	router.GET("/", func(c *gin.Context) {
+//		// Accessing the SDK through framework's context (when possible).
 //		sdk.FromContext(c).TrackEvent("my.event.one")
-//		aFunction(c.Request.Context())
+//		aFunction(c.Request)
 //	}
 //
-//	func aFunction(ctx context.Context) {
-//		sdk.FromContext(ctx).TrackEvent("my.event.two")
+//	func aFunction(req *http.Request) {
+//		// Accessing the SDK through the request context
+//		sdk.FromContext(req.Context()).TrackEvent("my.event.two")
 //		// ...
 //	}
 //
@@ -51,8 +60,7 @@ func FromContext(ctx context.Context) *HTTPRequestRecord {
 	return v.(*HTTPRequestRecord)
 }
 
-// Close signals the request handling is now done. Every collected security
-// event can thus be considered by the agnt.
+// Close the request record to signal the HTTP request handling is now done.
 func (ctx *HTTPRequestRecord) Close() {
 	if ctx == nil {
 		return
@@ -60,13 +68,14 @@ func (ctx *HTTPRequestRecord) Close() {
 	ctx.ctx.Close()
 }
 
-// Track allows to track a custom security-related event with the given event
-// name. Additional options can be set using the returned value's methods, such
-// WithProperties() or WithTimestamp().
+// TrackEvent allows to track a custom security-related event having the given
+// event name. It creates a new event whose additional options can be set using
+// the returned value's methods, such as `WithProperties()` or
+// `WithTimestamp()`. A call to this method creates a new event.
 //
 //	uid := sdk.EventUserIdentifierMap{"uid": "my-uid"}
 //	props := sdk.EventPropertyMap{"key": "value"}
-//	sqreen := middleware.GetHTTPContext(ctx)
+//	sqreen := sdk.FromContext(ctx)
 //	sqreen.TrackEvent("my.event").WithUserIdentifier(uid).WithProperties(props)
 //
 func (ctx *HTTPRequestRecord) TrackEvent(event string) *HTTPRequestEvent {
@@ -76,11 +85,12 @@ func (ctx *HTTPRequestRecord) TrackEvent(event string) *HTTPRequestEvent {
 	return &HTTPRequestEvent{ctx.ctx.Track(event)}
 }
 
-// TrackAuth allows to track a user authentication. The user id `id` is a set
-// uniquely identifying the user. `loginSuccess` must be true when the user
-// successfully logged in, false otherwise.
+// TrackAuth allows to track a user authentication. The given user identifier
+// value `id` is a map uniquely identifying the user. The boolean value
+// `loginSuccess` must be true when the user successfully logged in, false
+// otherwise. A call to this method creates a new event.
 //
-//	sqreen := middleware.GetHTTPContext(ctx)
+//	sqreen := sdk.FromContext(ctx)
 //	sqreen.TrackAuth(granted, sdk.EventUserIdentifierMap{"uid": "my-uid"})
 //
 func (ctx *HTTPRequestRecord) TrackAuth(loginSuccess bool, id EventUserIdentifierMap) {
@@ -90,20 +100,21 @@ func (ctx *HTTPRequestRecord) TrackAuth(loginSuccess bool, id EventUserIdentifie
 	ctx.ctx.TrackAuth(loginSuccess, agent.EventUserIdentifierMap(id))
 }
 
-// TrackAuthSuccess is equivalent to `TrackAuth(true, id)`
+// TrackAuthSuccess is equivalent to `TrackAuth(true, id)`.
 func (ctx *HTTPRequestRecord) TrackAuthSuccess(id EventUserIdentifierMap) {
 	ctx.TrackAuth(true, id)
 }
 
-// TrackAuthFailure is equivalent to `TrackAuth(false, id)`
+// TrackAuthFailure is equivalent to `TrackAuth(false, id)`.
 func (ctx *HTTPRequestRecord) TrackAuthFailure(id EventUserIdentifierMap) {
 	ctx.TrackAuth(false, id)
 }
 
-// TrackSignup allows to track a user signup. The user id `id` is a set
-// uniquely identifying the user.
+// TrackSignup allows to track a user signup. The given user identifier value
+// `id` is a map uniquely identifying the user. A call to this method creates a
+// new event.
 //
-//	sqreen := middleware.GetHTTPContext(ctx)
+//	sqreen := sdk.FromContext(ctx)
 //	sqreen.TrackSignup(sdk.EventUserIdentifierMap{"uid": "my-uid"})
 //
 func (ctx *HTTPRequestRecord) TrackSignup(id EventUserIdentifierMap) {

--- a/sdk/record.go
+++ b/sdk/record.go
@@ -7,8 +7,6 @@ import (
 	"github.com/sqreen/go-agent/agent"
 )
 
-const HTTPRequestRecordKey = "sqctx"
-
 // HTTPRequestRecord is the context associated to a single HTTP request. It
 // collects every security event happening during the HTTP handling, until the
 // Close() method is called to signal the request is done.
@@ -40,11 +38,16 @@ func NewHTTPRequestRecord(req *http.Request) *HTTPRequestRecord {
 //	}
 //
 func GetHTTPContext(ctx context.Context) *HTTPRequestRecord {
-	sqreen := ctx.Value(HTTPRequestRecordKey)
-	if sqreen == nil {
-		return nil
+	v := ctx.Value(HTTPRequestRecordContextKey)
+	if v == nil {
+		// Try with a string since frameworks such as Gin implement it with keys of
+		// type string.
+		v = ctx.Value(HTTPRequestRecordContextKey.String)
+		if v == nil {
+			return nil
+		}
 	}
-	return sqreen.(*HTTPRequestRecord)
+	return v.(*HTTPRequestRecord)
 }
 
 // Close signals the request handling is now done. Every collected security

--- a/sdk/record.go
+++ b/sdk/record.go
@@ -7,22 +7,22 @@ import (
 	"github.com/sqreen/go-agent/agent"
 )
 
-const HTTPRequestContextKey = "sqctx"
+const HTTPRequestRecordKey = "sqctx"
 
-// HTTPRequestContext is the context associated to a single HTTP request. It
+// HTTPRequestRecord is the context associated to a single HTTP request. It
 // collects every security event happening during the HTTP handling, until the
 // Close() method is called to signal the request is done.
-type HTTPRequestContext struct {
-	ctx *agent.HTTPRequestContext
+type HTTPRequestRecord struct {
+	ctx *agent.HTTPRequestRecord
 }
 
 type EventUserIdentifierMap map[string]string
 
-// NewHTTPRequestContext returns a new HTTP request context for the given HTTP
+// NewHTTPRequestRecord returns a new HTTP request context for the given HTTP
 // request.
-func NewHTTPRequestContext(req *http.Request) *HTTPRequestContext {
-	return &HTTPRequestContext{
-		ctx: agent.NewHTTPRequestContext(req),
+func NewHTTPRequestRecord(req *http.Request) *HTTPRequestRecord {
+	return &HTTPRequestRecord{
+		ctx: agent.NewHTTPRequestRecord(req),
 	}
 }
 
@@ -39,17 +39,17 @@ func NewHTTPRequestContext(req *http.Request) *HTTPRequestContext {
 //		// ...
 //	}
 //
-func GetHTTPContext(ctx context.Context) *HTTPRequestContext {
-	sqreen := ctx.Value(HTTPRequestContextKey)
+func GetHTTPContext(ctx context.Context) *HTTPRequestRecord {
+	sqreen := ctx.Value(HTTPRequestRecordKey)
 	if sqreen == nil {
 		return nil
 	}
-	return sqreen.(*HTTPRequestContext)
+	return sqreen.(*HTTPRequestRecord)
 }
 
 // Close signals the request handling is now done. Every collected security
 // event can thus be considered by the agnt.
-func (ctx *HTTPRequestContext) Close() {
+func (ctx *HTTPRequestRecord) Close() {
 	if ctx == nil {
 		return
 	}
@@ -65,7 +65,7 @@ func (ctx *HTTPRequestContext) Close() {
 //	sqreen := middleware.GetHTTPContext(ctx)
 //	sqreen.TrackEvent("my.event").WithUserIdentifier(uid).WithProperties(props)
 //
-func (ctx *HTTPRequestContext) TrackEvent(event string) *HTTPRequestEvent {
+func (ctx *HTTPRequestRecord) TrackEvent(event string) *HTTPRequestEvent {
 	if ctx == nil {
 		return nil
 	}
@@ -79,7 +79,7 @@ func (ctx *HTTPRequestContext) TrackEvent(event string) *HTTPRequestEvent {
 //	sqreen := middleware.GetHTTPContext(ctx)
 //	sqreen.TrackAuth(granted, sdk.EventUserIdentifierMap{"uid": "my-uid"})
 //
-func (ctx *HTTPRequestContext) TrackAuth(loginSuccess bool, id EventUserIdentifierMap) {
+func (ctx *HTTPRequestRecord) TrackAuth(loginSuccess bool, id EventUserIdentifierMap) {
 	if ctx == nil {
 		return
 	}
@@ -87,12 +87,12 @@ func (ctx *HTTPRequestContext) TrackAuth(loginSuccess bool, id EventUserIdentifi
 }
 
 // TrackAuthSuccess is equivalent to `TrackAuth(true, id)`
-func (ctx *HTTPRequestContext) TrackAuthSuccess(id EventUserIdentifierMap) {
+func (ctx *HTTPRequestRecord) TrackAuthSuccess(id EventUserIdentifierMap) {
 	ctx.TrackAuth(true, id)
 }
 
 // TrackAuthFailure is equivalent to `TrackAuth(false, id)`
-func (ctx *HTTPRequestContext) TrackAuthFailure(id EventUserIdentifierMap) {
+func (ctx *HTTPRequestRecord) TrackAuthFailure(id EventUserIdentifierMap) {
 	ctx.TrackAuth(false, id)
 }
 
@@ -102,7 +102,7 @@ func (ctx *HTTPRequestContext) TrackAuthFailure(id EventUserIdentifierMap) {
 //	sqreen := middleware.GetHTTPContext(ctx)
 //	sqreen.TrackSignup(sdk.EventUserIdentifierMap{"uid": "my-uid"})
 //
-func (ctx *HTTPRequestContext) TrackSignup(id EventUserIdentifierMap) {
+func (ctx *HTTPRequestRecord) TrackSignup(id EventUserIdentifierMap) {
 	if ctx == nil {
 		return
 	}

--- a/sdk/record.go
+++ b/sdk/record.go
@@ -24,20 +24,21 @@ func NewHTTPRequestRecord(req *http.Request) *HTTPRequestRecord {
 	}
 }
 
-// GetHTTPContext returns the sdk's context associated to the request's context
-// by the middleware function.
+// FromContext allows to access the HTTPRequestRecord from request handlers if
+// present, and nil otherwise. The value is stored in handler contexts by the
+// middleware function for the framework and is of type *HTTPRequestRecord.
 //
 //	router.GET("/", func(c *gin.Context) {
-//		sqgin.GetHTTPContext(c).TrackEvent("my.event.one")
+//		sdk.FromContext(c).TrackEvent("my.event.one")
 //		aFunction(c.Request.Context())
 //	}
 //
 //	func aFunction(ctx context.Context) {
-//		sqgin.GetHTTPContext(ctx).TrackEvent("my.event.two")
+//		sdk.FromContext(ctx).TrackEvent("my.event.two")
 //		// ...
 //	}
 //
-func GetHTTPContext(ctx context.Context) *HTTPRequestRecord {
+func FromContext(ctx context.Context) *HTTPRequestRecord {
 	v := ctx.Value(HTTPRequestRecordContextKey)
 	if v == nil {
 		// Try with a string since frameworks such as Gin implement it with keys of

--- a/sdk/sdk_test.go
+++ b/sdk/sdk_test.go
@@ -22,7 +22,7 @@ func TestSDK(t *testing.T) {
 	})
 
 	t.Run("Track", func(t *testing.T) {
-		ctx := NewHTTPRequestContext(newFakeRequest())
+		ctx := NewHTTPRequestRecord(newFakeRequest())
 		eventId := testlib.RandString(2, 50)
 		uid := testlib.RandString(2, 50)
 		idMap := EventUserIdentifierMap{"uid": uid}
@@ -39,7 +39,7 @@ func TestSDK(t *testing.T) {
 	})
 
 	t.Run("TrackAuth", func(t *testing.T) {
-		ctx := NewHTTPRequestContext(newFakeRequest())
+		ctx := NewHTTPRequestRecord(newFakeRequest())
 		uid := testlib.RandString(2, 50)
 		idMap := EventUserIdentifierMap{"uid": uid}
 		success := true
@@ -47,14 +47,14 @@ func TestSDK(t *testing.T) {
 	})
 
 	t.Run("TrackSignup", func(t *testing.T) {
-		ctx := NewHTTPRequestContext(newFakeRequest())
+		ctx := NewHTTPRequestRecord(newFakeRequest())
 		uid := testlib.RandString(2, 50)
 		idMap := EventUserIdentifierMap{"uid": uid}
 		ctx.TrackSignup(idMap)
 	})
 }
 
-func testDisabledSDKCalls(t *testing.T, ctx *HTTPRequestContext) {
+func testDisabledSDKCalls(t *testing.T, ctx *HTTPRequestRecord) {
 	event := ctx.TrackEvent(testlib.RandString(0, 50))
 	require.Nil(t, event)
 	event = event.WithTimestamp(time.Now())


### PR DESCRIPTION
- [x] Better naming of structures and functions.
- [x] Rename Gin's middleware package `gin` into `sqgin` to avoid name conflicts with the framework which require uses to alias the package.
- [x] Move every definition into package `sdk` so that godoc https://godoc.org/github.com/sqreen/go-agent/sdk is exhaustive and doesn't require users to go inside the agent's godoc.
- [x] Document everything, along with examples.
- [x] Homogeneous SDK functions `TrackXXX()`, hence `Track()` becomes `TrackEvent()`.

Closes SQR-5213, SQR-5344, SQR-5345 and SQR-5346.