### PR TITLE
agent/config: look for configuration file locations

### DIFF
--- a/tools/testlib/rand.go
+++ b/tools/testlib/rand.go
@@ -2,10 +2,17 @@ package testlib
 
 import "math/rand"
 
-func RandString(from, to int) string {
+func RandString(size ...int) string {
 	letterRunes := []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
 
-	n := from + rand.Intn(to-from)
+	var n int
+	if len(size) == 1 {
+		n = size[0]
+	} else {
+		from := size[0]
+		to := size[1]
+		n = from + rand.Intn(to-from)
+	}
 	b := make([]rune, n)
 	for i := range b {
 		b[i] = letterRunes[rand.Intn(len(letterRunes))]


### PR DESCRIPTION
To allow our users to store their configuration files into different locations, according to their use cases, the configuration file location can now be enforced with environment variable `SQREEN_CONFIG_FILE`. Otherwise, the configuration file is searched into the current working directory first, and then the executable directory.

Closes SQR-5390 and SQR-5389