### PR TITLE
Error Management: backoff the agent restart on error or panic (3/5)

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -8,11 +8,6 @@ import (
 	"github.com/sqreen/go-agent/agent/internal"
 )
 
-var agent *internal.Agent
-
 func init() {
-	agent = internal.New()
-	if agent != nil {
-		agent.Start()
-	}
+	internal.Start()
 }

--- a/agent/internal/metrics.go
+++ b/agent/internal/metrics.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/sqreen/go-agent/agent/internal/backend/api"
 	"github.com/sqreen/go-agent/agent/internal/plog"
+	"github.com/sqreen/go-agent/agent/sqlib/sqsafe"
 )
 
 type metricsManager struct {
@@ -59,10 +60,11 @@ func (m *metricsManager) get(name string) *metricsStore {
 	actual, _ := m.metrics.LoadOrStore(name, store)
 	store = actual.(*metricsStore)
 	store.once.Do(func() {
-		go func() {
+		_ = sqsafe.Go(func() error {
 			m.logger.Debug("bookkeeping metrics ", name, " with period ", store.period)
 			store.monitor(m.ctx, time.Now())
-		}()
+			return nil
+		})
 	})
 
 	return store

--- a/agent/sqlib/sqsafe/call.go
+++ b/agent/sqlib/sqsafe/call.go
@@ -2,7 +2,7 @@
 // Please refer to our terms for more information:
 // https://www.sqreen.io/terms.html
 
-package safe
+package sqsafe
 
 import (
 	"fmt"

--- a/agent/sqlib/sqsafe/call_test.go
+++ b/agent/sqlib/sqsafe/call_test.go
@@ -2,80 +2,74 @@
 // Please refer to our terms for more information:
 // https://www.sqreen.io/terms.html
 
-package safe_test
+package sqsafe_test
 
 import (
 	"testing"
 
-	"github.com/sqreen/go-agent/agent/sqlib/safe"
+	"github.com/sqreen/go-agent/agent/sqlib/sqsafe"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/xerrors"
 )
 
-func TestGo(t *testing.T) {
+func TestCall(t *testing.T) {
 	t.Run("without error", func(t *testing.T) {
-		ch := safe.Go(func() error {
+		err := sqsafe.Call(func() error {
 			return nil
 		})
-		err := <-ch
 		require.NoError(t, err)
 	})
 
 	t.Run("with a regular error", func(t *testing.T) {
-		ch := safe.Go(func() error {
+		err := sqsafe.Call(func() error {
 			return xerrors.New("oops")
 		})
-		err := <-ch
 		require.Error(t, err)
 		require.Equal(t, "oops", err.Error())
 	})
 
 	t.Run("with a panic string error", func(t *testing.T) {
-		ch := safe.Go(func() error {
+		err := sqsafe.Call(func() error {
 			panic("oops")
 			return nil
 		})
-		err := <-ch
 		require.Error(t, err)
-		var panicErr *safe.PanicError
+		var panicErr *sqsafe.PanicError
 		require.Error(t, err)
 		require.True(t, xerrors.As(err, &panicErr))
 		require.Equal(t, "oops", panicErr.Err.Error())
 	})
 
 	t.Run("with a panic error", func(t *testing.T) {
-		ch := safe.Go(func() error {
+		err := sqsafe.Call(func() error {
 			panic(xerrors.New("oops"))
 			return nil
 		})
-		err := <-ch
 		require.Error(t, err)
-		var panicErr *safe.PanicError
+		var panicErr *sqsafe.PanicError
 		require.Error(t, err)
 		require.True(t, xerrors.As(err, &panicErr))
 		require.Equal(t, "oops", panicErr.Err.Error())
 	})
 
 	t.Run("with another panic argument type", func(t *testing.T) {
-		ch := safe.Go(func() error {
+		err := sqsafe.Call(func() error {
 			panic(33.7)
 			return nil
 		})
-		err := <-ch
 		require.Error(t, err)
-		var panicErr *safe.PanicError
+		var panicErr *sqsafe.PanicError
 		require.Error(t, err)
 		require.True(t, xerrors.As(err, &panicErr))
 		require.Equal(t, "33.7", panicErr.Err.Error())
 	})
 
 	t.Run("with a nil panic argument value", func(t *testing.T) {
-		ch := safe.Go(func() error {
+		err := sqsafe.Call(func() error {
 			// This case cannot be differentiated yet.
 			panic(nil)
 			return xerrors.New("oops")
 		})
-		err := <-ch
 		require.NoError(t, err)
 	})
 }

--- a/agent/sqlib/sqsafe/doc.go
+++ b/agent/sqlib/sqsafe/doc.go
@@ -10,4 +10,4 @@
 // function that may panic and its goroutine equivalent. That way, any function
 // can be safely called and any panic will be returned as a regular function
 // error.
-package safe
+package sqsafe

--- a/agent/sqlib/sqsafe/go.go
+++ b/agent/sqlib/sqsafe/go.go
@@ -2,7 +2,7 @@
 // Please refer to our terms for more information:
 // https://www.sqreen.io/terms.html
 
-package safe
+package sqsafe
 
 // Go mimics the `go` goroutine built-in to execute function `f` in a goroutine
 // but with the ability to safely recover from any panic occurring while it

--- a/agent/sqlib/sqsafe/go_test.go
+++ b/agent/sqlib/sqsafe/go_test.go
@@ -2,74 +2,80 @@
 // Please refer to our terms for more information:
 // https://www.sqreen.io/terms.html
 
-package safe_test
+package sqsafe_test
 
 import (
 	"testing"
 
-	"github.com/sqreen/go-agent/agent/sqlib/safe"
+	"github.com/sqreen/go-agent/agent/sqlib/sqsafe"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/xerrors"
 )
 
-func TestCall(t *testing.T) {
+func TestGo(t *testing.T) {
 	t.Run("without error", func(t *testing.T) {
-		err := safe.Call(func() error {
+		ch := sqsafe.Go(func() error {
 			return nil
 		})
+		err := <-ch
 		require.NoError(t, err)
 	})
 
 	t.Run("with a regular error", func(t *testing.T) {
-		err := safe.Call(func() error {
+		ch := sqsafe.Go(func() error {
 			return xerrors.New("oops")
 		})
+		err := <-ch
 		require.Error(t, err)
 		require.Equal(t, "oops", err.Error())
 	})
 
 	t.Run("with a panic string error", func(t *testing.T) {
-		err := safe.Call(func() error {
+		ch := sqsafe.Go(func() error {
 			panic("oops")
 			return nil
 		})
+		err := <-ch
 		require.Error(t, err)
-		var panicErr *safe.PanicError
+		var panicErr *sqsafe.PanicError
 		require.Error(t, err)
 		require.True(t, xerrors.As(err, &panicErr))
 		require.Equal(t, "oops", panicErr.Err.Error())
 	})
 
 	t.Run("with a panic error", func(t *testing.T) {
-		err := safe.Call(func() error {
+		ch := sqsafe.Go(func() error {
 			panic(xerrors.New("oops"))
 			return nil
 		})
+		err := <-ch
 		require.Error(t, err)
-		var panicErr *safe.PanicError
+		var panicErr *sqsafe.PanicError
 		require.Error(t, err)
 		require.True(t, xerrors.As(err, &panicErr))
 		require.Equal(t, "oops", panicErr.Err.Error())
 	})
 
 	t.Run("with another panic argument type", func(t *testing.T) {
-		err := safe.Call(func() error {
+		ch := sqsafe.Go(func() error {
 			panic(33.7)
 			return nil
 		})
+		err := <-ch
 		require.Error(t, err)
-		var panicErr *safe.PanicError
+		var panicErr *sqsafe.PanicError
 		require.Error(t, err)
 		require.True(t, xerrors.As(err, &panicErr))
 		require.Equal(t, "33.7", panicErr.Err.Error())
 	})
 
 	t.Run("with a nil panic argument value", func(t *testing.T) {
-		err := safe.Call(func() error {
+		ch := sqsafe.Go(func() error {
 			// This case cannot be differentiated yet.
 			panic(nil)
 			return xerrors.New("oops")
 		})
+		err := <-ch
 		require.NoError(t, err)
 	})
 }

--- a/agent/sqlib/sqtime/backoff.go
+++ b/agent/sqlib/sqtime/backoff.go
@@ -1,0 +1,29 @@
+// Copyright (c) 2016 - 2019 Sqreen. All Rights Reserved.
+// Please refer to our terms for more information:
+// https://www.sqreen.io/terms.html
+
+package sqtime
+
+import "time"
+
+type Backoff struct {
+	current, max time.Duration
+	rate         int64
+}
+
+func NewBackoff(min, max time.Duration, rate int64) *Backoff {
+	return &Backoff{
+		current: min,
+		max:     max,
+		rate:    rate,
+	}
+}
+
+func (b *Backoff) Next() (duration time.Duration, max bool) {
+	if b.current >= b.max {
+		b.current = b.max
+		return b.current, true
+	}
+	b.current *= time.Duration(b.rate)
+	return b.current, false
+}


### PR DESCRIPTION
- Backoff restart the agent when it returns an error or a panic, which means it couldn't be handled.
- Replace bare calls to the `go` builtin by the `safe.Go()` wrapper in order to catch goroutine panics (to avoid program crashes).