### PR TITLE
Security automation: security actions store by user-identifiers (2/2)

### DIFF
--- a/agent/internal/actor/action.go
+++ b/agent/internal/actor/action.go
@@ -2,57 +2,28 @@
 // Please refer to our terms for more information:
 // https://www.sqreen.io/terms.html
 
-/*
-
-Security Actions
-
-Security actions are stored using structures implementing the Action interface.
-Actions can have a time duration by implementing the Timed interface.
-
-Security action HTTP handlers
-
-NewActionHandler() allows to get a http.Handler that applies the security
-response (eg. blocking). If required, security response HTTP handlers can use
-the SDK.
-
-*/
+// Security Actions
+//
+// Security actions are stored using structures implementing the Action
+// interface. Actions can have a time duration by implementing the Timed
+// interface.
+//
 package actor
 
 import (
-	"encoding/json"
-	"net"
-	"net/http"
 	"time"
-
-	"github.com/sqreen/go-agent/agent/internal/backend/api"
-	"github.com/sqreen/go-agent/agent/types"
-	"github.com/sqreen/go-agent/sdk"
 )
 
 // Action kinds.
 const (
-	actionKind_BlockIP = "block_ip"
+	actionKind_BlockIP   = "block_ip"
+	actionKind_BlockUser = "block_user"
 )
-
-// Event names.
-const (
-	blockIPEventName = "app.sqreen.action.block_ip"
-)
-
-// NewActionHandler returns a http.Handler for the given security action and IP
-// address. This HTTP handler can be applied at the request handler level to
-// perform the security response.
-func NewActionHandler(action Action, ip net.IP) http.Handler {
-	switch actual := action.(type) {
-	case *blockIPAction:
-		return newBlockIPActionHandler(actual, ip)
-	}
-	return nil
-}
 
 // Action is an interface common to each concrete action type stored in the data
 // structures, and allowing to type-switch the stored values.
 type Action interface {
+	// ActionID returns the unique ID of the request.
 	ActionID() string
 }
 
@@ -61,89 +32,38 @@ type Timed interface {
 	Expired() bool
 }
 
