### PR TITLE
agent: fix empty request records only having metrics or identify events

### DIFF
--- a/agent/internal/agent.go
+++ b/agent/internal/agent.go
@@ -258,7 +258,7 @@ func (m *eventManager) send(client *backend.Client, sessionID string) {
 	m.req.Batch = m.req.Batch[0:0]
 }
 
-func (a *Agent) addTrackEvent(r *httpRequestRecord) {
+func (a *Agent) addRecord(r *httpRequestRecord) {
 	if a.config.Disable() || a.eventMng == nil {
 		// Disabled or not yet initialized agent
 		return


### PR DESCRIPTION
Add simple logic to add and send the request record only when necessary, ie.
only when there are some events other than a single identify. To do so, add a
simple boolean value in the record to keep track of when the record should be
sent of not.

Closes SQR-6245.