### PR TITLE
Error management: add panic-safe function and goroutine wrappers (2/5)

### DIFF
--- a/agent/sqlib/safe/call.go
+++ b/agent/sqlib/safe/call.go
@@ -1,0 +1,65 @@
+// Copyright (c) 2016 - 2019 Sqreen. All Rights Reserved.
+// Please refer to our terms for more information:
+// https://www.sqreen.io/terms.html
+
+package safe
+
+import (
+	"fmt"
+	"reflect"
+	"runtime"
+
+	"golang.org/x/xerrors"
+)
+
+// PanicError is an error type wrapping a recovered panic value that happened
+// during a function call.
+type PanicError struct {
+	// The function that was given to `Call()`.
+	In func() error
+	// The recovered panic value while executing `In()`.
+	Err error
+}
+
+func NewPanicError(in func() error, err error) *PanicError {
+	return &PanicError{
+		In:  in,
+		Err: err,
+	}
+}
+
+func (e PanicError) Unwrap() error {
+	return e.Err
+}
+
+func (e PanicError) inName() string {
+	return runtime.FuncForPC(reflect.ValueOf(e.In).Pointer()).Name()
+}
+
+func (e PanicError) Error() string {
+	return fmt.Sprintf("panic while executing %s: %s", e.inName(), e.Err)
+}
+
+// Call calls function `f` and recovers from any panic occurring while it
+// executes, returning it in a `PanicError` object type.
+func Call(f func() error) (err error) {
+	defer func() {
+		r := recover()
+		if r == nil {
+			// Note that panic(nil) matches this case and cannot be really tested for.
+			return
+		}
+
+		switch actual := r.(type) {
+		case error:
+			err = actual
+		case string:
+			err = xerrors.New(actual)
+		default:
+			err = xerrors.Errorf("%v", r)
+		}
+
+		err = NewPanicError(f, err)
+	}()
+	return f()
+}

--- a/agent/sqlib/safe/call_test.go
+++ b/agent/sqlib/safe/call_test.go
@@ -1,0 +1,75 @@
+// Copyright (c) 2016 - 2019 Sqreen. All Rights Reserved.
+// Please refer to our terms for more information:
+// https://www.sqreen.io/terms.html
+
+package safe_test
+
+import (
+	"testing"
+
+	"github.com/sqreen/go-agent/agent/sqlib"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/xerrors"
+)
+
+func TestCall(t *testing.T) {
+	t.Run("without error", func(t *testing.T) {
+		err := sqlib.Call(func() error {
+			return nil
+		})
+		require.NoError(t, err)
+	})
+
+	t.Run("with a regular error", func(t *testing.T) {
+		err := sqlib.Call(func() error {
+			return xerrors.New("oops")
+		})
+		require.Error(t, err)
+		require.Equal(t, "oops", err.Error())
+	})
+
+	t.Run("with a panic string error", func(t *testing.T) {
+		err := sqlib.Call(func() error {
+			panic("oops")
+			return nil
+		})
+		require.Error(t, err)
+		var panicErr *sqlib.PanicError
+		require.Error(t, err)
+		require.True(t, xerrors.As(err, &panicErr))
+		require.Equal(t, "oops", panicErr.Err.Error())
+	})
+
+	t.Run("with a panic error", func(t *testing.T) {
+		err := sqlib.Call(func() error {
+			panic(xerrors.New("oops"))
+			return nil
+		})
+		require.Error(t, err)
+		var panicErr *sqlib.PanicError
+		require.Error(t, err)
+		require.True(t, xerrors.As(err, &panicErr))
+		require.Equal(t, "oops", panicErr.Err.Error())
+	})
+
+	t.Run("with another panic argument type", func(t *testing.T) {
+		err := sqlib.Call(func() error {
+			panic(33.7)
+			return nil
+		})
+		require.Error(t, err)
+		var panicErr *sqlib.PanicError
+		require.Error(t, err)
+		require.True(t, xerrors.As(err, &panicErr))
+		require.Equal(t, "33.7", panicErr.Err.Error())
+	})
+
+	t.Run("with a nil panic argument value", func(t *testing.T) {
+		err := sqlib.Call(func() error {
+			// This case cannot be differentiated yet.
+			panic(nil)
+			return xerrors.New("oops")
+		})
+		require.NoError(t, err)
+	})
+}

