### PR TITLE
Security automation: SDK to apply security responses by user-identifiers (1/2)

### DIFF
--- a/agent/internal/agent.go
+++ b/agent/internal/agent.go
@@ -179,21 +179,6 @@ func (a *Agent) ActionsReload() error {
 	return a.actors.SetActions(actions.Actions)
 }
 
-func (a *Agent) SecurityAction(req *http.Request) http.Handler {
-	ip := getClientIP(req, a.config)
-	action, exists, err := a.actors.FindIP(ip)
-	if err != nil {
-		a.logger.Error(err)
-		return nil
-	}
-
-	if !exists {
-		return nil
-	}
-
-	return actor.NewActionHandler(action, ip)
-}
-
 func (a *Agent) GracefulStop() {
 	if a.config.Disable() {
 		return

--- a/agent/internal/request.go
+++ b/agent/internal/request.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/pkg/errors"
+	"github.com/sqreen/go-agent/agent/internal/actor"
 	"github.com/sqreen/go-agent/agent/internal/backend/api"
 	"github.com/sqreen/go-agent/agent/internal/config"
 	"github.com/sqreen/go-agent/agent/types"
@@ -28,8 +29,15 @@ type HTTPRequestRecord struct {
 	eventsLock   sync.Mutex
 	events       []*HTTPRequestEvent
 	identifyOnce sync.Once
-	agent        *Agent
-	shouldSend   bool
+	// User-identifiers globally associated to this request using `Identify()`
+	userID map[string]string
+	// The last non-nil security response is cached and returned to every
+	// subsequent calls to method `SecurityResponse()`. Middleware functions can
+	// therefore observe the same result with `SecurityResponse()` as in the
+	// request handler with `MatchSecurityResponse()`.
+	lastSecurityResponseHandler http.Handler
+	agent                       *Agent
+	shouldSend                  bool
 }
 
 type HTTPRequestEvent struct {
@@ -129,6 +137,24 @@ func (ctx *HTTPRequestRecord) Identify(id map[string]string) {
 		}
 		ctx.addSilentEvent(evt)
 	})
+}
+
+func (ctx *HTTPRequestRecord) SecurityResponse() http.Handler {
+	if ctx.lastSecurityResponseHandler != nil {
+		return ctx.lastSecurityResponseHandler
+	}
+	agent := ctx.agent
+	ip := getClientIP(ctx.request, agent.config)
+	action, exists, err := agent.actors.FindIP(ip)
+	if err != nil {
+		agent.logger.Error(err)
+		return nil
+	}
+	if !exists {
+		return nil
+	}
+	ctx.lastSecurityResponseHandler = actor.NewActionHandler(action, ip)
+	return ctx.lastSecurityResponseHandler
 }
 
 func (ctx *HTTPRequestRecord) NewUserAuth(id map[string]string, loginSuccess bool) {

--- a/agent/internal/request.go
+++ b/agent/internal/request.go
@@ -32,12 +32,15 @@ type HTTPRequestRecord struct {
 	// User-identifiers globally associated to this request using `Identify()`
 	userID map[string]string
 	// The last non-nil security response is cached and returned to every
-	// subsequent calls to method `SecurityResponse()`. Middleware functions can
-	// therefore observe the same result with `SecurityResponse()` as in the
-	// request handler with `MatchSecurityResponse()`.
+	// subsequent calls to method `SecurityResponse()`.
 	lastSecurityResponseHandler http.Handler
-	agent                       *Agent
-	shouldSend                  bool
+	// The last non-nil user security response is cached and returned to every
+	// subsequent calls to method `UserSecurityResponse()`. Middleware functions
+	// can therefore observe the same result with `UserSecurityResponse()` as in
+	// the request handler with `MatchSecurityResponse()`.
+	lastUserSecurityResponseHandler http.Handler
+	agent                           *Agent
+	shouldSend                      bool
 }
 
 type HTTPRequestEvent struct {
@@ -155,6 +158,10 @@ func (ctx *HTTPRequestRecord) SecurityResponse() http.Handler {
 	}
 	ctx.lastSecurityResponseHandler = actor.NewActionHandler(action, ip)
 	return ctx.lastSecurityResponseHandler
+}
+
+func (ctx *HTTPRequestRecord) UserSecurityResponse() http.Handler {
+	return nil
 }
 
 func (ctx *HTTPRequestRecord) NewUserAuth(id map[string]string, loginSuccess bool) {

--- a/agent/types/types.go
+++ b/agent/types/types.go
@@ -16,29 +16,7 @@ type Agent interface {
 	// `sdk.FromContext()`.
 	NewRequestRecord(req *http.Request) RequestRecord
 
-	// SecurityAction returns a non-nil HTTP handler when a security action is
-	// required for the given request. The returned handler should be used to
-	// handle the request before aborting it. Because of a security rule (eg.
-	// blocking an IP address). The request handler should therefore abort the
-	// request.
-	SecurityAction(r *http.Request) http.Handler
-
 	GracefulStop()
-}
-
-type Request interface {
-	// Record returns the request record of the request.
-	Record() RequestRecord
-
-	// SecurityAction returns a non-nil HTTP handler when a security action is
-	// required for the given request. The returned handler should be used to
-	// handle the request before aborting it. Because of a security rule (eg.
-	// blocking an IP address). The request handler should therefore abort the
-	// request.
-	SecurityAction() http.Handler
-
-	// Close needs to be called when the request is done.
-	Close()
 }
 
 type RequestRecord interface {
@@ -50,7 +28,13 @@ type RequestRecord interface {
 	NewUserAuth(id map[string]string, success bool)
 	// Identify associates the given user identifiers to the request.
 	Identify(id map[string]string)
-
+	// SecurityResponse returns a non-nil HTTP handler when a security response is
+	// required for the current request, according to its IP address (taken from
+	// the request IP address) or user-identifiers (taken from method
+	// `Identify()`). The returned handler should be used to respond to the
+	// request before canceling it. When a security response matches the request,
+	// its value is cached and returned to subsequent calls.
+	SecurityResponse() http.Handler
 	// Close needs to be called when the request is done.
 	Close()
 }

--- a/agent/types/types.go
+++ b/agent/types/types.go
@@ -30,11 +30,17 @@ type RequestRecord interface {
 	Identify(id map[string]string)
 	// SecurityResponse returns a non-nil HTTP handler when a security response is
 	// required for the current request, according to its IP address (taken from
-	// the request IP address) or user-identifiers (taken from method
-	// `Identify()`). The returned handler should be used to respond to the
-	// request before canceling it. When a security response matches the request,
-	// its value is cached and returned to subsequent calls.
+	// the request IP address). The returned handler should be used to respond to
+	// the request before canceling it. When a security response matches the
+	// request, its value is cached and returned to subsequent calls.
 	SecurityResponse() http.Handler
+	// UserSecurityResponse returns a non-nil HTTP handler when a security
+	// response is required for the current request, according to its
+	// user-identifiers (taken from method `Identify()`). The returned handler
+	// should be used to respond to the request before canceling it. When a
+	// security response matches the request, its value is cached and returned to
+	// subsequent calls.
+	UserSecurityResponse() http.Handler
 	// Close needs to be called when the request is done.
 	Close()
 }

--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,7 @@ require (
 	github.com/valyala/bytebufferpool v1.0.0 // indirect
 	github.com/valyala/fasttemplate v0.0.0-20170224212429-dcecefd839c4 // indirect
 	golang.org/x/net v0.0.0-20181220203305-927f97764cc3
+	golang.org/x/xerrors v0.0.0-20190315151331-d61658bd2e18
 	gopkg.in/go-playground/assert.v1 v1.2.1 // indirect
 	gopkg.in/go-playground/validator.v8 v8.18.2 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -89,6 +89,8 @@ golang.org/x/sys v0.0.0-20181205085412-a5c9d58dba9a h1:1n5lsVfiQW3yfsRGu98756EH1
 golang.org/x/sys v0.0.0-20181205085412-a5c9d58dba9a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+golang.org/x/xerrors v0.0.0-20190315151331-d61658bd2e18 h1:1AGvnywFL1aB5KLRxyLseWJI6aSYPo3oF7HSpXdWQdU=
+golang.org/x/xerrors v0.0.0-20190315151331-d61658bd2e18/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/fsnotify.v1 v1.4.7 h1:xOHLXZwVvI9hhs+cLKq5+I5onOuwQLhQwiu63xxlHs4=

--- a/sdk/agent.go
+++ b/sdk/agent.go
@@ -6,12 +6,12 @@ import (
 	"github.com/sqreen/go-agent/agent/types"
 )
 
-// The agent entrypoints are disabled by default. It must set its entrypoints on
-// initialization using SetAgent().
+// The agent entry points are disabled by default. It must set its entry points
+// on initialization using `SetAgent()`.
 var agent types.Agent = disabledAgent{}
 
-// SetAgent allows the agent to set its SDK entrypoints. It is automatically set
-// by the agent when it intializes itself.
+// SetAgent allows the agent to set its SDK entry points. It is automatically
+// set by the agent when it initializes itself.
 func SetAgent(a types.Agent) {
 	if a == nil {
 		agent = disabledAgent{}

--- a/sdk/agent.go
+++ b/sdk/agent.go
@@ -30,10 +30,6 @@ type disabledAgent struct {
 func (_ disabledAgent) GracefulStop() {
 }
 
-func (disabledAgent) SecurityAction(*http.Request) http.Handler {
-	return nil
-}
-
 func (a disabledAgent) NewRequestRecord(*http.Request) types.RequestRecord {
 	return nil
 }

--- a/sdk/middleware/sqecho/echo.go
+++ b/sdk/middleware/sqecho/echo.go
@@ -8,8 +8,8 @@ import (
 
 // Middleware is Sqreen's middleware function for Echo to monitor and protect
 // the requests Echo receives. In protection mode, it can block and redirect
-// requests according to its IP address or identified user (using `Identify()`
-// and `SecurityResponse()` methods).
+// requests according to its IP address or identified user using `Identify()`
+// and `SecurityResponse()` methods from the request handler.
 //
 // SDK methods can be called from request handlers by using the request event
 // record. It can be accessed using `sdk.FromContext()` on a request context or
@@ -30,6 +30,20 @@ import (
 //	func foo(req *http.Request) {
 //		// Accessing the SDK through the request context
 //		sdk.FromContext(req.Context()).TrackEvent("my.event.two")
+//	}
+//
+//	e.GET("/", func(c echo.Context) {
+//		// Globally identifying a user and checking if the request should be
+//		// aborted.
+//		uid := sdk.EventUserIdentifiersMap{"uid": "my-uid"}
+//		sqUser := sqecho.FromContext(c).ForUser(uid)
+//		sqUser.Identify() // Globally associate this user to the current request
+//		if sqUser.MatchSecurityResponse() {
+//			// Return to stop further handling the request and let Sqreen's
+//			// middleware apply and abort the request.
+//			return
+//		}
+//		// ... not blocked ...
 //	}
 //
 func Middleware() echo.MiddlewareFunc {

--- a/sdk/middleware/sqecho/echo_test.go
+++ b/sdk/middleware/sqecho/echo_test.go
@@ -136,12 +136,12 @@ func TestMiddleware(t *testing.T) {
 	})
 
 	t.Run("with a security response", func(t *testing.T) {
-		t.Run("with early response", func(t *testing.T) {
+		t.Run("with ip response", func(t *testing.T) {
 			body := testlib.RandString(1, 100)
 			req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(body))
 
 			status := http.StatusBadRequest
-			agent, record := testlib.NewAgentForMiddlewareTestsWithEarlySecurityResponse(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			agent, record := testlib.NewAgentForMiddlewareTestsWithSecurityResponse(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.WriteHeader(status)
 			}))
 			sdk.SetAgent(agent)
@@ -165,12 +165,12 @@ func TestMiddleware(t *testing.T) {
 			require.Equal(t, rec.Body.String(), "")
 		})
 
-		t.Run("with late response", func(t *testing.T) {
+		t.Run("with user response", func(t *testing.T) {
 			body := testlib.RandString(1, 100)
 			req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(body))
 
 			status := http.StatusBadRequest
-			agent, record := testlib.NewAgentForMiddlewareTestsWithLateSecurityResponse(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			agent, record := testlib.NewAgentForMiddlewareTestsWithUserSecurityResponse(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.WriteHeader(status)
 			}))
 			uid := sdk.EventUserIdentifiersMap{}

--- a/sdk/middleware/sqgin/gin.go
+++ b/sdk/middleware/sqgin/gin.go
@@ -8,7 +8,7 @@ import (
 // Middleware is Sqreen's middleware function for Gin to monitor and protect the
 // requests Gin receives. In protection mode, it can block and redirect requests
 // according to its IP address or identified user using `Identify()` and
-// `SecurityResponse()` methods from the request handler.
+// `MatchSecurityResponse()` methods from the request handler.
 //
 // SDK methods can be called from request handlers by using the request event
 // record. It can be accessed using `sdk.FromContext()` on a request context or
@@ -39,7 +39,7 @@ import (
 //		uid := sdk.EventUserIdentifiersMap{"uid": "my-uid"}
 //		sqUser := sdk.FromContext(c).ForUser(uid)
 //		sqUser.Identify() // Globally associate this user to the current request
-//		if sqUser.MatchSecurityResponse() {
+//		if match, _ := sqUser.MatchSecurityResponse(); match {
 //			// Return to stop further handling the request and let Sqreen's
 //			// middleware apply and abort the request.
 //			return
@@ -80,7 +80,7 @@ func Middleware() gingonic.HandlerFunc {
 
 		// Check if a security response should be applied now after having used
 		// `Identify()` and `MatchSecurityResponse()`.
-		if handler := req.SecurityResponse(); handler != nil {
+		if handler := req.UserSecurityResponse(); handler != nil {
 			handler.ServeHTTP(c.Writer, r)
 			c.Abort()
 		}

--- a/sdk/middleware/sqgin/gin.go
+++ b/sdk/middleware/sqgin/gin.go
@@ -7,8 +7,8 @@ import (
 
 // Middleware is Sqreen's middleware function for Gin to monitor and protect the
 // requests Gin receives. In protection mode, it can block and redirect requests
-// according to its IP address or identified user (using `Identify()` and
-// `SecurityResponse()` methods).
+// according to its IP address or identified user using `Identify()` and
+// `SecurityResponse()` methods from the request handler.
 //
 // SDK methods can be called from request handlers by using the request event
 // record. It can be accessed using `sdk.FromContext()` on a request context or
@@ -31,6 +31,20 @@ import (
 //		// Accessing the SDK through the request context
 //		sdk.FromContext(req.Context()).TrackEvent("my.event.two")
 //		// ...
+//	}
+//
+//	router.GET("/", func(c *gin.Context) {
+//		// Globally identifying a user and checking if the request should be
+//		// aborted.
+//		uid := sdk.EventUserIdentifiersMap{"uid": "my-uid"}
+//		sqUser := sdk.FromContext(c).ForUser(uid)
+//		sqUser.Identify() // Globally associate this user to the current request
+//		if sqUser.MatchSecurityResponse() {
+//			// Return to stop further handling the request and let Sqreen's
+//			// middleware apply and abort the request.
+//			return
+//		}
+//		// ... not blocked ...
 //	}
 //
 func Middleware() gingonic.HandlerFunc {

--- a/sdk/middleware/sqgin/gin_test.go
+++ b/sdk/middleware/sqgin/gin_test.go
@@ -86,10 +86,10 @@ func TestMiddleware(t *testing.T) {
 	})
 
 	t.Run("with security response", func(t *testing.T) {
-		t.Run("with early response", func(t *testing.T) {
+		t.Run("with ip response", func(t *testing.T) {
 			req, _ := http.NewRequest("GET", "/", nil)
 			status := http.StatusBadRequest
-			agent, record := testlib.NewAgentForMiddlewareTestsWithEarlySecurityResponse(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			agent, record := testlib.NewAgentForMiddlewareTestsWithSecurityResponse(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.WriteHeader(status)
 			}))
 			sdk.SetAgent(agent)
@@ -112,10 +112,10 @@ func TestMiddleware(t *testing.T) {
 			require.Equal(t, rec.Body.String(), "")
 		})
 
-		t.Run("with late response", func(t *testing.T) {
+		t.Run("with user response", func(t *testing.T) {
 			req, _ := http.NewRequest("GET", "/", nil)
 			status := http.StatusBadRequest
-			agent, record := testlib.NewAgentForMiddlewareTestsWithLateSecurityResponse(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			agent, record := testlib.NewAgentForMiddlewareTestsWithUserSecurityResponse(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.WriteHeader(status)
 			}))
 			uid := sdk.EventUserIdentifiersMap{}

--- a/sdk/middleware/sqgin/gin_test.go
+++ b/sdk/middleware/sqgin/gin_test.go
@@ -43,7 +43,7 @@ func TestMiddleware(t *testing.T) {
 		body := testlib.RandString(1, 100)
 		// Create a Gin router
 		router := gin.New()
-		// Attach our middelware
+		// Attach our middleware
 		router.Use(sqgin.Middleware())
 		// Add an endpoint accessing the SDK handle
 		router.GET("/", func(c *gin.Context) {
@@ -59,8 +59,8 @@ func TestMiddleware(t *testing.T) {
 		require.Equal(t, body, rec.Body.String())
 	})
 
-	t.Run("without security action", func(t *testing.T) {
-		agent, record := testlib.NewAgentForMiddlewareTestsWithoutSecurityAction()
+	t.Run("without security response", func(t *testing.T) {
+		agent, record := testlib.NewAgentForMiddlewareTestsWithoutSecurityResponse()
 		sdk.SetAgent(agent)
 		defer agent.AssertExpectations(t)
 		defer record.AssertExpectations(t)
@@ -69,7 +69,7 @@ func TestMiddleware(t *testing.T) {
 		body := testlib.RandString(1, 100)
 		// Create a Gin router
 		router := gin.New()
-		// Attach our middelware
+		// Attach our middleware
 		router.Use(sqgin.Middleware())
 		// Add an endpoint accessing the SDK handle
 		router.GET("/", func(c *gin.Context) {
@@ -85,29 +85,64 @@ func TestMiddleware(t *testing.T) {
 		require.Equal(t, body, rec.Body.String())
 	})
 
-	t.Run("with security action", func(t *testing.T) {
-		req, _ := http.NewRequest("GET", "/", nil)
-		status := http.StatusBadRequest
-		agent, record := testlib.NewAgentForMiddlewareTestsWithSecurityAction(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			w.WriteHeader(status)
-		}))
-		sdk.SetAgent(agent)
-		defer agent.AssertExpectations(t)
-		defer record.AssertExpectations(t)
+	t.Run("with security response", func(t *testing.T) {
+		t.Run("with early response", func(t *testing.T) {
+			req, _ := http.NewRequest("GET", "/", nil)
+			status := http.StatusBadRequest
+			agent, record := testlib.NewAgentForMiddlewareTestsWithEarlySecurityResponse(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(status)
+			}))
+			sdk.SetAgent(agent)
+			defer agent.AssertExpectations(t)
+			defer record.AssertExpectations(t)
 
-		// Create a Gin router
-		router := gin.New()
-		// Attach our middelware
-		router.Use(sqgin.Middleware())
-		// Add an endpoint accessing the SDK handle
-		router.GET("/", func(c *gin.Context) {
-			panic("must not be called")
+			// Create a Gin router
+			router := gin.New()
+			// Attach our middleware
+			router.Use(sqgin.Middleware())
+			// Add an endpoint accessing the SDK handle
+			router.GET("/", func(c *gin.Context) {
+				panic("must not be called")
+			})
+			// Perform the request and record the output
+			rec := httptest.NewRecorder()
+			router.ServeHTTP(rec, req)
+			// Check the request was performed as expected
+			require.Equal(t, rec.Code, status)
+			require.Equal(t, rec.Body.String(), "")
 		})
-		// Perform the request and record the output
-		rec := httptest.NewRecorder()
-		router.ServeHTTP(rec, req)
-		// Check the request was performed as expected
-		require.Equal(t, rec.Code, status)
-		require.Equal(t, rec.Body.String(), "")
+
+		t.Run("with late response", func(t *testing.T) {
+			req, _ := http.NewRequest("GET", "/", nil)
+			status := http.StatusBadRequest
+			agent, record := testlib.NewAgentForMiddlewareTestsWithLateSecurityResponse(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(status)
+			}))
+			uid := sdk.EventUserIdentifiersMap{}
+			record.ExpectIdentify(uid)
+			sdk.SetAgent(agent)
+			defer agent.AssertExpectations(t)
+			defer record.AssertExpectations(t)
+
+			// Create a Gin router
+			router := gin.New()
+			// Attach our middleware
+			router.Use(sqgin.Middleware())
+			// Add an endpoint accessing the SDK handle
+			router.GET("/", func(c *gin.Context) {
+				sqreen := sdk.FromContext(c)
+				sqUser := sqreen.ForUser(uid)
+				sqUser.Identify()
+				match, err := sqUser.MatchSecurityResponse()
+				require.True(t, match)
+				require.Error(t, err)
+			})
+			// Perform the request and record the output
+			rec := httptest.NewRecorder()
+			router.ServeHTTP(rec, req)
+			// Check the request was performed as expected
+			require.Equal(t, rec.Code, status)
+			require.Equal(t, rec.Body.String(), "")
+		})
 	})
 }

--- a/sdk/middleware/sqhttp/http.go
+++ b/sdk/middleware/sqhttp/http.go
@@ -9,7 +9,7 @@ import (
 // Middleware is Sqreen's middleware function for `net/http` to monitor and
 // protect received requests. In protection mode, it can block and redirect
 // requests according to its IP address or identified user using `Identify()`
-// and `SecurityResponse()` methods during from the request handler.
+// and `MatchSecurityResponse()` methods during from the request handler.
 //
 // SDK methods can be called from request handlers by using the request event
 // record. It can be accessed using `sdk.FromContext()` on a request context.
@@ -29,7 +29,7 @@ import (
 //		uid := sdk.EventUserIdentifiersMap{"uid": "my-uid"}
 //		sqUser := sqreen.ForUser(uid)
 //		sqUser.Identify() // Globally associate this user to the current request
-//		if sqUser.MatchSecurityResponse() {
+//		if match, _ := sqUser.MatchSecurityResponse(); match {
 //			// Return to stop further handling the request and let Sqreen's
 //			// middleware apply and abort the request.
 //			return
@@ -59,7 +59,7 @@ func Middleware(next http.Handler) http.Handler {
 
 		// Check if a security response should be applied now after having used
 		// `Identify()` and `MatchSecurityResponse()`.
-		if handler := req.SecurityResponse(); handler != nil {
+		if handler := req.UserSecurityResponse(); handler != nil {
 			handler.ServeHTTP(w, r)
 			return
 		}

--- a/sdk/middleware/sqhttp/http.go
+++ b/sdk/middleware/sqhttp/http.go
@@ -8,8 +8,8 @@ import (
 
 // Middleware is Sqreen's middleware function for `net/http` to monitor and
 // protect received requests. In protection mode, it can block and redirect
-// requests according to its IP address or identified user (using `Identify()`
-// and `SecurityResponse()` methods).
+// requests according to its IP address or identified user using `Identify()`
+// and `SecurityResponse()` methods during from the request handler.
 //
 // SDK methods can be called from request handlers by using the request event
 // record. It can be accessed using `sdk.FromContext()` on a request context.
@@ -18,7 +18,23 @@ import (
 // Usage example:
 //
 //	fn := func(w http.ResponseWriter, r *http.Request) {
-//		sdk.FromContext(r.Context()).TrackEvent("my.event")
+//		// Get the request record.
+//		sqreen := sdk.FromContext(r.Context())
+//
+//		// Example of sending a custom event.
+//		sqreen.TrackEvent("my.event")
+//
+//		// Example of globally identifying a user and checking if the request
+//		// should be aborted.
+//		uid := sdk.EventUserIdentifiersMap{"uid": "my-uid"}
+//		sqUser := sqreen.ForUser(uid)
+//		sqUser.Identify() // Globally associate this user to the current request
+//		if sqUser.MatchSecurityResponse() {
+//			// Return to stop further handling the request and let Sqreen's
+//			// middleware apply and abort the request.
+//			return
+//		}
+//		// Not blocked.
 //		fmt.Fprintf(w, "OK")
 //	}
 //	http.Handle("/foo", sqhttp.Middleware(http.HandlerFunc(fn)))

--- a/sdk/middleware/sqhttp/http_test.go
+++ b/sdk/middleware/sqhttp/http_test.go
@@ -60,7 +60,7 @@ func TestMiddleware(t *testing.T) {
 		require.Equal(t, body, rec.Body.String())
 	})
 
-	t.Run("without security action", func(t *testing.T) {
+	t.Run("without security response", func(t *testing.T) {
 		agent, record := testlib.NewAgentForMiddlewareTestsWithoutSecurityResponse()
 		sdk.SetAgent(agent)
 		defer agent.AssertExpectations(t)
@@ -87,9 +87,9 @@ func TestMiddleware(t *testing.T) {
 	})
 
 	t.Run("with security response", func(t *testing.T) {
-		t.Run("early security response", func(t *testing.T) {
+		t.Run("ip security response", func(t *testing.T) {
 			status := http.StatusBadRequest
-			agent, record := testlib.NewAgentForMiddlewareTestsWithEarlySecurityResponse(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			agent, record := testlib.NewAgentForMiddlewareTestsWithSecurityResponse(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.WriteHeader(status)
 			}))
 			sdk.SetAgent(agent)
@@ -113,9 +113,9 @@ func TestMiddleware(t *testing.T) {
 			require.Equal(t, rec.Code, status)
 		})
 
-		t.Run("late response", func(t *testing.T) {
+		t.Run("user response", func(t *testing.T) {
 			status := http.StatusBadRequest
-			agent, record := testlib.NewAgentForMiddlewareTestsWithLateSecurityResponse(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			agent, record := testlib.NewAgentForMiddlewareTestsWithUserSecurityResponse(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.WriteHeader(status)
 			}))
 			uid := sdk.EventUserIdentifiersMap{}

--- a/sdk/request.go
+++ b/sdk/request.go
@@ -6,7 +6,7 @@ import (
 )
 
 // HTTPRequest is a convenience type to hold together the request and its
-// request record. Most impotantly, it is created by `sdk.NewHTTPRequest()` by
+// request record. Most importantly, it is created by `sdk.NewHTTPRequest()` by
 // middleware functions to ensure that the request pointer it contains is the
 // one having the context value expected by `sdk.FromContext()`.
 type HTTPRequest struct {

--- a/sdk/request.go
+++ b/sdk/request.go
@@ -63,3 +63,11 @@ func (r *HTTPRequest) SecurityResponse() http.Handler {
 	}
 	return record.record.SecurityResponse()
 }
+
+func (r *HTTPRequest) UserSecurityResponse() http.Handler {
+	record := r.Record()
+	if record == nil {
+		return nil
+	}
+	return record.record.UserSecurityResponse()
+}

--- a/sdk/request.go
+++ b/sdk/request.go
@@ -56,6 +56,10 @@ func (r *HTTPRequest) Record() *HTTPRequestRecord {
 	return r.record
 }
 
-func (r *HTTPRequest) SecurityAction() http.Handler {
-	return agent.SecurityAction(r.request)
+func (r *HTTPRequest) SecurityResponse() http.Handler {
+	record := r.Record()
+	if record == nil {
+		return nil
+	}
+	return record.record.SecurityResponse()
 }

--- a/sdk/sdk_test.go
+++ b/sdk/sdk_test.go
@@ -193,7 +193,7 @@ func TestForUser(t *testing.T) {
 
 	t.Run("MatchSecurityResponse", func(t *testing.T) {
 		t.Run("without security response", func(t *testing.T) {
-			record.ExpectSecurityResponse().Return(http.Handler(nil)).Once()
+			record.ExpectUserSecurityResponse().Return(http.Handler(nil)).Once()
 			match, err := sqUser.MatchSecurityResponse()
 			require.NoError(t, err)
 			require.False(t, match)
@@ -201,7 +201,7 @@ func TestForUser(t *testing.T) {
 
 		t.Run("with security response", func(t *testing.T) {
 			handler := http.HandlerFunc(func(http.ResponseWriter, *http.Request) {})
-			record.ExpectSecurityResponse().Return(handler).Once()
+			record.ExpectUserSecurityResponse().Return(handler).Once()
 			match, err := sqUser.MatchSecurityResponse()
 			require.Error(t, err)
 			require.NotEmpty(t, err.Error())

--- a/sdk/user.go
+++ b/sdk/user.go
@@ -130,7 +130,7 @@ func (ctx *UserHTTPRequestRecord) MatchSecurityResponse() (match bool, err error
 		return false, nil
 	}
 
-	response := ctx.record.SecurityResponse()
+	response := ctx.record.UserSecurityResponse()
 	if response != nil {
 		err = SecurityResponseMatch{response}
 	}

--- a/sdk/user.go
+++ b/sdk/user.go
@@ -92,13 +92,19 @@ func (ctx *UserHTTPRequestRecord) TrackEvent(event string) *UserHTTPRequestEvent
 // They are also required to find security responses for users, for example to
 // block a specific user.
 //
+// This method and `MatchSecurityResponse()` are not concurrency-safe.
+//
+// Usage example:
+//
 //	uid := sdk.EventUserIdentifiersMap{"uid": "my-uid"}
 //	sqUser := sdk.FromContext(ctx).ForUser(uid)
 //	sqUser.Identify()
-//	if sqUser.SecurityResponse() {
-//		// Return to stop further handling the request and let Sqreen's
-//		// middleware apply and abort the request.
-//		return
+//	if match, err := sqUser.MatchSecurityResponse(); match {
+//		// Return now to stop further handling the request and let Sqreen's
+//		// middleware apply and abort the request. The returned error may help
+//		// aborting from sub-functions by returning it to the callers when the
+//		// Go error handling pattern is used.
+//		return err
 //	}
 //
 func (ctx *UserHTTPRequestRecord) Identify() *UserHTTPRequestRecord {
@@ -115,8 +121,10 @@ func (ctx *UserHTTPRequestRecord) Identify() *UserHTTPRequestRecord {
 // which will apply the security response and abort the request.
 // Note that `panic()` shouldn't be used.
 //
-// The returned error value can be used to help returning from the handler from
-// sub-functions using the classic Go error handling pattern.
+// The returned error may help aborting from sub-functions by returning it to
+// the callers when the Go error handling pattern is used.
+//
+// This method and `Identify()` are not concurrency-safe.
 func (ctx *UserHTTPRequestRecord) MatchSecurityResponse() (match bool, err error) {
 	if ctx == nil {
 		return false, nil

--- a/tools/testlib/agent.go
+++ b/tools/testlib/agent.go
@@ -38,38 +38,41 @@ func (a *AgentMockup) ExpectGracefulStop() *mock.Call {
 	return a.On("GracefulStop")
 }
 
-func (a *AgentMockup) SecurityAction(r *http.Request) http.Handler {
-	ret := a.Called(r).Get(0)
-	if ret == nil {
-		return nil
-	}
-	return ret.(http.Handler)
-}
-
-func (a *AgentMockup) ExpectSecurityAction(r interface{}) *mock.Call {
-	return a.On("SecurityAction", r)
-}
-
-func NewAgentForMiddlewareTestsWithoutSecurityAction() (*AgentMockup, *HTTPRequestRecordMockup) {
+func NewAgentForMiddlewareTestsWithoutSecurityResponse() (*AgentMockup, *HTTPRequestRecordMockup) {
 	agent := &AgentMockup{}
 	record := &HTTPRequestRecordMockup{}
 	agent.ExpectNewRequestRecord(mock.Anything).Return(record).Once()
-	agent.ExpectSecurityAction(mock.Anything).Return(nil).Once()
+	record.ExpectSecurityResponse().Return(nil)
 	record.ExpectClose().Once()
 	return agent, record
 }
 
-func NewAgentForMiddlewareTestsWithSecurityAction(actionHandler http.Handler) (*AgentMockup, *HTTPRequestRecordMockup) {
+func NewAgentForMiddlewareTestsWithEarlySecurityResponse(actionHandler http.Handler) (*AgentMockup, *HTTPRequestRecordMockup) {
 	agent := &AgentMockup{}
-	record := &HTTPRequestRecordMockup{}
+	record := &HTTPRequestRecordMockup{
+		lateSecurityResponse: false,
+	}
 	agent.ExpectNewRequestRecord(mock.Anything).Return(record).Once()
-	agent.ExpectSecurityAction(mock.Anything).Return(actionHandler).Once()
+	record.ExpectSecurityResponse().Return(actionHandler)
+	record.ExpectClose().Once()
+	return agent, record
+}
+
+func NewAgentForMiddlewareTestsWithLateSecurityResponse(actionHandler http.Handler) (*AgentMockup, *HTTPRequestRecordMockup) {
+	agent := &AgentMockup{}
+	record := &HTTPRequestRecordMockup{
+		lateSecurityResponse: true,
+	}
+	agent.ExpectNewRequestRecord(mock.Anything).Return(record).Once()
+	record.ExpectSecurityResponse().Return(actionHandler)
 	record.ExpectClose().Once()
 	return agent, record
 }
 
 type HTTPRequestRecordMockup struct {
 	mock.Mock
+	securityResponseCall int
+	lateSecurityResponse bool
 }
 
 // Static assertion of correct interface implementation.
@@ -110,6 +113,23 @@ func (r *HTTPRequestRecordMockup) ExpectTrackSignup(id map[string]string) *mock.
 
 func (r *HTTPRequestRecordMockup) Identify(id map[string]string) {
 	r.Called(id)
+}
+
+func (r *HTTPRequestRecordMockup) SecurityResponse() http.Handler {
+	r.securityResponseCall++
+	if r.lateSecurityResponse && r.securityResponseCall == 1 {
+		return nil
+	}
+
+	ret := r.Called().Get(0)
+	if ret == nil {
+		return nil
+	}
+	return ret.(http.Handler)
+}
+
+func (r *HTTPRequestRecordMockup) ExpectSecurityResponse() *mock.Call {
+	return r.On("SecurityResponse")
 }
 
 func (r *HTTPRequestRecordMockup) ExpectIdentify(id map[string]string) *mock.Call {


### PR DESCRIPTION
- Adapt the existing security response API so that it can match identified users
  per request. The `SecurityResponse()` method was therefore moved from the
  agent interface to the request record interface so that it is now a
  per-request method with full access and visibility to the recorded user.

- The new per-user method `MatchSecurityResponse()` allows to check from request
  handlers and sub-functions if a user has a security response. The main reason
  why we are not using `panic()` to abort the current request from `Identify()`
  is that a `panic()` cannot be catched from outside of the calling goroutine,
  leading to a crash.

  Method `MatchSecurityResponse()` returns an error to allow bubbling up the
  error using the usual Go error handling (ie. returning it to the caller). So
  that any caller that needs to return an error to abort and exit its request
  handler can simply return this one.

- Since the `SecurityResponse()` method can now be called multiple times (before
  the request handler, maybe during the request handler, and after the request
  handler), it now caches the first non-nil value that matched the request.

Note `SecurityAction` was renamed into `SecurityResponse` to match the product
name.