### PR TITLE
agent: add custom IP header parser to support HA Proxy Unique Request ID

### DIFF
--- a/agent/internal/config/config.go
+++ b/agent/internal/config/config.go
@@ -187,14 +187,15 @@ const (
 const (
 	configEnvKeyConfigFile = `config_file`
 
-	configKeyBackendHTTPAPIBaseURL = `url`
-	configKeyBackendHTTPAPIToken   = `token`
-	configKeyLogLevel              = `log_level`
-	configKeyAppName               = `app_name`
-	configKeyHTTPClientIPHeader    = `ip_header`
-	configKeyBackendHTTPAPIProxy   = `proxy`
-	configKeyDisable               = `disable`
-	configKeyStripHTTPReferer      = `strip_http_referer`
+	configKeyBackendHTTPAPIBaseURL    = `url`
+	configKeyBackendHTTPAPIToken      = `token`
+	configKeyLogLevel                 = `log_level`
+	configKeyAppName                  = `app_name`
+	configKeyHTTPClientIPHeader       = `ip_header`
+	configKeyHTTPClientIPHeaderFormat = `ip_header_format`
+	configKeyBackendHTTPAPIProxy      = `proxy`
+	configKeyDisable                  = `disable`
+	configKeyStripHTTPReferer         = `strip_http_referer`
 )
 
 // User configuration's default values.
@@ -235,6 +236,7 @@ func New(logger *plog.Logger) *Config {
 	manager.SetDefault(configKeyLogLevel, configDefaultLogLevel)
 	manager.SetDefault(configKeyAppName, "")
 	manager.SetDefault(configKeyHTTPClientIPHeader, "")
+	manager.SetDefault(configKeyHTTPClientIPHeaderFormat, "")
 	manager.SetDefault(configKeyBackendHTTPAPIProxy, "")
 	manager.SetDefault(configKeyDisable, "")
 	manager.SetDefault(configKeyStripHTTPReferer, "")
@@ -267,9 +269,14 @@ func (c *Config) AppName() string {
 	return sanitizeString(c.GetString(configKeyAppName))
 }
 
-// HTTPClientIPHeader IPHeader returns the header to first lookup to find the client ip of a HTTP request.
+// HTTPClientIPHeader returns the header to first lookup to find the client ip of a HTTP request.
 func (c *Config) HTTPClientIPHeader() string {
 	return sanitizeString(c.GetString(configKeyHTTPClientIPHeader))
+}
+
+// HTTPClientIPHeaderFormat returns the header format of the `ip_header` value.
+func (c *Config) HTTPClientIPHeaderFormat() string {
+	return sanitizeString(c.GetString(configKeyHTTPClientIPHeaderFormat))
 }
 
 // Proxy returns the proxy configuration to use for backend HTTP calls.

--- a/agent/internal/request.go
+++ b/agent/internal/request.go
@@ -350,6 +350,9 @@ func getClientIP(req *http.Request, cfg getClientIPConfigFace) string {
 }
 
 func parseClientIPHeaderHeaderValue(format, value string) (string, error) {
+	// Hard-coded HA Proxy format for now: `%ci:%cp...` so we expect the value to
+	// start with the client IP in hexadecimal format (eg. 7F000001) separated by
+	// the client port number with a semicolon `:`.
 	sep := strings.IndexRune(value, ':')
 	if sep == -1 {
 		return "", errors.Errorf("unexpected IP address value `%s`", value)

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/modern-go/reflect2 v1.0.1 // indirect
 	github.com/onsi/ginkgo v1.7.0
 	github.com/onsi/gomega v1.4.3
+	github.com/pkg/errors v0.8.1
 	github.com/spf13/viper v1.3.1
 	github.com/stretchr/objx v0.1.1 // indirect
 	github.com/stretchr/testify v1.3.0


### PR DESCRIPTION
The HA Proxy header `X-Unique-Id` can be added using a user-configured format
that may include the IP address. To be able to properly parse it, the agent
needs to be given the format string that is used to generate the header value so
that it can parse it back and find the IP address in it.

The configuration should be:

```
ip_header: X-Unique-Id
ip_header_format: <your format>
```

For now, `ip_header_format` value is only used as a boolean value to activate
this behaviour, but with a hard-coded format: the client IP address first, in
hexadecimal number, followed by a semicolon (port number separator).

Closes SQR-6191