--- a/agent/sqlib/safe/call_test.go
+++ b/agent/sqlib/safe/call_test.go
@@ -7,21 +7,21 @@ package safe_test
 import (
 	"testing"
 
-	"github.com/sqreen/go-agent/agent/sqlib"
+	"github.com/sqreen/go-agent/agent/sqlib/safe"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/xerrors"
 )
 
 func TestCall(t *testing.T) {
 	t.Run("without error", func(t *testing.T) {
-		err := sqlib.Call(func() error {
+		err := safe.Call(func() error {
 			return nil
 		})
 		require.NoError(t, err)
 	})
 
 	t.Run("with a regular error", func(t *testing.T) {
-		err := sqlib.Call(func() error {
+		err := safe.Call(func() error {
 			return xerrors.New("oops")
 		})
 		require.Error(t, err)
@@ -29,43 +29,43 @@ func TestCall(t *testing.T) {
 	})
 
 	t.Run("with a panic string error", func(t *testing.T) {
-		err := sqlib.Call(func() error {
+		err := safe.Call(func() error {
 			panic("oops")
 			return nil
 		})
 		require.Error(t, err)
-		var panicErr *sqlib.PanicError
+		var panicErr *safe.PanicError
 		require.Error(t, err)
 		require.True(t, xerrors.As(err, &panicErr))
 		require.Equal(t, "oops", panicErr.Err.Error())
 	})
 
 	t.Run("with a panic error", func(t *testing.T) {
-		err := sqlib.Call(func() error {
+		err := safe.Call(func() error {
 			panic(xerrors.New("oops"))
 			return nil
 		})
 		require.Error(t, err)
-		var panicErr *sqlib.PanicError
+		var panicErr *safe.PanicError
 		require.Error(t, err)
 		require.True(t, xerrors.As(err, &panicErr))
 		require.Equal(t, "oops", panicErr.Err.Error())
 	})
 
 	t.Run("with another panic argument type", func(t *testing.T) {
-		err := sqlib.Call(func() error {
+		err := safe.Call(func() error {
 			panic(33.7)
 			return nil
 		})
 		require.Error(t, err)
-		var panicErr *sqlib.PanicError
+		var panicErr *safe.PanicError
 		require.Error(t, err)
 		require.True(t, xerrors.As(err, &panicErr))
 		require.Equal(t, "33.7", panicErr.Err.Error())
 	})
 
 	t.Run("with a nil panic argument value", func(t *testing.T) {
-		err := sqlib.Call(func() error {
+		err := safe.Call(func() error {
 			// This case cannot be differentiated yet.
 			panic(nil)
 			return xerrors.New("oops")

--- a/agent/sqlib/safe/doc.go
+++ b/agent/sqlib/safe/doc.go
@@ -1,0 +1,13 @@
+// Copyright (c) 2016 - 2019 Sqreen. All Rights Reserved.
+// Please refer to our terms for more information:
+// https://www.sqreen.io/terms.html
+
+// This package provides functions making sure panics are safely caught and do
+// not break the running program. Since panics can stop the program execution
+// if they are not recovered, we need ways to safely recover and handle them.
+//
+// Therefore, this package provides simple function call wrappers to call a
+// function that may panic and its goroutine equivalent. That way, any function
+// can be safely called and any panic will be returned as a regular function
+// error.
+package safe

--- a/agent/sqlib/safe/go.go
+++ b/agent/sqlib/safe/go.go
@@ -1,0 +1,39 @@
+// Copyright (c) 2016 - 2019 Sqreen. All Rights Reserved.
+// Please refer to our terms for more information:
+// https://www.sqreen.io/terms.html
+
+package safe
+
+// Go mimics the `go` goroutine built-in to execute function `f` in a goroutine
+// but with the ability to safely recover from any panic occurring while it
+// executes. To do so, it uses `Call()` and returns an error channel in order
+// to retrieve any panic occurring during the execution of `f()` or the error
+// it returns otherwise. An error is sent into the channel only in case of
+// error or panic, and is closed in any case before returning from the
+// goroutine.
+//
+// Usage example:
+//
+//		errChan := safe.Go(f)
+//    // ...
+//		select {
+//			case err := <-errChan:
+//				var panicErr *sqlib.PanicError
+//				if xerrors.As(err, &panicErr) {
+//					// A panic occurred while executing f()
+//				} else {
+//					// A regular error was returned by f()
+//				}
+//			// ...
+//		}
+//
+func Go(f func() error) <-chan error {
+	c := make(chan error, 1)
+	go func() {
+		if err := Call(f); err != nil {
+			c <- err
+		}
+		close(c)
+	}()
+	return c
+}

--- a/agent/sqlib/safe/go_test.go
+++ b/agent/sqlib/safe/go_test.go
@@ -7,15 +7,14 @@ package safe_test
 import (
 	"testing"
 
-	"github.com/onsi/gomega"
-	"github.com/sqreen/go-agent/agent/sqlib"
+	"github.com/sqreen/go-agent/agent/sqlib/safe"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/xerrors"
 )
 
 func TestGo(t *testing.T) {
 	t.Run("without error", func(t *testing.T) {
-		ch := sqlib.Go(func() error {
+		ch := safe.Go(func() error {
 			return nil
 		})
 		err := <-ch
@@ -23,7 +22,7 @@ func TestGo(t *testing.T) {
 	})
 
 	t.Run("with a regular error", func(t *testing.T) {
-		ch := sqlib.Go(func() error {
+		ch := safe.Go(func() error {
 			return xerrors.New("oops")
 		})
 		err := <-ch
@@ -32,53 +31,51 @@ func TestGo(t *testing.T) {
 	})
 
 	t.Run("with a panic string error", func(t *testing.T) {
-		ch := sqlib.Go(func() error {
+		ch := safe.Go(func() error {
 			panic("oops")
 			return nil
 		})
 		err := <-ch
 		require.Error(t, err)
-		var panicErr *sqlib.PanicError
+		var panicErr *safe.PanicError
 		require.Error(t, err)
 		require.True(t, xerrors.As(err, &panicErr))
 		require.Equal(t, "oops", panicErr.Err.Error())
 	})
 
 	t.Run("with a panic error", func(t *testing.T) {
-		ch := sqlib.Go(func() error {
+		ch := safe.Go(func() error {
 			panic(xerrors.New("oops"))
 			return nil
 		})
 		err := <-ch
 		require.Error(t, err)
-		var panicErr *sqlib.PanicError
+		var panicErr *safe.PanicError
 		require.Error(t, err)
 		require.True(t, xerrors.As(err, &panicErr))
 		require.Equal(t, "oops", panicErr.Err.Error())
 	})
 
 	t.Run("with another panic argument type", func(t *testing.T) {
-		ch := sqlib.Go(func() error {
+		ch := safe.Go(func() error {
 			panic(33.7)
 			return nil
 		})
 		err := <-ch
-		gomega.Consistently(ch).Should(gomega.Receive(&err))
 		require.Error(t, err)
-		var panicErr *sqlib.PanicError
+		var panicErr *safe.PanicError
 		require.Error(t, err)
 		require.True(t, xerrors.As(err, &panicErr))
 		require.Equal(t, "33.7", panicErr.Err.Error())
 	})
 
 	t.Run("with a nil panic argument value", func(t *testing.T) {
-		ch := sqlib.Go(func() error {
+		ch := safe.Go(func() error {
 			// This case cannot be differentiated yet.
 			panic(nil)
 			return xerrors.New("oops")
 		})
 		err := <-ch
-		gomega.Consistently(ch).Should(gomega.Receive(&err))
 		require.NoError(t, err)
 	})
 }

--- a/agent/sqlib/safe/go_test.go
+++ b/agent/sqlib/safe/go_test.go
@@ -1,0 +1,84 @@
+// Copyright (c) 2016 - 2019 Sqreen. All Rights Reserved.
+// Please refer to our terms for more information:
+// https://www.sqreen.io/terms.html
+
+package safe_test
+
+import (
+	"testing"
+
+	"github.com/onsi/gomega"
+	"github.com/sqreen/go-agent/agent/sqlib"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/xerrors"
+)
+
+func TestGo(t *testing.T) {
+	t.Run("without error", func(t *testing.T) {
+		ch := sqlib.Go(func() error {
+			return nil
+		})
+		err := <-ch
+		require.NoError(t, err)
+	})
+
+	t.Run("with a regular error", func(t *testing.T) {
+		ch := sqlib.Go(func() error {
+			return xerrors.New("oops")
+		})
+		err := <-ch
+		require.Error(t, err)
+		require.Equal(t, "oops", err.Error())
+	})
+
+	t.Run("with a panic string error", func(t *testing.T) {
+		ch := sqlib.Go(func() error {
+			panic("oops")
+			return nil
+		})
+		err := <-ch
+		require.Error(t, err)
+		var panicErr *sqlib.PanicError
+		require.Error(t, err)
+		require.True(t, xerrors.As(err, &panicErr))
+		require.Equal(t, "oops", panicErr.Err.Error())
+	})
+
+	t.Run("with a panic error", func(t *testing.T) {
+		ch := sqlib.Go(func() error {
+			panic(xerrors.New("oops"))
+			return nil
+		})
+		err := <-ch
+		require.Error(t, err)
+		var panicErr *sqlib.PanicError
+		require.Error(t, err)
+		require.True(t, xerrors.As(err, &panicErr))
+		require.Equal(t, "oops", panicErr.Err.Error())
+	})
+
+	t.Run("with another panic argument type", func(t *testing.T) {
+		ch := sqlib.Go(func() error {
+			panic(33.7)
+			return nil
+		})
+		err := <-ch
+		gomega.Consistently(ch).Should(gomega.Receive(&err))
+		require.Error(t, err)
+		var panicErr *sqlib.PanicError
+		require.Error(t, err)
+		require.True(t, xerrors.As(err, &panicErr))
+		require.Equal(t, "33.7", panicErr.Err.Error())
+	})
+
+	t.Run("with a nil panic argument value", func(t *testing.T) {
+		ch := sqlib.Go(func() error {
+			// This case cannot be differentiated yet.
+			panic(nil)
+			return xerrors.New("oops")
+		})
+		err := <-ch
+		gomega.Consistently(ch).Should(gomega.Receive(&err))
+		require.NoError(t, err)
+	})
+}


### PR DESCRIPTION
This package provides functions making sure panics are safely caught and do not
break the running program. Since panics can stop the program execution if they
are not recovered, we need ways to safely recover and handle them.

Therefore, this package provides simple function call wrappers to call a
function that may panic and its goroutine equivalent. That way, any function can
be safely called and any panic will be returned as a regular function error.