### PR TITLE
Security automation: update the agent logic

### DIFF
--- a/agent/internal/agent.go
+++ b/agent/internal/agent.go
@@ -168,6 +168,16 @@ func (a *Agent) InstrumentationDisable() error {
 	return nil
 }
 
+func (a *Agent) ActionsReload() error {
+	actions, err := a.client.ActionsPack()
+	if err != nil {
+		a.logger.Error(err)
+		return err
+	}
+
+	return a.actors.SetActions(actions.Actions)
+}
+
 func (a *Agent) SecurityAction(req *http.Request) http.Handler {
 	ip := getClientIP(req, a.config)
 	action, exists, err := a.actors.FindIP(ip)

--- a/agent/internal/command.go
+++ b/agent/internal/command.go
@@ -19,6 +19,7 @@ type CommandHandler func() api.CommandResult
 type CommandManagerAgent interface {
 	InstrumentationEnable() error
 	InstrumentationDisable() error
+	ActionsReload() error
 }
 
 func NewCommandManager(agent CommandManagerAgent, logger *plog.Logger) *CommandManager {
@@ -31,6 +32,7 @@ func NewCommandManager(agent CommandManagerAgent, logger *plog.Logger) *CommandM
 	mng.handlers = map[string]CommandHandler{
 		"instrumentation_enable": mng.InstrumentationEnable,
 		"instrumentation_remove": mng.InstrumentationRemove,
+		"actions_reload":         mng.ActionsReload,
 	}
 
 	return mng
@@ -69,6 +71,11 @@ func (m *CommandManager) InstrumentationEnable() api.CommandResult {
 
 func (m *CommandManager) InstrumentationRemove() api.CommandResult {
 	err := m.agent.InstrumentationDisable()
+	return commandResult(err)
+}
+
+func (m *CommandManager) ActionsReload() api.CommandResult {
+	err := m.agent.ActionsReload()
 	return commandResult(err)
 }
 

--- a/agent/internal/command_test.go
+++ b/agent/internal/command_test.go
@@ -170,3 +170,8 @@ func (a *agentMockup) ExpectInstrumentationEnable() *mock.Call {
 func (a *agentMockup) ExpectInstrumentationDisable() *mock.Call {
 	return a.On("InstrumentationDisable")
 }
+
+func (a *agentMockup) ActionsReload() error {
+	ret := a.Called()
+	return ret.Error(0)
+}

--- a/agent/internal/config/config.go
+++ b/agent/internal/config/config.go
@@ -43,12 +43,13 @@ var (
 
 	// List of endpoint addresses, relative to the base URL.
 	BackendHTTPAPIEndpoint = struct {
-		AppLogin, AppLogout, AppBeat, Batch HTTPAPIEndpoint
+		AppLogin, AppLogout, AppBeat, Batch, ActionsPack HTTPAPIEndpoint
 	}{
-		AppLogin:  HTTPAPIEndpoint{http.MethodPost, "/sqreen/v1/app-login"},
-		AppLogout: HTTPAPIEndpoint{http.MethodGet, "/sqreen/v0/app-logout"},
-		AppBeat:   HTTPAPIEndpoint{http.MethodPost, "/sqreen/v1/app-beat"},
-		Batch:     HTTPAPIEndpoint{http.MethodPost, "/sqreen/v0/batch"},
+		AppLogin:    HTTPAPIEndpoint{http.MethodPost, "/sqreen/v1/app-login"},
+		AppLogout:   HTTPAPIEndpoint{http.MethodGet, "/sqreen/v0/app-logout"},
+		AppBeat:     HTTPAPIEndpoint{http.MethodPost, "/sqreen/v1/app-beat"},
+		Batch:       HTTPAPIEndpoint{http.MethodPost, "/sqreen/v0/batch"},
+		ActionsPack: HTTPAPIEndpoint{http.MethodGet, "/sqreen/v0/actionspack"},
 	}
 
 	// Header name of the API token.

--- a/agent/internal/request.go
+++ b/agent/internal/request.go
@@ -28,13 +28,6 @@ type HTTPRequestRecord struct {
 	shouldSend   bool
 }
 
-func (a *Agent) newHTTPRequestRecord(req *http.Request) *HTTPRequestRecord {
-	return &HTTPRequestRecord{
-		request: req,
-		agent:   a,
-	}
-}
-
 type HTTPRequestEvent struct {
 	method          string
 	event           string

--- a/agent/internal/request.go
+++ b/agent/internal/request.go
@@ -1,3 +1,7 @@
+// Copyright 2019 Sqreen. All Rights Reserved.
+// Please refer to our terms for more information:
+// https://www.sqreen.io/terms.html
+
 package internal
 
 import (
@@ -44,7 +48,7 @@ type userEventFace interface {
 type userEvent struct {
 	userIdentifiers EventUserIdentifiersMap
 	timestamp       time.Time
-	ip              string
+	ip              net.IP
 }
 
 type authUserEvent struct {
@@ -64,7 +68,7 @@ func (e *authUserEvent) bucketID() (string, error) {
 
 type userMetricKey struct {
 	id EventUserIdentifiersMap
-	ip string
+	ip net.IP
 }
 
 func (k *userMetricKey) bucketID() (string, error) {
@@ -77,7 +81,7 @@ func (k *userMetricKey) bucketID() (string, error) {
 		IP   string          `json:"ip"`
 	}{
 		Keys: keys,
-		IP:   k.ip,
+		IP:   k.ip.String(),
 	}
 	buf, err := json.Marshal(&v)
 	return string(buf), err
@@ -272,7 +276,7 @@ func (r *httpRequestRecord) SetRulespackId(rulespackId string) {
 }
 
 func (r *httpRequestRecord) GetClientIp() string {
-	return getClientIP(r.ctx.request, r.ctx.agent.config)
+	return getClientIP(r.ctx.request, r.ctx.agent.config).String()
 }
 
 type getClientIPConfigFace interface {
@@ -280,7 +284,7 @@ type getClientIPConfigFace interface {
 	HTTPClientIPHeaderFormat() string
 }
 
-func getClientIP(req *http.Request, cfg getClientIPConfigFace) string {
+func getClientIP(req *http.Request, cfg getClientIPConfigFace) net.IP {
 	var privateIP net.IP
 	check := func(value string) net.IP {
 		for _, ip := range strings.Split(value, ",") {
@@ -316,7 +320,7 @@ func getClientIP(req *http.Request, cfg getClientIPConfigFace) string {
 
 			if value != "" {
 				if ip := check(value); ip != nil {
-					return ip.String()
+					return ip
 				}
 			}
 		}
@@ -325,22 +329,22 @@ func getClientIP(req *http.Request, cfg getClientIPConfigFace) string {
 	for _, key := range config.IPRelatedHTTPHeaders {
 		value := req.Header.Get(key)
 		if ip := check(value); ip != nil {
-			return ip.String()
+			return ip
 		}
 	}
 
-	remoteIP, _ := parseAddr(req.RemoteAddr)
-	if remoteIP == "" {
+	remoteIPStr, _ := splitHostPort(req.RemoteAddr)
+	if remoteIPStr == "" {
 		if privateIP != nil {
-			return privateIP.String()
+			return privateIP
 		}
-		return ""
+		return nil
 	}
 
-	if privateIP == nil || isGlobal(net.ParseIP(remoteIP)) {
+	if remoteIP := net.ParseIP(remoteIPStr); remoteIP != nil && (privateIP == nil || isGlobal(remoteIP)) {
 		return remoteIP
 	}
-	return privateIP.String()
+	return privateIP
 }
 
 func parseClientIPHeaderHeaderValue(format, value string) (string, error) {
@@ -386,8 +390,8 @@ func (r *httpRequestRecord) GetRequest() api.RequestRecord_Request {
 		}
 	}
 
-	remoteIP, remotePort := parseAddr(req.RemoteAddr)
-	_, hostPort := parseAddr(req.Host)
+	remoteIP, remotePort := splitHostPort(req.RemoteAddr)
+	_, hostPort := splitHostPort(req.Host)
 
 	var scheme string
 	if req.TLS != nil {
@@ -470,7 +474,9 @@ func isPrivate(ip net.IP) bool {
 	return false
 }
 
-func parseAddr(addr string) (host string, port string) {
+// splitHostPort splits a network address of the form `host:port` or
+// `[host]:port` into `host` and `port`.
+func splitHostPort(addr string) (host string, port string) {
 	i := strings.LastIndex(addr, "]:")
 	if i != -1 {
 		// ipv6

--- a/agent/internal/request.go
+++ b/agent/internal/request.go
@@ -31,7 +31,7 @@ type HTTPRequestRecord struct {
 type HTTPRequestEvent struct {
 	method          string
 	event           string
-	properties      EventPropertyMap
+	properties      types.EventProperties
 	userIdentifiers EventUserIdentifiersMap
 	timestamp       time.Time
 }
@@ -194,7 +194,7 @@ func (e *HTTPRequestEvent) WithTimestamp(t time.Time) {
 	e.timestamp = t
 }
 
-func (e *HTTPRequestEvent) WithProperties(p map[string]string) {
+func (e *HTTPRequestEvent) WithProperties(p types.EventProperties) {
 	if e == nil {
 		return
 	}
@@ -234,9 +234,10 @@ func (e *HTTPRequestEvent) GetOptions() *api.RequestRecord_Observed_SDKEvent_Arg
 }
 
 func (e *HTTPRequestEvent) GetProperties() *api.Struct {
-	if len(e.properties) == 0 {
+	if e.properties == nil {
 		return nil
 	}
+
 	return &api.Struct{e.properties}
 }
 

--- a/agent/internal/request_test.go
+++ b/agent/internal/request_test.go
@@ -1,3 +1,7 @@
+// Copyright 2019 Sqreen. All Rights Reserved.
+// Please refer to our terms for more information:
+// https://www.sqreen.io/terms.html
+
 package internal
 
 import (
@@ -107,7 +111,7 @@ func TestGetClientIP(t *testing.T) {
 				}
 
 				ip := getClientIP(req, cfg)
-				require.Equal(t, tc.expected, ip)
+				require.Equal(t, tc.expected, ip.String())
 			})
 		}
 	})
@@ -186,7 +190,7 @@ func TestGetClientIP(t *testing.T) {
 					}
 
 					ip := getClientIP(req, cfg)
-					require.Equal(t, tc.expected, ip)
+					require.Equal(t, tc.expected, ip.String())
 				})
 			}
 		})

--- a/tools/testlib/agent.go
+++ b/tools/testlib/agent.go
@@ -4,7 +4,7 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/sqreen/go-agent/sdk"
+	"github.com/sqreen/go-agent/agent/types"
 	"github.com/stretchr/testify/mock"
 )
 
@@ -12,22 +12,22 @@ type AgentMockup struct {
 	mock.Mock
 }
 
+// Static assertion of correct interface implementation.
+var _ types.Agent = &AgentMockup{}
+
 func (a *AgentMockup) ResetExpectations() {
 	a.Mock = mock.Mock{
 		ExpectedCalls: a.Mock.ExpectedCalls,
 	}
 }
 
-func (a *AgentMockup) SecurityAction(req *http.Request) sdk.Action {
-	ret := a.Called(req)
-	if ret := ret.Get(0); ret != nil {
-		return ret.(sdk.Action)
-	}
-	return nil
+func (a *AgentMockup) NewRequestRecord(r *http.Request) types.RequestRecord {
+	ret := a.Called(r)
+	return ret.Get(0).(types.RequestRecord)
 }
 
-func (a *AgentMockup) ExpectSecurityAction(req *http.Request) *mock.Call {
-	return a.On("SecurityAction", req)
+func (a *AgentMockup) ExpectNewRequestRecord(r interface{}) *mock.Call {
+	return a.On("NewRequestRecord", r)
 }
 
 func (a *AgentMockup) GracefulStop() {
@@ -38,110 +38,104 @@ func (a *AgentMockup) ExpectGracefulStop() *mock.Call {
 	return a.On("GracefulStop")
 }
 
-func (a *AgentMockup) NewRequestRecord(req *http.Request) sdk.RequestRecord {
-	a.Called(req)
-	return a
-}
-
-func (a *AgentMockup) ExpectNewRequestRecord(req *http.Request) *mock.Call {
-	return a.On("NewRequestRecord", req)
-}
-
-func (a *AgentMockup) Close() {
-	a.Called()
-}
-
-func (a *AgentMockup) ExpectClose() *mock.Call {
-	return a.On("Close")
-}
-
-func (a *AgentMockup) NewCustomEvent(event string) sdk.CustomEvent {
-	// Return itself as long as it can both implement RequestRecord and Event
-	// interfaces without conflicting thanks to distinct method signatures.
-	a.Called(event)
-	return a
-}
-
-func (a *AgentMockup) ExpectTrackEvent(event string) *mock.Call {
-	return a.On("NewCustomEvent", event)
-}
-
-func (a *AgentMockup) NewUserAuth(id map[string]string, success bool) {
-	a.Called(id, success)
-}
-
-func (a *AgentMockup) ExpectTrackAuth(id map[string]string, success bool) *mock.Call {
-	return a.On("NewUserAuth", id, success)
-}
-
-func (a *AgentMockup) NewUserSignup(id map[string]string) {
-	a.Called(id)
-}
-
-func (a *AgentMockup) ExpectTrackSignup(id map[string]string) *mock.Call {
-	return a.On("NewUserSignup", id)
-}
-
-func (a *AgentMockup) Identify(id map[string]string) {
-	a.Called(id)
-}
-
-func (a *AgentMockup) ExpectIdentify(id map[string]string) *mock.Call {
-	return a.On("Identify", id)
-}
-
-func (a *AgentMockup) WithTimestamp(t time.Time) {
-	a.Called(t)
-}
-
-func (a *AgentMockup) ExpectWithTimestamp(t time.Time) *mock.Call {
-	return a.On("WithTimestamp", t)
-}
-
-func (a *AgentMockup) WithProperties(props map[string]string) {
-	a.Called(props)
-}
-
-func (a *AgentMockup) ExpectWithProperties(props map[string]string) *mock.Call {
-	return a.On("WithProperties", props)
-}
-
-func (a *AgentMockup) WithUserIdentifiers(id map[string]string) {
-	a.Called(id)
-}
-
-func (a *AgentMockup) ExpectWithUserIdentifiers(id map[string]string) *mock.Call {
-	return a.On("WithUserIdentifiers", id)
-}
-
-func NewAgentForMiddlewareTests(req *http.Request) *AgentMockup {
-	agent := &AgentMockup{}
-	agent.ExpectNewRequestRecord(req).Once()
-	agent.ExpectClose().Once()
-	agent.ExpectSecurityAction(req).Return(nil).Once()
-	return agent
-}
-
-type SecurityActionMockup struct {
-	mock.Mock
-	ApplyFunc func(w http.ResponseWriter)
-}
-
-func (m *SecurityActionMockup) Apply(w http.ResponseWriter) {
-	m.Called(w)
-	m.ApplyFunc(w)
-}
-
-func (m *SecurityActionMockup) ExpectApply() *mock.Call {
-	return m.On("Apply", mock.Anything)
-}
-
-func NewSecurityActionBlockWithStatus(statusCode int) *SecurityActionMockup {
-	action := &SecurityActionMockup{
-		ApplyFunc: func(w http.ResponseWriter) {
-			w.WriteHeader(statusCode)
-		},
+func (a *AgentMockup) SecurityAction(r *http.Request) http.Handler {
+	ret := a.Called(r).Get(0)
+	if ret == nil {
+		return nil
 	}
-	action.ExpectApply().Once()
-	return action
+	return ret.(http.Handler)
+}
+
+func (a *AgentMockup) ExpectSecurityAction(r interface{}) *mock.Call {
+	return a.On("SecurityAction", r)
+}
+
+func NewAgentForMiddlewareTestsWithoutSecurityAction() (*AgentMockup, *HTTPRequestRecordMockup) {
+	agent := &AgentMockup{}
+	record := &HTTPRequestRecordMockup{}
+	agent.ExpectNewRequestRecord(mock.Anything).Return(record).Once()
+	agent.ExpectSecurityAction(mock.Anything).Return(nil).Once()
+	record.ExpectClose().Once()
+	return agent, record
+}
+
+func NewAgentForMiddlewareTestsWithSecurityAction(actionHandler http.Handler) (*AgentMockup, *HTTPRequestRecordMockup) {
+	agent := &AgentMockup{}
+	record := &HTTPRequestRecordMockup{}
+	agent.ExpectNewRequestRecord(mock.Anything).Return(record).Once()
+	agent.ExpectSecurityAction(mock.Anything).Return(actionHandler).Once()
+	record.ExpectClose().Once()
+	return agent, record
+}
+
+type HTTPRequestRecordMockup struct {
+	mock.Mock
+}
+
+// Static assertion of correct interface implementation.
+var _ types.RequestRecord = &HTTPRequestRecordMockup{}
+
+func (r *HTTPRequestRecordMockup) NewCustomEvent(event string) types.CustomEvent {
+	r.Called(event)
+	return r
+}
+
+func (r *HTTPRequestRecordMockup) ExpectTrackEvent(event string) *mock.Call {
+	return r.On("NewCustomEvent", event)
+}
+
+func (r *HTTPRequestRecordMockup) Close() {
+	r.Called()
+}
+
+func (r *HTTPRequestRecordMockup) ExpectClose() *mock.Call {
+	return r.On("Close")
+}
+
+func (r *HTTPRequestRecordMockup) NewUserAuth(id map[string]string, success bool) {
+	r.Called(id, success)
+}
+
+func (r *HTTPRequestRecordMockup) ExpectTrackAuth(id map[string]string, success bool) *mock.Call {
+	return r.On("NewUserAuth", id, success)
+}
+
+func (r *HTTPRequestRecordMockup) NewUserSignup(id map[string]string) {
+	r.Called(id)
+}
+
+func (r *HTTPRequestRecordMockup) ExpectTrackSignup(id map[string]string) *mock.Call {
+	return r.On("NewUserSignup", id)
+}
+
+func (r *HTTPRequestRecordMockup) Identify(id map[string]string) {
+	r.Called(id)
+}
+
+func (r *HTTPRequestRecordMockup) ExpectIdentify(id map[string]string) *mock.Call {
+	return r.On("Identify", id)
+}
+
+func (r *HTTPRequestRecordMockup) WithTimestamp(t time.Time) {
+	r.Called(t)
+}
+
+func (r *HTTPRequestRecordMockup) ExpectWithTimestamp(t time.Time) *mock.Call {
+	return r.On("WithTimestamp", t)
+}
+
+func (r *HTTPRequestRecordMockup) WithProperties(props types.EventProperties) {
+	r.Called(props)
+}
+
+func (r *HTTPRequestRecordMockup) ExpectWithProperties(props types.EventProperties) *mock.Call {
+	return r.On("WithProperties", props)
+}
+
+func (r *HTTPRequestRecordMockup) WithUserIdentifiers(id map[string]string) {
+	r.Called(id)
+}
+
+func (r *HTTPRequestRecordMockup) ExpectWithUserIdentifiers(id map[string]string) *mock.Call {
+	return r.On("WithUserIdentifiers", id)
 }


### PR DESCRIPTION
- [x] Time-efficiency: replace the string representation of an IP address by the standard `net.IP` type which is a byte of slices.
- [x] Instantiate the actor store.
- [x] Implement the command to reload the list security actions.
- [x] Implement the security action entry point of the agent used by the SDK.
