### PR TITLE
sdk/middleware/echo: middleware function for Echo

### DIFF
--- a/sdk/middleware/sqecho/echo.go
+++ b/sdk/middleware/sqecho/echo.go
@@ -1,0 +1,73 @@
+package sqecho
+
+import (
+	"context"
+
+	"github.com/labstack/echo"
+	"github.com/sqreen/go-agent/sdk"
+)
+
+// Middleware is Sqreen's middleware function for Echo to monitor and protect
+// the requests Echo receives. It creates and stores the HTTP request record
+// both into the Echo and request contexts so that it can be later accessed from
+// handlers using `sdk.FromContext()` to perform SDK calls.
+//
+// Note that Echo's context does not implement the `context.Context` interface,
+// so `sdk.FromContext()` cannot be used with it, hence `FromContext()` in this
+// package to access the SDK context value from Echo's context.
+// `sdk.FromContext()` can still be used on the request context.
+//
+//	e := echo.New()
+//	e.Use(sqecho.Middleware())
+//
+//	e.GET("/", func(c echo.Context) {
+//		// Accessing the SDK through Echo's context
+//		sqecho.FromContext(c).TrackEvent("my.event.one")
+//		foo(c.Request())
+//	}
+//
+//	func foo(req *http.Request) {
+//		// Accessing the SDK through the request context
+//		sdk.FromContext(req.Context()).TrackEvent("my.event.two")
+//	}
+//
+func Middleware() echo.MiddlewareFunc {
+	return func(next echo.HandlerFunc) echo.HandlerFunc {
+		return func(c echo.Context) error {
+			// Create a new request record for this request.
+			req := c.Request()
+			sqreen := sdk.NewHTTPRequestRecord(req)
+			defer sqreen.Close()
+
+			// Echo defines its own context interface, so we need to store it both in
+			// the request and Echo contexts.
+
+			// Store it into the request's context.
+			contextKey := sdk.HTTPRequestRecordContextKey.String
+			ctx := req.Context()
+			ctx = context.WithValue(ctx, contextKey, sqreen)
+			c.SetRequest(req.WithContext(ctx))
+
+			// Store it into Echo's context.
+			c.Set(contextKey, sqreen)
+
+			return next(c)
+		}
+	}
+}
+
+// FromContext allows to access the HTTPRequestRecord from Echo request handlers
+// if present, and nil otherwise. The value is stored in handler contexts by the
+// middleware function, and is of type *HTTPRequestRecord.
+//
+// Note that Echo's context does not implement the `context.Context` interface,
+// so `sdk.FromContext()` cannot be used with it, hence `FromContext()` in this
+// package to access the SDK context value from Echo's context.
+// `sdk.FromContext()` can still be used on the request context.
+func FromContext(c echo.Context) *sdk.HTTPRequestRecord {
+	v := c.Get(sdk.HTTPRequestRecordContextKey.String)
+	if v == nil {
+		return nil
+	}
+	return v.(*sdk.HTTPRequestRecord)
+}

--- a/sdk/middleware/sqecho/echo_test.go
+++ b/sdk/middleware/sqecho/echo_test.go
@@ -1,0 +1,42 @@
+package sqecho_test
+
+import (
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/labstack/echo"
+	"github.com/sqreen/go-agent/sdk"
+	"github.com/sqreen/go-agent/sdk/middleware/sqecho"
+	"github.com/sqreen/go-agent/tools/testlib"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMiddleware(t *testing.T) {
+	require := require.New(t)
+	// Create an Echo context
+	e := echo.New()
+	hw := testlib.RandString(1, 100)
+	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(hw))
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	// Define a Echo handler
+	h := func(c echo.Context) error {
+		require.NotNil(sqecho.FromContext(c), "The middleware should attach its handle object to Gin's context")
+		require.NotNil(sdk.FromContext(c.Request().Context()), "The middleware should attach its handle object to the request's context")
+		body, err := ioutil.ReadAll(c.Request().Body)
+		if err != nil {
+			return err
+		}
+		return c.String(http.StatusOK, string(body))
+	}
+	// Perform the request and record the output
+	mw := sqecho.Middleware()
+	err := mw(h)(c)
+	// Check the request was performed as expected
+	require.NoError(err)
+	require.Equal(http.StatusOK, rec.Code)
+	require.Equal(hw, rec.Body.String())
+}


### PR DESCRIPTION
- Middleware function for Echo.
- Echo-specific `FromContext()` function as Echo's context does not implement
  the Go context interface, so it cannot be used with `sdk.FromContext()`.