### PR TITLE
sdk: security action interface for requests

### DIFF
--- a/agent/types/types.go
+++ b/agent/types/types.go
@@ -11,6 +11,7 @@ import (
 
 type Agent interface {
 	NewRequestRecord(req *http.Request) RequestRecord
+	SecurityAction(req *http.Request) Action
 	GracefulStop()
 }
 
@@ -31,4 +32,8 @@ type CustomEvent interface {
 	WithTimestamp(t time.Time)
 	WithProperties(props map[string]string)
 	WithUserIdentifiers(id map[string]string)
+}
+
+type Action interface {
+	Apply(w http.ResponseWriter)
 }

--- a/agent/types/types.go
+++ b/agent/types/types.go
@@ -10,8 +10,18 @@ import (
 )
 
 type Agent interface {
+	// NewRequestRecord returns a new request record for the given request. It
+	// should be stored into the request context to be retrieved using
+	// `sdk.FromContext()`.
 	NewRequestRecord(req *http.Request) RequestRecord
-	SecurityAction(req *http.Request) Action
+
+	// SecurityAction returns a non-nil HTTP handler when a security action is
+	// required for the given request. The returned handler should be used to
+	// handle the request before aborting it. Because of a security rule (eg.
+	// blocking an IP address). The request handler should therefore abort the
+	// request.
+	SecurityAction(r *http.Request) http.Handler
+
 	GracefulStop()
 }
 

--- a/sdk/agent.go
+++ b/sdk/agent.go
@@ -21,6 +21,10 @@ func SetAgent(a types.Agent) {
 	agent = a
 }
 
+func SecurityAction(req *http.Request) types.Action {
+	return agent.SecurityAction(req)
+}
+
 func GracefulStop() {
 	agent.GracefulStop()
 }
@@ -62,4 +66,11 @@ func (_ disabledAgent) WithProperties(_ map[string]string) {
 }
 
 func (_ disabledAgent) WithUserIdentifiers(_ map[string]string) {
+}
+
+func (a disabledAgent) SecurityAction(*http.Request) types.Action {
+	return a
+}
+
+func (disabledAgent) Apply(http.ResponseWriter) {
 }

--- a/sdk/agent.go
+++ b/sdk/agent.go
@@ -2,7 +2,6 @@ package sdk
 
 import (
 	"net/http"
-	"time"
 
 	"github.com/sqreen/go-agent/agent/types"
 )
@@ -21,10 +20,6 @@ func SetAgent(a types.Agent) {
 	agent = a
 }
 
-func SecurityAction(req *http.Request) types.Action {
-	return agent.SecurityAction(req)
-}
-
 func GracefulStop() {
 	agent.GracefulStop()
 }
@@ -35,42 +30,10 @@ type disabledAgent struct {
 func (_ disabledAgent) GracefulStop() {
 }
 
-func (a disabledAgent) NewRequestRecord(_ *http.Request) types.RequestRecord {
-	// Return itself as long as it can both implement RequestRecord and Agent
-	// interfaces without conflicting thanks to distinct method signatures.
-	return a
+func (disabledAgent) SecurityAction(*http.Request) http.Handler {
+	return nil
 }
 
-func (_ disabledAgent) Close() {
-}
-
-func (a disabledAgent) NewCustomEvent(_ string) types.CustomEvent {
-	// Return itself as long as it can both implement RequestRecord and Event
-	// interfaces without conflicting thanks to distinct method signatures.
-	return a
-}
-
-func (_ disabledAgent) NewUserAuth(_ map[string]string, _ bool) {
-}
-
-func (_ disabledAgent) NewUserSignup(_ map[string]string) {
-}
-
-func (_ disabledAgent) Identify(_ map[string]string) {
-}
-
-func (_ disabledAgent) WithTimestamp(_ time.Time) {
-}
-
-func (_ disabledAgent) WithProperties(_ map[string]string) {
-}
-
-func (_ disabledAgent) WithUserIdentifiers(_ map[string]string) {
-}
-
-func (a disabledAgent) SecurityAction(*http.Request) types.Action {
-	return a
-}
-
-func (disabledAgent) Apply(http.ResponseWriter) {
+func (a disabledAgent) NewRequestRecord(*http.Request) types.RequestRecord {
+	return nil
 }

--- a/sdk/middleware/sqecho/echo.go
+++ b/sdk/middleware/sqecho/echo.go
@@ -34,8 +34,14 @@ import (
 func Middleware() echo.MiddlewareFunc {
 	return func(next echo.HandlerFunc) echo.HandlerFunc {
 		return func(c echo.Context) error {
-			// Create a new request record for this request.
 			req := c.Request()
+
+			if action := sdk.SecurityAction(req); action != nil {
+				action.Apply(c.Response())
+				return nil
+			}
+
+			// Create a new request record for this request.
 			sqreen := sdk.NewHTTPRequestRecord(req)
 			defer sqreen.Close()
 

--- a/sdk/middleware/sqecho/echo_test.go
+++ b/sdk/middleware/sqecho/echo_test.go
@@ -15,25 +15,50 @@ import (
 )
 
 func TestMiddleware(t *testing.T) {
-	body := testlib.RandString(1, 100)
-	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(body))
+	t.Run("without middleware", func(t *testing.T) {
+		body := testlib.RandString(1, 100)
+		req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(body))
 
-	agent := testlib.NewAgentForMiddlewareTests(req)
-	sdk.SetAgent(agent)
-
-	t.Run("without security action", func(t *testing.T) {
-		agent.ResetExpectations()
+		agent := &testlib.AgentMockup{}
 		defer agent.AssertExpectations(t)
+		sdk.SetAgent(agent)
 
-		require := require.New(t)
 		// Create an Echo context
 		e := echo.New()
 		rec := httptest.NewRecorder()
 		c := e.NewContext(req, rec)
 		// Define a Echo handler
 		h := func(c echo.Context) error {
-			require.NotNil(sqecho.FromContext(c), "The middleware should attach its handle object to Gin's context")
-			require.NotNil(sdk.FromContext(c.Request().Context()), "The middleware should attach its handle object to the request's context")
+			require.Nil(t, sqecho.FromContext(c))
+			require.Nil(t, sdk.FromContext(c.Request().Context()))
+			body, err := ioutil.ReadAll(c.Request().Body)
+			if err != nil {
+				return err
+			}
+			return c.String(http.StatusOK, string(body))
+		}
+		// Perform the request and record the output
+		err := h(c)
+		// Check the request was performed as expected
+		require.NoError(t, err)
+		require.Equal(t, http.StatusOK, rec.Code)
+		require.Equal(t, body, rec.Body.String())
+	})
+
+	t.Run("without agent", func(t *testing.T) {
+		body := testlib.RandString(1, 100)
+		req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(body))
+
+		sdk.SetAgent(nil)
+
+		// Create an Echo context
+		e := echo.New()
+		rec := httptest.NewRecorder()
+		c := e.NewContext(req, rec)
+		// Define a Echo handler
+		h := func(c echo.Context) error {
+			require.Nil(t, sqecho.FromContext(c))
+			require.Nil(t, sdk.FromContext(c.Request().Context()))
 			body, err := ioutil.ReadAll(c.Request().Body)
 			if err != nil {
 				return err
@@ -44,22 +69,19 @@ func TestMiddleware(t *testing.T) {
 		mw := sqecho.Middleware()
 		err := mw(h)(c)
 		// Check the request was performed as expected
-		require.NoError(err)
-		require.Equal(http.StatusOK, rec.Code)
-		require.Equal(body, rec.Body.String())
+		require.NoError(t, err)
+		require.Equal(t, http.StatusOK, rec.Code)
+		require.Equal(t, body, rec.Body.String())
 	})
 
-	t.Run("with a security action", func(t *testing.T) {
-		agent.ResetExpectations()
+	t.Run("without security action", func(t *testing.T) {
+		body := testlib.RandString(1, 100)
+		req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(body))
+
+		agent, record := testlib.NewAgentForMiddlewareTestsWithoutSecurityAction()
+		sdk.SetAgent(agent)
 		defer agent.AssertExpectations(t)
-
-		status := http.StatusBadRequest
-		action := testlib.NewSecurityActionBlockWithStatus(status)
-		defer action.AssertExpectations(t)
-
-		agent.ExpectSecurityAction(req).Return(action).Once()
-
-		require := require.New(t)
+		defer record.AssertExpectations(t)
 
 		// Create an Echo context
 		e := echo.New()
@@ -67,15 +89,49 @@ func TestMiddleware(t *testing.T) {
 		c := e.NewContext(req, rec)
 		// Define a Echo handler
 		h := func(c echo.Context) error {
-			panic("called")
-			return c.String(http.StatusOK, testlib.RandString(10))
+			require.NotNil(t, sqecho.FromContext(c), "The middleware should attach its handle object to Gin's context")
+			require.NotNil(t, sdk.FromContext(c.Request().Context()), "The middleware should attach its handle object to the request's context")
+			body, err := ioutil.ReadAll(c.Request().Body)
+			if err != nil {
+				return err
+			}
+			return c.String(http.StatusOK, string(body))
 		}
 		// Perform the request and record the output
 		mw := sqecho.Middleware()
 		err := mw(h)(c)
 		// Check the request was performed as expected
-		require.NoError(err)
-		require.Equal(rec.Code, status)
-		require.Equal(rec.Body.String(), "")
+		require.NoError(t, err)
+		require.Equal(t, http.StatusOK, rec.Code)
+		require.Equal(t, body, rec.Body.String())
+	})
+
+	t.Run("with a security action", func(t *testing.T) {
+		body := testlib.RandString(1, 100)
+		req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(body))
+
+		status := http.StatusBadRequest
+		agent, record := testlib.NewAgentForMiddlewareTestsWithSecurityAction(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(status)
+		}))
+		sdk.SetAgent(agent)
+		defer agent.AssertExpectations(t)
+		defer record.AssertExpectations(t)
+
+		// Create an Echo context
+		e := echo.New()
+		rec := httptest.NewRecorder()
+		c := e.NewContext(req, rec)
+		// Define a Echo handler
+		h := func(c echo.Context) error {
+			panic("must not be called")
+		}
+		// Perform the request and record the output
+		mw := sqecho.Middleware()
+		err := mw(h)(c)
+		// Check the request was performed as expected
+		require.NoError(t, err)
+		require.Equal(t, rec.Code, status)
+		require.Equal(t, rec.Body.String(), "")
 	})
 }

--- a/sdk/middleware/sqecho/echo_test.go
+++ b/sdk/middleware/sqecho/echo_test.go
@@ -15,28 +15,67 @@ import (
 )
 
 func TestMiddleware(t *testing.T) {
-	require := require.New(t)
-	// Create an Echo context
-	e := echo.New()
-	hw := testlib.RandString(1, 100)
-	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(hw))
-	rec := httptest.NewRecorder()
-	c := e.NewContext(req, rec)
-	// Define a Echo handler
-	h := func(c echo.Context) error {
-		require.NotNil(sqecho.FromContext(c), "The middleware should attach its handle object to Gin's context")
-		require.NotNil(sdk.FromContext(c.Request().Context()), "The middleware should attach its handle object to the request's context")
-		body, err := ioutil.ReadAll(c.Request().Body)
-		if err != nil {
-			return err
+	body := testlib.RandString(1, 100)
+	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(body))
+
+	agent := testlib.NewAgentForMiddlewareTests(req)
+	sdk.SetAgent(agent)
+
+	t.Run("without security action", func(t *testing.T) {
+		agent.ResetExpectations()
+		defer agent.AssertExpectations(t)
+
+		require := require.New(t)
+		// Create an Echo context
+		e := echo.New()
+		rec := httptest.NewRecorder()
+		c := e.NewContext(req, rec)
+		// Define a Echo handler
+		h := func(c echo.Context) error {
+			require.NotNil(sqecho.FromContext(c), "The middleware should attach its handle object to Gin's context")
+			require.NotNil(sdk.FromContext(c.Request().Context()), "The middleware should attach its handle object to the request's context")
+			body, err := ioutil.ReadAll(c.Request().Body)
+			if err != nil {
+				return err
+			}
+			return c.String(http.StatusOK, string(body))
 		}
-		return c.String(http.StatusOK, string(body))
-	}
-	// Perform the request and record the output
-	mw := sqecho.Middleware()
-	err := mw(h)(c)
-	// Check the request was performed as expected
-	require.NoError(err)
-	require.Equal(http.StatusOK, rec.Code)
-	require.Equal(hw, rec.Body.String())
+		// Perform the request and record the output
+		mw := sqecho.Middleware()
+		err := mw(h)(c)
+		// Check the request was performed as expected
+		require.NoError(err)
+		require.Equal(http.StatusOK, rec.Code)
+		require.Equal(body, rec.Body.String())
+	})
+
+	t.Run("with a security action", func(t *testing.T) {
+		agent.ResetExpectations()
+		defer agent.AssertExpectations(t)
+
+		status := http.StatusBadRequest
+		action := testlib.NewSecurityActionBlockWithStatus(status)
+		defer action.AssertExpectations(t)
+
+		agent.ExpectSecurityAction(req).Return(action).Once()
+
+		require := require.New(t)
+
+		// Create an Echo context
+		e := echo.New()
+		rec := httptest.NewRecorder()
+		c := e.NewContext(req, rec)
+		// Define a Echo handler
+		h := func(c echo.Context) error {
+			panic("called")
+			return c.String(http.StatusOK, testlib.RandString(10))
+		}
+		// Perform the request and record the output
+		mw := sqecho.Middleware()
+		err := mw(h)(c)
+		// Check the request was performed as expected
+		require.NoError(err)
+		require.Equal(rec.Code, status)
+		require.Equal(rec.Body.String(), "")
+	})
 }

--- a/sdk/middleware/sqgin/gin.go
+++ b/sdk/middleware/sqgin/gin.go
@@ -32,8 +32,16 @@ import (
 //
 func Middleware() gingonic.HandlerFunc {
 	return func(c *gingonic.Context) {
+		req := c.Request
+
+		if action := sdk.SecurityAction(req); action != nil {
+			action.Apply(c.Writer)
+			c.Abort()
+			return
+		}
+
 		// Create a new request record for this request.
-		sqreen := sdk.NewHTTPRequestRecord(c.Request)
+		sqreen := sdk.NewHTTPRequestRecord(req)
 		defer sqreen.Close()
 
 		// Gin redefines the request context interface, so we need to store it both

--- a/sdk/middleware/sqgin/gin_test.go
+++ b/sdk/middleware/sqgin/gin_test.go
@@ -13,23 +13,61 @@ import (
 )
 
 func TestMiddleware(t *testing.T) {
-	require := require.New(t)
-	hw := testlib.RandString(1, 100)
-	// Create a Gin router
-	router := gin.New()
-	// Attach our middelware
-	router.Use(sqgin.Middleware())
-	// Add an endpoint accessing the SDK handle
-	router.GET("/", func(c *gin.Context) {
-		require.NotNil(sdk.FromContext(c), "The middleware should attach its handle object to Gin's context")
-		require.NotNil(sdk.FromContext(c.Request.Context()), "The middleware should attach its handle object to the request's context")
-		c.String(http.StatusOK, hw)
-	})
-	// Perform the request and record the output
-	rec := httptest.NewRecorder()
 	req, _ := http.NewRequest("GET", "/", nil)
-	router.ServeHTTP(rec, req)
-	// Check the request was performed as expected
-	require.Equal(http.StatusOK, rec.Code)
-	require.Equal(hw, rec.Body.String())
+
+	agent := testlib.NewAgentForMiddlewareTests(req)
+	sdk.SetAgent(agent)
+
+	t.Run("without security action", func(t *testing.T) {
+		defer agent.AssertExpectations(t)
+
+		require := require.New(t)
+		body := testlib.RandString(1, 100)
+		// Create a Gin router
+		router := gin.New()
+		// Attach our middelware
+		router.Use(sqgin.Middleware())
+		// Add an endpoint accessing the SDK handle
+		router.GET("/", func(c *gin.Context) {
+			require.NotNil(sdk.FromContext(c), "The middleware should attach its handle object to Gin's context")
+			require.NotNil(sdk.FromContext(c.Request.Context()), "The middleware should attach its handle object to the request's context")
+			c.String(http.StatusOK, body)
+		})
+		// Perform the request and record the output
+		rec := httptest.NewRecorder()
+		router.ServeHTTP(rec, req)
+		// Check the request was performed as expected
+		require.Equal(http.StatusOK, rec.Code)
+		require.Equal(body, rec.Body.String())
+	})
+
+	t.Run("with security action", func(t *testing.T) {
+		agent.ResetExpectations()
+		defer agent.AssertExpectations(t)
+
+		status := http.StatusBadRequest
+		action := testlib.NewSecurityActionBlockWithStatus(status)
+		defer action.AssertExpectations(t)
+
+		agent.ExpectSecurityAction(req).Return(action).Once()
+
+		require := require.New(t)
+		body := testlib.RandString(1, 100)
+		// Create a Gin router
+		router := gin.New()
+		// Attach our middelware
+		router.Use(sqgin.Middleware())
+		// Add an endpoint accessing the SDK handle
+		router.GET("/", func(c *gin.Context) {
+			require.NotNil(sdk.FromContext(c), "The middleware should attach its handle object to Gin's context")
+			require.NotNil(sdk.FromContext(c.Request.Context()), "The middleware should attach its handle object to the request's context")
+			c.String(http.StatusOK, body)
+		})
+		// Perform the request and record the output
+		rec := httptest.NewRecorder()
+		router.ServeHTTP(rec, req)
+		// Check the request was performed as expected
+		require.Equal(rec.Code, status)
+		require.Equal(rec.Body.String(), "")
+	})
 }

--- a/sdk/middleware/sqhttp/http.go
+++ b/sdk/middleware/sqhttp/http.go
@@ -1,7 +1,6 @@
 package sqhttp
 
 import (
-	"context"
 	"net/http"
 
 	"github.com/sqreen/go-agent/sdk"
@@ -20,20 +19,19 @@ import (
 //
 func Middleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if action := sdk.SecurityAction(r); action != nil {
-			action.Apply(w)
+		// Create a new sqreen request wrapper.
+		req := sdk.NewHTTPRequest(r)
+		defer req.Close()
+		// Use the newly created request compliant with `sdk.FromContext()`.
+		r = req.Request()
+
+		// Check if a security action is required.
+		if handler := req.SecurityAction(); handler != nil {
+			handler.ServeHTTP(w, r)
 			return
 		}
 
-		// Create a new request record for this request.
-		sqreen := sdk.NewHTTPRequestRecord(r)
-		defer sqreen.Close()
-
-		// Store it into the request's context.
-		ctx := r.Context()
-		contextKey := sdk.HTTPRequestRecordContextKey.String
-		ctx = context.WithValue(ctx, contextKey, sqreen)
-		r = r.WithContext(ctx)
+		// Call next handler.
 		next.ServeHTTP(w, r)
 	})
 }

--- a/sdk/middleware/sqhttp/http.go
+++ b/sdk/middleware/sqhttp/http.go
@@ -20,6 +20,11 @@ import (
 //
 func Middleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if action := sdk.SecurityAction(r); action != nil {
+			action.Apply(w)
+			return
+		}
+
 		// Create a new request record for this request.
 		sqreen := sdk.NewHTTPRequestRecord(r)
 		defer sqreen.Close()

--- a/sdk/middleware/sqhttp/http_test.go
+++ b/sdk/middleware/sqhttp/http_test.go
@@ -12,22 +12,17 @@ import (
 )
 
 func TestMiddleware(t *testing.T) {
-	req, _ := http.NewRequest("GET", "/hello", nil)
+	t.Run("without agent", func(t *testing.T) {
+		sdk.SetAgent(nil)
 
-	agent := testlib.NewAgentForMiddlewareTests(req)
-	sdk.SetAgent(agent)
-
-	t.Run("without security action", func(t *testing.T) {
-		defer agent.AssertExpectations(t)
-
-		require := require.New(t)
+		req, _ := http.NewRequest("GET", "/hello", nil)
 		body := testlib.RandString(1, 100)
 		// Create a router
 		router := http.NewServeMux()
 		// Add an endpoint accessing the SDK handle
 		subrouter := http.NewServeMux()
 		subrouter.HandleFunc("/hello", func(w http.ResponseWriter, req *http.Request) {
-			require.NotNil(sdk.FromContext(req.Context()), "The middleware should attach its handle object to the request's context")
+			require.Nil(t, sdk.FromContext(req.Context()))
 			w.Write([]byte(body))
 			w.WriteHeader(http.StatusOK)
 		})
@@ -36,37 +31,84 @@ func TestMiddleware(t *testing.T) {
 		rec := httptest.NewRecorder()
 		router.ServeHTTP(rec, req)
 		// Check the request was performed as expected
-		require.Equal(http.StatusOK, rec.Code)
-		require.Equal(body, rec.Body.String())
+		require.Equal(t, http.StatusOK, rec.Code)
+		require.Equal(t, body, rec.Body.String())
+	})
+
+	t.Run("without middleware", func(t *testing.T) {
+		agent := &testlib.AgentMockup{}
+		defer agent.AssertExpectations(t)
+		sdk.SetAgent(agent)
+
+		req, _ := http.NewRequest("GET", "/hello", nil)
+		body := testlib.RandString(1, 100)
+		// Create a router
+		router := http.NewServeMux()
+		// Add an endpoint accessing the SDK handle
+		subrouter := http.NewServeMux()
+		subrouter.HandleFunc("/hello", func(w http.ResponseWriter, req *http.Request) {
+			require.Nil(t, sdk.FromContext(req.Context()))
+			w.Write([]byte(body))
+			w.WriteHeader(http.StatusOK)
+		})
+		router.Handle("/", subrouter)
+		// Perform the request and record the output
+		rec := httptest.NewRecorder()
+		router.ServeHTTP(rec, req)
+		// Check the request was performed as expected
+		require.Equal(t, http.StatusOK, rec.Code)
+		require.Equal(t, body, rec.Body.String())
+	})
+
+	t.Run("without security action", func(t *testing.T) {
+		agent, record := testlib.NewAgentForMiddlewareTestsWithoutSecurityAction()
+		sdk.SetAgent(agent)
+		defer agent.AssertExpectations(t)
+		defer record.AssertExpectations(t)
+
+		req, _ := http.NewRequest("GET", "/hello", nil)
+		body := testlib.RandString(1, 100)
+		// Create a router
+		router := http.NewServeMux()
+		// Add an endpoint accessing the SDK handle
+		subrouter := http.NewServeMux()
+		subrouter.HandleFunc("/hello", func(w http.ResponseWriter, req *http.Request) {
+			require.NotNil(t, sdk.FromContext(req.Context()), "The middleware should attach its handle object to the request's context")
+			w.Write([]byte(body))
+			w.WriteHeader(http.StatusOK)
+		})
+		router.Handle("/", sqhttp.Middleware(subrouter))
+		// Perform the request and record the output
+		rec := httptest.NewRecorder()
+		router.ServeHTTP(rec, req)
+		// Check the request was performed as expected
+		require.Equal(t, http.StatusOK, rec.Code)
+		require.Equal(t, body, rec.Body.String())
 	})
 
 	t.Run("with security action", func(t *testing.T) {
-		agent.ResetExpectations()
-		defer agent.AssertExpectations(t)
-
 		status := http.StatusBadRequest
-		action := testlib.NewSecurityActionBlockWithStatus(status)
-		defer action.AssertExpectations(t)
+		agent, record := testlib.NewAgentForMiddlewareTestsWithSecurityAction(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(status)
+		}))
+		sdk.SetAgent(agent)
+		defer agent.AssertExpectations(t)
+		defer record.AssertExpectations(t)
 
-		agent.ExpectSecurityAction(req).Return(action).Once()
-
-		require := require.New(t)
-		body := testlib.RandString(1, 100)
 		// Create a router
 		router := http.NewServeMux()
 		// Add an endpoint accessing the SDK handle
 		subrouter := http.NewServeMux()
 		subrouter.HandleFunc("/hello", func(w http.ResponseWriter, req *http.Request) {
-			require.NotNil(sdk.FromContext(req.Context()), "The middleware should attach its handle object to the request's context")
-			w.Write([]byte(body))
-			w.WriteHeader(http.StatusOK)
+			panic("must not be called")
 		})
 		router.Handle("/", sqhttp.Middleware(subrouter))
 		// Perform the request and record the output
+		req, _ := http.NewRequest("GET", "/hello", nil)
 		rec := httptest.NewRecorder()
 		router.ServeHTTP(rec, req)
 		// Check the request was performed as expected
-		require.Equal(rec.Code, status)
-		require.Equal(rec.Body.String(), "")
+		require.Equal(t, rec.Body.String(), "")
+		require.Equal(t, rec.Code, status)
 	})
 }

--- a/sdk/middleware/sqhttp/http_test.go
+++ b/sdk/middleware/sqhttp/http_test.go
@@ -12,23 +12,61 @@ import (
 )
 
 func TestMiddleware(t *testing.T) {
-	require := require.New(t)
-	body := testlib.RandString(1, 100)
-	// Create a router
-	router := http.NewServeMux()
-	// Add an endpoint accessing the SDK handle
-	subrouter := http.NewServeMux()
-	subrouter.HandleFunc("/hello", func(w http.ResponseWriter, req *http.Request) {
-		require.NotNil(sdk.FromContext(req.Context()), "The middleware should attach its handle object to the request's context")
-		w.Write([]byte(body))
-		w.WriteHeader(http.StatusOK)
-	})
-	router.Handle("/", sqhttp.Middleware(subrouter))
-	// Perform the request and record the output
-	rec := httptest.NewRecorder()
 	req, _ := http.NewRequest("GET", "/hello", nil)
-	router.ServeHTTP(rec, req)
-	// Check the request was performed as expected
-	require.Equal(http.StatusOK, rec.Code)
-	require.Equal(body, rec.Body.String())
+
+	agent := testlib.NewAgentForMiddlewareTests(req)
+	sdk.SetAgent(agent)
+
+	t.Run("without security action", func(t *testing.T) {
+		defer agent.AssertExpectations(t)
+
+		require := require.New(t)
+		body := testlib.RandString(1, 100)
+		// Create a router
+		router := http.NewServeMux()
+		// Add an endpoint accessing the SDK handle
+		subrouter := http.NewServeMux()
+		subrouter.HandleFunc("/hello", func(w http.ResponseWriter, req *http.Request) {
+			require.NotNil(sdk.FromContext(req.Context()), "The middleware should attach its handle object to the request's context")
+			w.Write([]byte(body))
+			w.WriteHeader(http.StatusOK)
+		})
+		router.Handle("/", sqhttp.Middleware(subrouter))
+		// Perform the request and record the output
+		rec := httptest.NewRecorder()
+		router.ServeHTTP(rec, req)
+		// Check the request was performed as expected
+		require.Equal(http.StatusOK, rec.Code)
+		require.Equal(body, rec.Body.String())
+	})
+
+	t.Run("with security action", func(t *testing.T) {
+		agent.ResetExpectations()
+		defer agent.AssertExpectations(t)
+
+		status := http.StatusBadRequest
+		action := testlib.NewSecurityActionBlockWithStatus(status)
+		defer action.AssertExpectations(t)
+
+		agent.ExpectSecurityAction(req).Return(action).Once()
+
+		require := require.New(t)
+		body := testlib.RandString(1, 100)
+		// Create a router
+		router := http.NewServeMux()
+		// Add an endpoint accessing the SDK handle
+		subrouter := http.NewServeMux()
+		subrouter.HandleFunc("/hello", func(w http.ResponseWriter, req *http.Request) {
+			require.NotNil(sdk.FromContext(req.Context()), "The middleware should attach its handle object to the request's context")
+			w.Write([]byte(body))
+			w.WriteHeader(http.StatusOK)
+		})
+		router.Handle("/", sqhttp.Middleware(subrouter))
+		// Perform the request and record the output
+		rec := httptest.NewRecorder()
+		router.ServeHTTP(rec, req)
+		// Check the request was performed as expected
+		require.Equal(rec.Code, status)
+		require.Equal(rec.Body.String(), "")
+	})
 }

--- a/sdk/record.go
+++ b/sdk/record.go
@@ -2,7 +2,6 @@ package sdk
 
 import (
 	"context"
-	"net/http"
 
 	"github.com/sqreen/go-agent/agent/types"
 )
@@ -22,14 +21,6 @@ type HTTPRequestRecord struct {
 //	sdk.FromContext(ctx).ForUser(uid).TrackEvent("my.event")
 //
 type EventUserIdentifiersMap map[string]string
-
-// NewHTTPRequestRecord returns a new HTTP request record for the given HTTP
-// request.
-func NewHTTPRequestRecord(req *http.Request) *HTTPRequestRecord {
-	return &HTTPRequestRecord{
-		record: agent.NewRequestRecord(req),
-	}
-}
 
 // FromContext allows to access the HTTPRequestRecord from request handlers if
 // present, and nil otherwise. The value is stored in handler contexts by the

--- a/sdk/request.go
+++ b/sdk/request.go
@@ -1,0 +1,61 @@
+package sdk
+
+import (
+	"context"
+	"net/http"
+)
+
+// HTTPRequest is a convenience type to hold together the request and its
+// request record. Most impotantly, it is created by `sdk.NewHTTPRequest()` by
+// middleware functions to ensure that the request pointer it contains is the
+// one having the context value expected by `sdk.FromContext()`.
+type HTTPRequest struct {
+	request *http.Request
+	record  *HTTPRequestRecord
+}
+
+// NewHTTPRequest returns a new HTTP request handle for the given HTTP request.
+// It is a convenience value making sure the wrapped request has the request
+// record value, which can be retrieved using `sdk.FromContext()` to perform.
+func NewHTTPRequest(req *http.Request) *HTTPRequest {
+	if _, disabled := agent.(disabledAgent); disabled {
+		return &HTTPRequest{
+			request: req,
+			record:  nil,
+		}
+	}
+
+	// Create a pointer to a HTTPRequest.
+	record := new(HTTPRequestRecord)
+	// Store it into the request context.
+	ctx := req.Context()
+	contextKey := HTTPRequestRecordContextKey
+	ctx = context.WithValue(ctx, contextKey, record)
+	// Set the request context with the new one.
+	req = req.WithContext(ctx)
+	// Set the record pointer value using the new request.
+	*record = HTTPRequestRecord{
+		record: agent.NewRequestRecord(req),
+	}
+
+	return &HTTPRequest{
+		request: req,
+		record:  record,
+	}
+}
+
+func (r *HTTPRequest) Close() {
+	r.record.Close()
+}
+
+func (r *HTTPRequest) Request() *http.Request {
+	return r.request
+}
+
+func (r *HTTPRequest) Record() *HTTPRequestRecord {
+	return r.record
+}
+
+func (r *HTTPRequest) SecurityAction() http.Handler {
+	return agent.SecurityAction(r.request)
+}

--- a/tools/testlib/agent.go
+++ b/tools/testlib/agent.go
@@ -1,0 +1,147 @@
+package testlib
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/sqreen/go-agent/sdk"
+	"github.com/stretchr/testify/mock"
+)
+
+type AgentMockup struct {
+	mock.Mock
+}
+
+func (a *AgentMockup) ResetExpectations() {
+	a.Mock = mock.Mock{
+		ExpectedCalls: a.Mock.ExpectedCalls,
+	}
+}
+
+func (a *AgentMockup) SecurityAction(req *http.Request) sdk.Action {
+	ret := a.Called(req)
+	if ret := ret.Get(0); ret != nil {
+		return ret.(sdk.Action)
+	}
+	return nil
+}
+
+func (a *AgentMockup) ExpectSecurityAction(req *http.Request) *mock.Call {
+	return a.On("SecurityAction", req)
+}
+
+func (a *AgentMockup) GracefulStop() {
+	a.Called()
+}
+
+func (a *AgentMockup) ExpectGracefulStop() *mock.Call {
+	return a.On("GracefulStop")
+}
+
+func (a *AgentMockup) NewRequestRecord(req *http.Request) sdk.RequestRecord {
+	a.Called(req)
+	return a
+}
+
+func (a *AgentMockup) ExpectNewRequestRecord(req *http.Request) *mock.Call {
+	return a.On("NewRequestRecord", req)
+}
+
+func (a *AgentMockup) Close() {
+	a.Called()
+}
+
+func (a *AgentMockup) ExpectClose() *mock.Call {
+	return a.On("Close")
+}
+
+func (a *AgentMockup) NewCustomEvent(event string) sdk.CustomEvent {
+	// Return itself as long as it can both implement RequestRecord and Event
+	// interfaces without conflicting thanks to distinct method signatures.
+	a.Called(event)
+	return a
+}
+
+func (a *AgentMockup) ExpectTrackEvent(event string) *mock.Call {
+	return a.On("NewCustomEvent", event)
+}
+
+func (a *AgentMockup) NewUserAuth(id map[string]string, success bool) {
+	a.Called(id, success)
+}
+
+func (a *AgentMockup) ExpectTrackAuth(id map[string]string, success bool) *mock.Call {
+	return a.On("NewUserAuth", id, success)
+}
+
+func (a *AgentMockup) NewUserSignup(id map[string]string) {
+	a.Called(id)
+}
+
+func (a *AgentMockup) ExpectTrackSignup(id map[string]string) *mock.Call {
+	return a.On("NewUserSignup", id)
+}
+
+func (a *AgentMockup) Identify(id map[string]string) {
+	a.Called(id)
+}
+
+func (a *AgentMockup) ExpectIdentify(id map[string]string) *mock.Call {
+	return a.On("Identify", id)
+}
+
+func (a *AgentMockup) WithTimestamp(t time.Time) {
+	a.Called(t)
+}
+
+func (a *AgentMockup) ExpectWithTimestamp(t time.Time) *mock.Call {
+	return a.On("WithTimestamp", t)
+}
+
+func (a *AgentMockup) WithProperties(props map[string]string) {
+	a.Called(props)
+}
+
+func (a *AgentMockup) ExpectWithProperties(props map[string]string) *mock.Call {
+	return a.On("WithProperties", props)
+}
+
+func (a *AgentMockup) WithUserIdentifiers(id map[string]string) {
+	a.Called(id)
+}
+
+func (a *AgentMockup) ExpectWithUserIdentifiers(id map[string]string) *mock.Call {
+	return a.On("WithUserIdentifiers", id)
+}
+
+func NewAgentForMiddlewareTests(req *http.Request) *AgentMockup {
+	agent := &AgentMockup{}
+	agent.ExpectNewRequestRecord(req).Once()
+	agent.ExpectClose().Once()
+	agent.ExpectSecurityAction(req).Return(nil).Once()
+	return agent
+}
+
+type SecurityActionMockup struct {
+	mock.Mock
+	ApplyFunc func(w http.ResponseWriter)
+}
+
+func (m *SecurityActionMockup) Apply(w http.ResponseWriter) {
+	m.Called(w)
+	m.ApplyFunc(w)
+}
+
+func (m *SecurityActionMockup) ExpectApply() *mock.Call {
+	return m.On("Apply", mock.Anything)
+}
+
+func NewSecurityActionBlockWithStatus(statusCode int) *SecurityActionMockup {
+	action := &SecurityActionMockup{
+		ApplyFunc: func(w http.ResponseWriter) {
+			w.WriteHeader(statusCode)
+		},
+	}
+	action.ExpectApply().Once()
+	return action
+}


### PR DESCRIPTION
Implement the ability to block a request at the request handler-level using a new abstract agent entrypoint called `SecurityAction()` which can return a blocking action to be applied to the current request before aborting it.

It will allow to implement blocking IP addresses when a new request is received and of course before user handlers are called.