### PR TITLE
sdk/middleware/sqhttp: middleware function for net/http

### DIFF
--- a/sdk/middleware/sqhttp/http.go
+++ b/sdk/middleware/sqhttp/http.go
@@ -1,0 +1,34 @@
+package sqhttp
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/sqreen/go-agent/sdk"
+)
+
+// Middleware is Sqreen's middleware function for `net/http` to monitor and
+// protect received requests. It creates and stores the HTTP request record into
+// the request context so that it can be later accessed to perform SDK calls in
+// the decorated handler using `sdk.FromContext()`.
+//
+//	fn := func(w http.ResponseWriter, r *http.Request) {
+//		sdk.FromContext(r.Context()).TrackEvent("my.event")
+//		fmt.Fprintf(w, "OK")
+//	}
+//	http.HandleFunc("/foo", sqhttp.Middleware(http.HandlerFunc(fn)))
+//
+func Middleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Create a new request record for this request.
+		sqreen := sdk.NewHTTPRequestRecord(r)
+		defer sqreen.Close()
+
+		// Store it into the request's context.
+		ctx := r.Context()
+		contextKey := sdk.HTTPRequestRecordContextKey.String
+		ctx = context.WithValue(ctx, contextKey, sqreen)
+		r = r.WithContext(ctx)
+		next.ServeHTTP(w, r)
+	})
+}

--- a/sdk/middleware/sqhttp/http_test.go
+++ b/sdk/middleware/sqhttp/http_test.go
@@ -1,0 +1,34 @@
+package sqhttp_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/sqreen/go-agent/sdk"
+	"github.com/sqreen/go-agent/sdk/middleware/sqhttp"
+	"github.com/sqreen/go-agent/tools/testlib"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMiddleware(t *testing.T) {
+	require := require.New(t)
+	body := testlib.RandString(1, 100)
+	// Create a router
+	router := http.NewServeMux()
+	// Add an endpoint accessing the SDK handle
+	subrouter := http.NewServeMux()
+	subrouter.HandleFunc("/hello", func(w http.ResponseWriter, req *http.Request) {
+		require.NotNil(sdk.FromContext(req.Context()), "The middleware should attach its handle object to the request's context")
+		w.Write([]byte(body))
+		w.WriteHeader(http.StatusOK)
+	})
+	router.Handle("/", sqhttp.Middleware(subrouter))
+	// Perform the request and record the output
+	rec := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/hello", nil)
+	router.ServeHTTP(rec, req)
+	// Check the request was performed as expected
+	require.Equal(http.StatusOK, rec.Code)
+	require.Equal(body, rec.Body.String())
+}


### PR DESCRIPTION
Middleware function for `net/http` storing the SDK handle into the request
context, so that it can be later accessed by sub-handlers.

Note that this is the most generic middleware implementation in Go, that can be
used with other frameworks such as Gorilla or Mux. So thanks to this middleware
function, we indirectly support more frameworks when their API allows it.

Closes SQR-5084