### PR TITLE
agent: replace globals with struct members

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -10,5 +10,7 @@ var agent *internal.Agent
 func init() {
 	agent = internal.New()
 	sdk.SetAgent(agent)
-	agent.Start()
+	if agent != nil {
+		agent.Start()
+	}
 }

--- a/agent/internal/backend/client_test.go
+++ b/agent/internal/backend/client_test.go
@@ -16,13 +16,16 @@ import (
 	"github.com/sqreen/go-agent/agent/internal/backend"
 	"github.com/sqreen/go-agent/agent/internal/backend/api"
 	"github.com/sqreen/go-agent/agent/internal/config"
+	"github.com/sqreen/go-agent/agent/internal/plog"
 	"github.com/sqreen/go-agent/tools/testlib"
 	"github.com/stretchr/testify/require"
 )
 
 var (
-	seed = time.Now().UnixNano()
-	popr = math_rand.New(math_rand.NewSource(seed))
+	logger = plog.NewLogger("test", nil)
+	cfg    = config.New(logger)
+	seed   = time.Now().UnixNano()
+	popr   = math_rand.New(math_rand.NewSource(seed))
 )
 
 func TestClient(t *testing.T) {
@@ -53,7 +56,7 @@ func TestClient(t *testing.T) {
 		server := initFakeServer(endpointCfg, request, response, statusCode, headers)
 		defer server.Close()
 
-		client, err := backend.NewClient(server.URL())
+		client, err := backend.NewClient(server.URL(), cfg, logger)
 		g.Expect(err).NotTo(HaveOccurred())
 
 		res, err := client.AppLogin(request, token, appName)
@@ -85,7 +88,7 @@ func TestClient(t *testing.T) {
 		server := initFakeServer(endpointCfg, request, response, statusCode, headers)
 		defer server.Close()
 
-		client, err := backend.NewClient(server.URL())
+		client, err := backend.NewClient(server.URL(), cfg, logger)
 		g.Expect(err).NotTo(HaveOccurred())
 
 		res, err := client.AppBeat(request, session)
@@ -114,7 +117,7 @@ func TestClient(t *testing.T) {
 		server := initFakeServer(endpointCfg, request, nil, statusCode, headers)
 		defer server.Close()
 
-		client, err := backend.NewClient(server.URL())
+		client, err := backend.NewClient(server.URL(), cfg, logger)
 		g.Expect(err).NotTo(HaveOccurred())
 
 		err = client.Batch(request, session)
@@ -137,7 +140,7 @@ func TestClient(t *testing.T) {
 		server := initFakeServer(endpointCfg, nil, nil, statusCode, headers)
 		defer server.Close()
 
-		client, err := backend.NewClient(server.URL())
+		client, err := backend.NewClient(server.URL(), cfg, logger)
 		g.Expect(err).NotTo(HaveOccurred())
 
 		err = client.AppLogout(session)
@@ -265,7 +268,7 @@ func testProxy(t *testing.T, envVar string) {
 	require.Equal(t, os.Getenv(envVar), proxy.URL())
 
 	// The new client should take the proxy into account.
-	client, err := backend.NewClient(config.BackendHTTPAPIBaseURL())
+	client, err := backend.NewClient(cfg.BackendHTTPAPIBaseURL(), cfg, logger)
 	require.Equal(t, err, nil)
 	// Perform a request that should go through the proxy.
 	request := api.NewPopulatedAppLoginRequest(popr, false)

--- a/agent/internal/client.go
+++ b/agent/internal/client.go
@@ -10,6 +10,7 @@ import (
 	"github.com/sqreen/go-agent/agent/internal/backend"
 	"github.com/sqreen/go-agent/agent/internal/backend/api"
 	"github.com/sqreen/go-agent/agent/internal/config"
+	"github.com/sqreen/go-agent/agent/internal/plog"
 )
 
 var (
@@ -19,12 +20,12 @@ var (
 
 // Login to the backend. When the API request fails, retry for ever and after
 // sleeping some time.
-func appLogin(ctx context.Context, client *backend.Client, token string, appName string) (*api.AppLoginResponse, error) {
+func appLogin(ctx context.Context, logger *plog.Logger, client *backend.Client, token string, appName string, appInfo *app.Info) (*api.AppLoginResponse, error) {
 	if err := validateToken(token, appName); err != nil {
 		return nil, err
 	}
 
-	procInfo := app.GetProcessInfo()
+	procInfo := appInfo.GetProcessInfo()
 
 	appLoginReq := api.AppLoginRequest{
 		VariousInfos:    *api.NewAppLoginRequest_VariousInfosFromFace(procInfo),
@@ -32,7 +33,7 @@ func appLogin(ctx context.Context, client *backend.Client, token string, appName
 		AgentType:       "golang",
 		AgentVersion:    version,
 		OsType:          app.GoBuildTarget(),
-		Hostname:        app.Hostname(),
+		Hostname:        appInfo.Hostname(),
 		RuntimeVersion:  app.GoVersion(),
 	}
 
@@ -51,6 +52,7 @@ func appLogin(ctx context.Context, client *backend.Client, token string, appName
 			if err != nil {
 				logger.Error(err)
 				appLoginRes = nil
+				logger.Debugf("retrying the request in %s (number of failures: %d)", backoff.duration, backoff.fails)
 				backoff.sleep()
 			}
 		}
@@ -77,7 +79,6 @@ func (b *backoff) next() {
 
 func (b *backoff) sleep() {
 	b.next()
-	logger.Debugf("retrying the request in %s (number of failures: %d)", b.duration, b.fails)
 	time.Sleep(b.duration)
 }
 

--- a/agent/internal/config/config.go
+++ b/agent/internal/config/config.go
@@ -18,7 +18,9 @@ import (
 	"github.com/spf13/viper"
 )
 
-var manager *viper.Viper
+type Config struct {
+	*viper.Viper
+}
 
 type HTTPAPIEndpoint struct {
 	Method, URL string
@@ -192,14 +194,10 @@ const (
 	configDefaultLogLevel              = `warn`
 )
 
-func init() {
-	New()
-}
+func New(logger *plog.Logger) *Config {
+	logger = plog.NewLogger("agent/config", logger)
 
-func New() {
-	logger := plog.NewLogger("sqreen/agent/config")
-
-	manager = viper.New()
+	manager := viper.New()
 	manager.SetEnvPrefix(configEnvPrefix)
 	manager.AutomaticEnv()
 	manager.SetConfigName(configFileBasename)
@@ -235,42 +233,44 @@ func New() {
 	if err != nil {
 		logger.Error("could not read the configuration file: ", err)
 	}
+
+	return &Config{manager}
 }
 
 // BackendHTTPAPIBaseURL returns the base URL of the backend HTTP API.
-func BackendHTTPAPIBaseURL() string {
-	return sanitizeString(manager.GetString(configKeyBackendHTTPAPIBaseURL))
+func (c *Config) BackendHTTPAPIBaseURL() string {
+	return sanitizeString(c.GetString(configKeyBackendHTTPAPIBaseURL))
 }
 
 // BackendHTTPAPIToken returns the access token to the backend API.
-func BackendHTTPAPIToken() string {
-	return sanitizeString(manager.GetString(configKeyBackendHTTPAPIToken))
+func (c *Config) BackendHTTPAPIToken() string {
+	return sanitizeString(c.GetString(configKeyBackendHTTPAPIToken))
 }
 
 // LogLevel returns the log level.
-func LogLevel() string {
-	return sanitizeString(manager.GetString(configKeyLogLevel))
+func (c *Config) LogLevel() string {
+	return sanitizeString(c.GetString(configKeyLogLevel))
 }
 
 // AppName returns the app name.
-func AppName() string {
-	return sanitizeString(manager.GetString(configKeyAppName))
+func (c *Config) AppName() string {
+	return sanitizeString(c.GetString(configKeyAppName))
 }
 
 // HTTPClientIPHeader IPHeader returns the header to first lookup to find the client ip of a HTTP request.
-func HTTPClientIPHeader() string {
-	return sanitizeString(manager.GetString(configKeyHTTPClientIPHeader))
+func (c *Config) HTTPClientIPHeader() string {
+	return sanitizeString(c.GetString(configKeyHTTPClientIPHeader))
 }
 
 // Proxy returns the proxy configuration to use for backend HTTP calls.
-func BackendHTTPAPIProxy() string {
-	return sanitizeString(manager.GetString(configKeyBackendHTTPAPIProxy))
+func (c *Config) BackendHTTPAPIProxy() string {
+	return sanitizeString(c.GetString(configKeyBackendHTTPAPIProxy))
 }
 
 // Disable returns true when the agent should be disabled, false otherwise.
-func Disable() bool {
-	disable := sanitizeString(manager.GetString(configKeyDisable))
-	return disable != "" || BackendHTTPAPIToken() == ""
+func (c *Config) Disable() bool {
+	disable := sanitizeString(c.GetString(configKeyDisable))
+	return disable != "" || c.BackendHTTPAPIToken() == ""
 }
 
 func sanitizeString(s string) string {

--- a/agent/internal/plog/plog.go
+++ b/agent/internal/plog/plog.go
@@ -113,7 +113,8 @@ type OutputSetter interface {
 
 // NewLogger returns a Logger instance wrapping one logger instance per level.
 // They can thus be individually enabled or disabled.
-func NewLogger(namespace string) *Logger {
+func NewLogger(namespace string, parent *Logger) *Logger {
+	namespace = canonicalNamespace(namespace, parent)
 	logger := &Logger{
 		PanicLogger: disabledLogger{},
 		ErrorLogger: disabledLogger{},
@@ -124,6 +125,16 @@ func NewLogger(namespace string) *Logger {
 	}
 	loggers[namespace] = logger
 	return logger
+}
+
+func canonicalNamespace(namespace string, parent *Logger) string {
+	var fullNS string
+	if parent == nil {
+		fullNS = "sqreen/" + namespace
+	} else {
+		fullNS = parent.namespace + "/" + namespace
+	}
+	return fullNS
 }
 
 // SetOutput sets the output of all loggers created so far.

--- a/agent/internal/plog/plog_test.go
+++ b/agent/internal/plog/plog_test.go
@@ -19,7 +19,7 @@ var _ = Describe("plog", func() {
 		)
 
 		JustBeforeEach(func() {
-			logger = plog.NewLogger("ns")
+			logger = plog.NewLogger("ns", nil)
 		})
 
 		Context("setting its output", func() {


### PR DESCRIPTION
Refactor the agent so that it no longer relies on Go globals whose life-cycles are managed by the Go runtime, while we would like to be able te manage them ourselves to restart and stop the agent.

In order to be able to properly quit, restart or stop the agent, replace every global variable by structure members, whose life-cycle depends on the agent's: when the agent is initialized/deinitialization, it is now responsible of each data initialization/deinitialization, and the same applies recursively to sub-objects.

Another benefit will be better testing, as every dependency is now exposed in the interfaces, so they will be mockable as we did for the SDK to reach 100% coverage.