### PR TITLE
agent: remove the User-Agent stored twice in the request record

### DIFF
--- a/agent/internal/config/config.go
+++ b/agent/internal/config/config.go
@@ -102,7 +102,6 @@ var (
 		"Forwarded-For",
 		"Forwarded",
 		"Via",
-		"User-Agent",
 		"Content-Type",
 		"Content-Length",
 		"Host",


### PR DESCRIPTION
The User-Agent is already included in the request record, so remove it from the
list of tracked headers to avoid sending it twice in the same request record.

Closes SQR-6261.