### PR TITLE
agent/backend/client/api: escape the batch event type name string

### DIFF
--- a/agent/internal/backend/api/jsonpb.go
+++ b/agent/internal/backend/api/jsonpb.go
@@ -66,7 +66,11 @@ func (e *BatchRequest_Event) MarshalJSON() ([]byte, error) {
 	if len(buf) <= 2 {
 		return buf, nil
 	}
-	buf = []byte(`{"event_type":"` + e.EventType + `",` + string(buf[1:]))
+	eventType, err := json.Marshal(e.EventType)
+	if err != nil {
+		return nil, err
+	}
+	buf = []byte(`{"event_type":` + string(eventType) + `,` + string(buf[1:]))
 	return buf, nil
 }
 

--- a/agent/internal/backend/client_test.go
+++ b/agent/internal/backend/client_test.go
@@ -79,6 +79,7 @@ func TestClient(t *testing.T) {
 		endpointCfg := &config.BackendHTTPAPIEndpoint.Batch
 
 		request := NewRandomBatchRequest()
+		t.Logf("%#v", request)
 
 		client, server := initFakeServerSession(endpointCfg, request, nil, statusCode, nil)
 		defer server.Close()
@@ -282,36 +283,20 @@ func NewRandomActionsPackResponse() *api.ActionsPackResponse {
 }
 
 func FuzzStruct(e *api.Struct, c fuzz.Continue) {
-	nbFields := c.Uint32() % 10
-	if nbFields == 0 {
-		e.Value = nil
-		return
-	}
-
-	kv := make(map[string]interface{}, nbFields)
-	e.Value = kv
-	for n := 0; n < len(kv); n++ {
-		var k string
-		c.Fuzz(&k)
-
-		var v interface{}
-		switch c.Uint32() % 4 {
-		case 0:
-			v = nil
-		case 1:
-			var actual string
-			c.Fuzz(&actual)
-			v = actual
-		case 2:
-			var actual float64
-			c.Fuzz(&actual)
-			v = actual
-		case 3:
-			var actual bool
-			c.Fuzz(&actual)
-			v = actual
+	v := struct {
+		A string
+		B int
+		C float64
+		D bool
+		F []byte
+		G struct {
+			A string
+			B int
+			C float64
+			D bool
+			F []byte
 		}
-
-		kv[k] = v
-	}
+	}{}
+	c.Fuzz(&v)
+	e.Value = v
 }


### PR DESCRIPTION
The fuzzy tests highlighted the case where the event type had a double-quote `"` which
was concatenated to the JSON string without being escaped, leading to a broken JSON
string such as:

```
{"event_type:"event"type", ...}
```

This is fixed by escaping the string using the JSON marshaler and appending the returned
value to the JSON.