-// blockIPAction is an action type blocking the matching IP address.
-type blockIPAction struct {
+type blockAction struct {
 	ID string
 }
 
-// timedBlockIPAction is a blockIPAction with a time deadline after which it is
-// considered expired.
-type timedBlockIPAction struct {
-	Action
-	deadline time.Time
-}
-
-func newBlockIPAction(id string) *blockIPAction {
-	return &blockIPAction{
+func newBlockAction(id string) *blockAction {
+	return &blockAction{
 		ID: id,
 	}
 }
 
-func (a *blockIPAction) ActionID() string {
+func (a *blockAction) ActionID() string {
 	return a.ID
+}
+
+// timedAction is an Action with a time deadline after which it is considered
+// expired.
+type timedAction struct {
+	Action
+	deadline time.Time
 }
 
 // withDuration sets a time duration to an action. The returned value implements
 // the Action and Timed interfaces.
-func withDuration(action Action, duration time.Duration) *timedBlockIPAction {
-	return &timedBlockIPAction{
+func withDuration(action Action, duration time.Duration) *timedAction {
+	return &timedAction{
 		Action:   action,
 		deadline: time.Now().Add(duration),
 	}
 }
 
 // Expired is true when the deadline has expired, false otherwise.
-func (a *timedBlockIPAction) Expired() bool {
+func (a *timedAction) Expired() bool {
 	// Is the current time after the deadline?
 	return time.Now().After(a.deadline)
-}
-
-// blockIPActionHandler is the blocking HTTP handler action to be applied to the
-// request.
-type blockIPActionHandler struct {
-	*blockIPAction
-	ip net.IP
-}
-
-func newBlockIPActionHandler(action *blockIPAction, ip net.IP) *blockIPActionHandler {
-	return &blockIPActionHandler{
-		blockIPAction: action,
-		ip:            ip,
-	}
-}
-
-// ServeHTTP writes the HTTP status code 500 into the HTTP response writer `w`.
-// The caller needs to abort the request.
-func (a *blockIPActionHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	record := sdk.FromContext(r.Context())
-	record.TrackEvent(blockIPEventName).WithProperties((*blockedIPEventProperties)(a))
-	w.WriteHeader(500)
-}
-
-// blockedIPEventProperties is an adapter type. It implements
-// `types.EventProperties` to be marshaled to an SDK event property structure.
-type blockedIPEventProperties blockIPActionHandler
-
-// Static assert that blockedIPEventProperties implements types.EventProperties.
-var _ types.EventProperties = &blockedIPEventProperties{}
-
-// Static assert that blockedIPEventProperties implements
-// api.BlockedIPEventPropertiesFace.
-var _ api.BlockedIPEventPropertiesFace = &blockedIPEventProperties{}
-
-func (p *blockedIPEventProperties) MarshalJSON() ([]byte, error) {
-	pb := api.NewBlockedIPEventPropertiesFromFace(p)
-	return json.Marshal(pb)
-}
-
-func (p *blockedIPEventProperties) GetActionId() string {
-	return p.blockIPAction.ID
-}
-
-func (p *blockedIPEventProperties) GetOutput() api.BlockedIPEventProperties_Output {
-	return *api.NewBlockedIPEventProperties_OutputFromFace(p)
-}
-
-func (p *blockedIPEventProperties) GetIpAddress() string {
-	return p.ip.String()
 }

--- a/agent/internal/actor/action_test.go
+++ b/agent/internal/actor/action_test.go
@@ -11,39 +11,41 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestActionHandler(t *testing.T) {
-	t.Run("nil", func(t *testing.T) {
-		handler := NewActionHandler(nil, nil)
-		require.Nil(t, handler)
+func TestAction(t *testing.T) {
+	action := newBlockAction(testlib.RandString(1, 20))
+
+	t.Run("with duration", func(t *testing.T) {
+		t.Run("not expired", func(t *testing.T) {
+			action := withDuration(action, 10*time.Hour)
+			require.False(t, action.Expired())
+		})
+		t.Run("expired", func(t *testing.T) {
+			action := withDuration(action, 0)
+			require.True(t, action.Expired())
+		})
 	})
 
-	t.Run("BlockIPAction", func(t *testing.T) {
-		action := newBlockIPAction(testlib.RandString(1, 20))
-		handler := NewActionHandler(action, net.IPv4(1, 2, 3, 4))
-		require.NotNil(t, handler)
-
-		t.Run("is a http.Handler", func(t *testing.T) {
+	t.Run("HTTP Handler", func(t *testing.T) {
+		t.Run("Block IP", func(t *testing.T) {
+			handler := NewIPActionHTTPHandler(action, net.IPv4(1, 2, 3, 4))
+			require.NotNil(t, handler)
+			// Use the handler
 			req := httptest.NewRequest(http.MethodPost, "/", nil)
 			rec := httptest.NewRecorder()
 			handler.ServeHTTP(rec, req)
 			require.Equal(t, rec.Code, 500)
+			// TODO: check the sdk event
 		})
 
-		t.Run("is a types.EventProperties", func(t *testing.T) {
-			props := (*blockedIPEventProperties)(handler.(*blockIPActionHandler))
-			_, err := props.MarshalJSON()
-			require.NoError(t, err)
-		})
-
-		t.Run("with duration", func(t *testing.T) {
-			t.Run("not expired", func(t *testing.T) {
-				action := withDuration(action, 10*time.Hour)
-				require.False(t, action.Expired())
-			})
-			t.Run("expired", func(t *testing.T) {
-				action := withDuration(action, 0)
-				require.True(t, action.Expired())
-			})
+		t.Run("Block User", func(t *testing.T) {
+			handler := NewUserActionHTTPHandler(action, map[string]string{"uid": testlib.RandString(1, 250)})
+			require.NotNil(t, handler)
+			// Use the handler
+			req := httptest.NewRequest(http.MethodPost, "/", nil)
+			rec := httptest.NewRecorder()
+			handler.ServeHTTP(rec, req)
+			require.Equal(t, rec.Code, 500)
+			// TODO: check the sdk event
 		})
 	})
 }

--- a/agent/internal/actor/actor.go
+++ b/agent/internal/actor/actor.go
@@ -14,6 +14,7 @@
 package actor
 
 import (
+	"hash/crc64"
 	"net"
 	"sync"
 
@@ -102,6 +103,31 @@ func (s *Store) FindIP(ip net.IP) (action Action, exists bool, err error) {
 	return action, action != nil, nil
 }
 
+// FindUser returns the security action of the given userID map. The returned
+// boolean `exists` is `false` when it is not present in the store, `true`
+// otherwise.
+func (s *Store) FindUser(userID map[string]string) (action Action, exists bool) {
+	store := s.getStore()
+	if store == nil {
+		return nil, false
+	}
+	users := store.users
+	if len(users) == 0 {
+		return nil, false
+	}
+	hash := NewUserIdentifiersHash(userID)
+	action, exists = users[hash]
+
+	// Check if the action is timed.
+	if timed, implementsTimed := action.(Timed); implementsTimed && timed.Expired() {
+		// The action is not removed from the map to avoid locking it with a
+		// RWMutex.
+		return nil, false
+	}
+
+	return
+}
+
 // SetActions creates a new action store and then replaces the current one. The
 // new store is being built while still performing store methods on the current
 // one.
@@ -123,7 +149,10 @@ func (s *Store) SetActions(actions []api.ActionsPackResponse_Action) error {
 type store struct {
 	treeV4 *treeV4
 	treeV6 *treeV6
+	users  userActionMap
 }
+
+type userActionMap map[UserIdentifiersHash]Action
 
 func newStore(actions []api.ActionsPackResponse_Action) (*store, error) {
 	if len(actions) == 0 {
@@ -142,22 +171,28 @@ func newStore(actions []api.ActionsPackResponse_Action) (*store, error) {
 	return store, nil
 }
 
-func (s *store) addAction(action api.ActionsPackResponse_Action) error {
+func (s *store) addAction(action api.ActionsPackResponse_Action) (err error) {
 	switch action.Action {
 	case actionKind_BlockIP:
-		var blockIP Action = newBlockIPAction(action.ActionId)
-		if action.Duration > 0 {
-			blockIP = withDuration(blockIP, action.Duration)
-		}
-		cidrs := action.Parameters.IpCidr
-		if len(cidrs) == 0 {
-			return errors.Errorf("could not add action `%s`: empty list of CIDRs", action.ActionId)
-		}
+		err = s.addBlockIPAction(action)
+	case actionKind_BlockUser:
+		err = s.addBlockUserAction(action)
+	}
+	return err
+}
 
-		err := s.addCIDRList(cidrs, blockIP)
-		if err != nil {
-			return err
-		}
+func (s *store) addBlockIPAction(action api.ActionsPackResponse_Action) error {
+	var blockIP Action = newBlockAction(action.ActionId)
+	if action.Duration > 0 {
+		blockIP = withDuration(blockIP, action.Duration)
+	}
+	cidrs := action.Parameters.IpCidr
+	if len(cidrs) == 0 {
+		return errors.Errorf("could not add action `%s`: empty list of CIDRs", action.ActionId)
+	}
+	err := s.addCIDRList(cidrs, blockIP)
+	if err != nil {
+		return err
 	}
 	return nil
 }
@@ -194,4 +229,52 @@ func (s *store) addCIDRv6(ip *patricia.IPv6Address, action Action) error {
 		s.treeV6 = newTreeV6(maxStoreActions)
 	}
 	return s.treeV6.addAction(ip, action)
+}
+
+func (s *store) addBlockUserAction(action api.ActionsPackResponse_Action) error {
+	var blockUser Action = newBlockAction(action.ActionId)
+	if action.Duration > 0 {
+		blockUser = withDuration(blockUser, action.Duration)
+	}
+	users := action.Parameters.Users
+	if len(users) == 0 {
+		return errors.Errorf("could not add action `%s`: empty list of users", action.ActionId)
+	}
+	return s.addUserList(users, blockUser)
+}
+
+func (s *store) addUserList(users []api.ActionsPackResponse_Action_Params_UserIdentifiers, action Action) error {
+	if len(s.users)+len(users) >= maxStoreActions {
+		return errors.Errorf("number of actions `%d` exceeds `%d`", len(users), maxStoreActions)
+	}
+
+	if s.users == nil {
+		s.users = make(userActionMap, len(users))
+	}
+	for _, user := range users {
+		s.addUser(user.User, action)
+	}
+	return nil
+}
+
+func (s *store) addUser(identifiers map[string]string, action Action) {
+	hash := NewUserIdentifiersHash(identifiers)
+	s.users[hash] = action
+}
+
+// UserIdentifierHash is a type suitable to be used as key type of the map of
+// user actions. It is therefore an array, as slices cannot be used as map key
+// types.
+type UserIdentifiersHash uint64
+
+var crc64Table = crc64.MakeTable(crc64.ISO)
+
+func NewUserIdentifiersHash(id map[string]string) UserIdentifiersHash {
+	var hash uint64
+	for k, v := range id {
+		// hash.Hash doc: method Write() never returns an error.
+		hash += crc64.Checksum([]byte(k), crc64Table)
+		hash += crc64.Checksum([]byte(v), crc64Table)
+	}
+	return UserIdentifiersHash(hash)
 }

--- a/agent/internal/actor/http.go
+++ b/agent/internal/actor/http.go
@@ -1,0 +1,126 @@
+// Copyright 2019 Sqreen. All Rights Reserved.
+// Please refer to our terms for more information:
+// https://www.sqreen.io/terms.html
+
+// Security Action HTTP Handlers
+//
+// Constructors `NewUserActionHTTPHandler()` and `NewIPActionHTTPHandler()`
+// allow to create a `http.Handler` from an action that matched a user or an IP
+// address. They allow to apply the expected security response to the request's
+// response. The user and IP address are used as properties of events performed
+// by handlers.
+package actor
+
+import (
+	"encoding/json"
+	"net"
+	"net/http"
+
+	"github.com/sqreen/go-agent/agent/internal/backend/api"
+	"github.com/sqreen/go-agent/agent/types"
+	"github.com/sqreen/go-agent/sdk"
+)
+
+// Event names.
+const (
+	blockIPEventName   = "app.sqreen.action.block_ip"
+	blockUserEventName = "app.sqreen.action.block_user"
+)
+
+// NewIPActionHTTPHandler returns a HTTP handler that should be applied at the
+// request handler level to perform the security response.
+func NewIPActionHTTPHandler(action Action, ip net.IP) http.Handler {
+	return newBlockHTTPHandler(blockIPEventName, newBlockedIPEventProperties(action, ip))
+}
+
+// NewUserActionHTTPHandler returns a HTTP handler that should be applied at
+// the request handler level to perform the security response.
+func NewUserActionHTTPHandler(action Action, userID map[string]string) http.Handler {
+	return newBlockHTTPHandler(blockUserEventName, newBlockedUserEventProperties(action, userID))
+}
+
+// blockHTTPHandler implements the http.Handler interface and holds the event
+// data corresponding to the action.
+type blockHTTPHandler struct {
+	eventName       string
+	eventProperties types.EventProperties
+}
+
+// Static assertion that http.Handler is implemented.
+var _ http.Handler = &blockHTTPHandler{}
+
+func newBlockHTTPHandler(eventName string, properties types.EventProperties) *blockHTTPHandler {
+	return &blockHTTPHandler{
+		eventName:       eventName,
+		eventProperties: properties,
+	}
+}
+
+// ServeHTTP writes the HTTP status code 500 into the HTTP response writer `w`.
+// The caller needs to abort the request.
+func (a *blockHTTPHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	record := sdk.FromContext(r.Context())
+	record.TrackEvent(a.eventName).WithProperties(a.eventProperties)
+	w.WriteHeader(500)
+}
+
+// blockedIPEventProperties implements `types.EventProperties` to be marshaled
+// to an SDK event property structure.
+type blockedIPEventProperties struct {
+	action Action
+	ip     net.IP
+}
+
+// Static assert that blockedIPEventProperties implements types.EventProperties.
+var _ types.EventProperties = &blockedIPEventProperties{}
+
+func newBlockedIPEventProperties(action Action, ip net.IP) *blockedIPEventProperties {
+	return &blockedIPEventProperties{
+		action: action,
+		ip:     ip,
+	}
+}
+func (p *blockedIPEventProperties) MarshalJSON() ([]byte, error) {
+	pb := api.NewBlockedIPEventPropertiesFromFace(p)
+	return json.Marshal(pb)
+}
+func (p *blockedIPEventProperties) GetActionId() string {
+	return p.action.ActionID()
+}
+func (p *blockedIPEventProperties) GetOutput() api.BlockedIPEventProperties_Output {
+	return *api.NewBlockedIPEventProperties_OutputFromFace(p)
+}
+func (p *blockedIPEventProperties) GetIpAddress() string {
+	return p.ip.String()
+}
+
+// blockedIPEventProperties implements `types.EventProperties` to be marshaled
+// to an SDK event property structure.
+type blockedUserEventProperties struct {
+	action Action
+	userID map[string]string
+}
+
+// Static assert that blockedUserEventProperties implements
+// `types.EventProperties`.
+var _ types.EventProperties = &blockedUserEventProperties{}
+
+func newBlockedUserEventProperties(action Action, userID map[string]string) *blockedUserEventProperties {
+	return &blockedUserEventProperties{
+		action: action,
+		userID: userID,
+	}
+}
+func (p *blockedUserEventProperties) MarshalJSON() ([]byte, error) {
+	pb := api.NewBlockedUserEventPropertiesFromFace(p)
+	return json.Marshal(pb)
+}
+func (p *blockedUserEventProperties) GetActionId() string {
+	return p.action.ActionID()
+}
+func (p *blockedUserEventProperties) GetOutput() api.BlockedUserEventProperties_Output {
+	return *api.NewBlockedUserEventProperties_OutputFromFace(p)
+}
+func (p *blockedUserEventProperties) GetUser() map[string]string {
+	return p.userID
+}

--- a/agent/internal/backend/api/api.go
+++ b/agent/internal/backend/api/api.go
@@ -1165,3 +1165,34 @@ func NewBlockedIPEventProperties_OutputFromFace(that BlockedIPEventProperties_Ou
 	this.IpAddress = that.GetIpAddress()
 	return this
 }
+
+type BlockedUserEventProperties struct {
+	ActionId string                            `json:"action_id"`
+	Output   BlockedUserEventProperties_Output `json:"output"`
+}
+
+type BlockedUserEventProperties_Output struct {
+	User map[string]string `json:"user"`
+}
+
+func NewBlockedUserEventPropertiesFromFace(that BlockedUserEventPropertiesFace) *BlockedUserEventProperties {
+	this := &BlockedUserEventProperties{}
+	this.ActionId = that.GetActionId()
+	this.Output = that.GetOutput()
+	return this
+}
+
+type BlockedUserEventPropertiesFace interface {
+	GetActionId() string
+	GetOutput() BlockedUserEventProperties_Output
+}
+
+type BlockedUserEventProperties_OutputFace interface {
+	GetUser() map[string]string
+}
+
+func NewBlockedUserEventProperties_OutputFromFace(that BlockedUserEventProperties_OutputFace) *BlockedUserEventProperties_Output {
+	this := &BlockedUserEventProperties_Output{}
+	this.User = that.GetUser()
+	return this
+}

--- a/agent/types/types.go
+++ b/agent/types/types.go
@@ -1,7 +1,6 @@
 // This package is the contract between the agent and the SDK. It allows to
 // strictly separate the SDK from the agent package since the agent does not
 // export its internals.
-
 package types
 
 import (


### PR DESCRIPTION
- Data-structure based on a Go map. Since the key is a map[string]string,
  which cannot be used as a key type, values are hashed using a simple crc64
  on each key and value of the map. Since Go maps are unordered, it is
  necessary to implement a simple cumulative crc64 so that crc64(userID) is
  equal to crc64(key1) + crc64(value2) + ... + crc64(keyn) + crc64(valuen).
  The sum allows to keep an even distribution of bits. And sums of integers
  are considered cheap. It also has the benefit of not storing huge string
  keys of some kind of deserialized view of the user-identifier map.

- `FindUser()` allows to find actions matching the user-identifier map.

- `SetActions()` adapted to add users.