### PR TITLE
Configurable stripping of the referer http header

### DIFF
--- a/agent/internal/config/config.go
+++ b/agent/internal/config/config.go
@@ -191,6 +191,7 @@ const (
 	configKeyHTTPClientIPHeader    = `ip_header`
 	configKeyBackendHTTPAPIProxy   = `proxy`
 	configKeyDisable               = `disable`
+	configKeyStripHTTPReferer      = `strip_http_referer`
 )
 
 // User configuration's default values.
@@ -233,6 +234,7 @@ func New(logger *plog.Logger) *Config {
 	manager.SetDefault(configKeyHTTPClientIPHeader, "")
 	manager.SetDefault(configKeyBackendHTTPAPIProxy, "")
 	manager.SetDefault(configKeyDisable, "")
+	manager.SetDefault(configKeyStripHTTPReferer, "")
 
 	err := manager.ReadInConfig()
 	if err != nil {
@@ -276,6 +278,13 @@ func (c *Config) BackendHTTPAPIProxy() string {
 func (c *Config) Disable() bool {
 	disable := sanitizeString(c.GetString(configKeyDisable))
 	return disable != "" || c.BackendHTTPAPIToken() == ""
+}
+
+// Disable returns true when the agent should be strip the `Referer` HTTP
+// header, false otherwise.
+func (c *Config) StripHTTPReferer() bool {
+	strip := sanitizeString(c.GetString(configKeyStripHTTPReferer))
+	return strip != ""
 }
 
 func sanitizeString(s string) string {

--- a/agent/internal/request.go
+++ b/agent/internal/request.go
@@ -352,7 +352,12 @@ func (r *httpRequestRecord) GetRequest() api.RequestRecord_Request {
 		requestId = hex.EncodeToString(uuid[:])
 	}
 
-	// FIXME: create it from an interface for compile-time errors.
+	var referer string
+	if !r.ctx.agent.config.StripHTTPReferer() {
+		referer = req.Referer()
+	}
+
+	// FIXME: create it from an interface for compile-time error-checking.
 	return api.RequestRecord_Request{
 		Rid:        requestId,
 		Headers:    headers,
@@ -365,7 +370,7 @@ func (r *httpRequestRecord) GetRequest() api.RequestRecord_Request {
 		RemotePort: remotePort,
 		Scheme:     scheme,
 		UserAgent:  req.UserAgent(),
-		Referer:    req.Referer(),
+		Referer:    referer,
 	}
 }
 


### PR DESCRIPTION
- [x] Add a new configuration key `strip_http_referer` (corresponding to the env key
`SQREEN_STRIP_HTTP_REFERER`), whose boolean value is true when set to a non-empty
value, false otherwise.

- [x] Do not send the referer header when explicitly configured by the user.

Note that it is intentionally named after the `referer` HTTP header, including the missing `r` letter.