### PR TITLE
agent/plog: fix early logs not showing up

### DIFF
--- a/agent/internal/agent.go
+++ b/agent/internal/agent.go
@@ -31,6 +31,8 @@ func New() *Agent {
 	logger := plog.NewLogger("agent", nil)
 
 	cfg := config.New(logger)
+	plog.SetLevelFromString(cfg.LogLevel())
+	plog.SetOutput(os.Stderr)
 
 	if cfg.Disable() {
 		return nil
@@ -69,9 +71,6 @@ func (a *Agent) start() {
 		// Signal we are done
 		close(a.isDone)
 	}()
-
-	plog.SetLevelFromString(a.config.LogLevel())
-	plog.SetOutput(os.Stderr)
 
 	client, err := backend.NewClient(a.config.BackendHTTPAPIBaseURL(), a.config, a.logger)
 	if checkErr(err, a.logger) {


### PR DESCRIPTION
Early logs happening before the agent actual starting do not show up because the
loggers are not yet enabled. Move the enabling in the agent initialization so
that we can see early logs.