### PR TITLE
sdk: explicit user identification method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,88 @@
+# v0.1.0-beta.2
+
+## New feature
+
+- Add a new `Identify()` method allowing to explicitly associate a user to the
+current request. As soon as we add the support for the security reponses, it
+will allow to block users (#26).
+
+# v0.1.0-beta.1
+
+This version is a new major version towards the v0.1.0 as it proposes a new and
+stable SDK API, that now will only be updated upon user feedback. So please,
+share your impressions with us.
+
+## New Features
+
+- New web framework middleware support:
+  - Standard Go's `net/http` package (#21).
+  - Echo (#19).
+
+- Multiple custom events can now be easily associated to a user using the
+  user-scoped methods under `ForUser()`. For example, to send two custom events
+  for a given user, do:
+
+    ```go
+    sqUser := sqreen.ForUser(uid)
+    sqUser.TrackEvent("my.event.one")
+    sqUser.TrackEvent("my.event.two")
+    ```
+
+- The configuration file can now be stored into multiple locations, the current
+  working directory or the executable one, or enforced using the new
+  configuration environment variable `SQREEN_CONFIG_FILE` (#25).
+
+- The custom client IP header configured in `SCREEN_IP_HEADER` is now also sent
+  to Sqreen so that it can better understand what IP headers were considered by
+  the agent to determine what is the actual client IP address
+  (67e2d4cbf9b883e9e91e1a5d9e53348a18c1b900).
+
+## Breaking Changes
+
+- Stable SDK API of "Sqreen for Go":
+
+  - Avoid name conflicts with framework packages by prefixing Sqreen's
+    middleware packages with `sq`. For example, `gin` becomes `sqgin` (#17).
+
+  - Cleaner Go documentation now entirely included in the SDK and middleware
+    packages Go documentations. So no more need to go inside the agent
+    documentation to know more on some SDK methods, it is now all documented
+    in the same place, with lot of examples.
+
+  - Clearer SDK API: The flow of security events that can send to Sqreen is
+    now well-defined by a tree of SDK methods that can only be used the right
+    way. (#18, #24)
+
+     - The SDK handle getter function name is renamed from
+       `GetHTTPRequestContext()` into a simpler `FromContext()`.
+
+     - User-related SDK methods are now provided by `ForUser()`, for example:
+
+         ```go
+         sqreen.TrackAuth(true, uid)
+         ```
+
+       becomes
+
+         ```go
+         sqreen.ForUser(uid).TrackAuthSuccess()
+         ```
+
+
+# v0.1.0-alpha.5
+
+## New features
+
+- sdk: user-related security events:
+      - ability to associate a user to an event using `WithUserIdentifier()` (#13).
+      - track user creation using `TrackSignup()` (#15).
+      - track user authentication using `TrackAuth()` (#15).
+    
+- agent/backend: take into account `{HTTPS,HTTP,NO}_PROXY` environment variables (and their lowercase alternatives) (#14).
+    
+- agent/backend: share the organization token for all your apps (#12).
+
+## Fixes
+
+- agent/config: avoid conflicts with global viper configs (#16).
+- sdk: better documentation with examples.

--- a/agent/version.go
+++ b/agent/version.go
@@ -1,3 +1,3 @@
 package agent
 
-const version = "0.1.0-beta.1"
+const version = "0.1.0-beta.2"

--- a/sdk/sdk_test.go
+++ b/sdk/sdk_test.go
@@ -47,11 +47,18 @@ func TestSDK(t *testing.T) {
 		ctx.ForUser(idMap).TrackSignup()
 	})
 
-	t.Run("Identify", func(t *testing.T) {
+	t.Run("TrackEvent", func(t *testing.T) {
 		ctx := NewHTTPRequestRecord(newFakeRequest())
 		uid := testlib.RandString(2, 50)
 		idMap := EventUserIdentifiersMap{"uid": uid}
 		ctx.ForUser(idMap).TrackEvent("my.event")
+	})
+
+	t.Run("Identify", func(t *testing.T) {
+		ctx := NewHTTPRequestRecord(newFakeRequest())
+		uid := testlib.RandString(2, 50)
+		idMap := EventUserIdentifiersMap{"uid": uid}
+		ctx.ForUser(idMap).Identify()
 	})
 }
 
@@ -73,5 +80,6 @@ func testDisabledSDKCalls(t *testing.T, ctx *HTTPRequestRecord) {
 	ctx.ForUser(uid).TrackAuthSuccess()
 	ctx.ForUser(uid).TrackAuthFailure()
 	ctx.ForUser(uid).TrackSignup()
+	ctx.ForUser(uid).Identify()
 	ctx.Close()
 }

--- a/sdk/user.go
+++ b/sdk/user.go
@@ -53,9 +53,10 @@ func (ctx *UserHTTPRequestRecord) TrackSignup() *UserHTTPRequestRecord {
 }
 
 // TrackEvent allows to send a custom security event related to the user. A call
-// to this method creates an event. Note that the top-level `TrackEvent()` does
-// not associate any user unless you call the method `WithUserCredentials()`. To
-// avoid confusion, the object returned does not provide `WithUserCredentials()`
+// to this method creates an event. Note that this method automatically
+// associates the user to the request, compared to the top-level `TrackEvent()`
+// that does not, unless using its `WithUserCredentials()` method. To avoid
+// confusion, the object returned does not provide `WithUserCredentials()`
 // method.
 //
 //	uid := sdk.EventUserIdentifiersMap{"uid": "my-uid"}
@@ -68,4 +69,20 @@ func (ctx *UserHTTPRequestRecord) TrackEvent(event string) *UserHTTPRequestEvent
 	}
 	ctx.ctx.TrackIdentify(agent.EventUserIdentifiersMap(ctx.id))
 	return &UserHTTPRequestEvent{&HTTPRequestEvent{ctx.ctx.TrackEvent(event)}}
+}
+
+// Identify associates the user to current request so that Sqreen can apply
+// security countermeasures targeting specific users when necessary. A call to
+// this method does not create an event.
+//
+//	uid := sdk.EventUserIdentifiersMap{"uid": "my-uid"}
+//	sqUser := sdk.FromContext(ctx).ForUser(uid)
+//	sqUser.Identify()
+//
+func (ctx *UserHTTPRequestRecord) Identify() *UserHTTPRequestRecord {
+	if ctx == nil {
+		return nil
+	}
+	ctx.ctx.TrackIdentify(agent.EventUserIdentifiersMap(ctx.id))
+	return ctx
 }


### PR DESCRIPTION
Make the SDK method `Identify()` public so that it is now possible to explicitly
associate a user to the current request. As soon as we add the support for the
security reponses, it will allow to block users.