### PR TITLE
Redirection security response for playbooks

### DIFF
--- a/agent/internal/actor/action.go
+++ b/agent/internal/actor/action.go
@@ -13,9 +13,10 @@ import (
 
 // Action kinds.
 const (
-	actionKindBlockIP    = "block_ip"
-	actionKindBlockUser  = "block_user"
-	actionKindRedirectIP = "redirect_ip"
+	actionKindBlockIP      = "block_ip"
+	actionKindBlockUser    = "block_user"
+	actionKindRedirectIP   = "redirect_ip"
+	actionKindRedirectUser = "redirect_user"
 )
 
 // Action is an interface common to each concrete action type stored in the data

--- a/agent/internal/actor/action.go
+++ b/agent/internal/actor/action.go
@@ -5,13 +5,17 @@
 package actor
 
 import (
+	"net/url"
 	"time"
+
+	"github.com/sqreen/go-agent/agent/sqlib/sqerrors"
 )
 
 // Action kinds.
 const (
-	actionKind_BlockIP   = "block_ip"
-	actionKind_BlockUser = "block_user"
+	actionKindBlockIP    = "block_ip"
+	actionKindBlockUser  = "block_user"
+	actionKindRedirectIP = "redirect_ip"
 )
 
 // Action is an interface common to each concrete action type stored in the data
@@ -37,6 +41,24 @@ func newBlockAction(id string) blockAction {
 }
 
 func (a blockAction) ActionID() string {
+	return a.ID
+}
+
+type redirectAction struct {
+	ID, URL string
+}
+
+func newRedirectAction(id, location string) (*redirectAction, error) {
+	if _, err := url.ParseRequestURI(location); err != nil {
+		return nil, sqerrors.Wrap(err, "validation of the redirection location url")
+	}
+	return &redirectAction{
+		ID:  id,
+		URL: location,
+	}, nil
+}
+
+func (a *redirectAction) ActionID() string {
 	return a.ID
 }
 

--- a/agent/internal/actor/action_test.go
+++ b/agent/internal/actor/action_test.go
@@ -16,40 +16,85 @@ import (
 )
 
 func TestAction(t *testing.T) {
-	action := newBlockAction(testlib.RandString(1, 20))
+	t.Run("Blocking action", func(t *testing.T) {
+		action := newBlockAction(testlib.RandString(1, 20))
 
-	t.Run("with duration", func(t *testing.T) {
-		t.Run("not expired", func(t *testing.T) {
-			action := withDuration(action, 10*time.Hour)
-			require.False(t, action.Expired())
+		t.Run("with duration", func(t *testing.T) {
+			t.Run("not expired", func(t *testing.T) {
+				action := withDuration(action, 10*time.Hour)
+				require.False(t, action.Expired())
+			})
+			t.Run("expired", func(t *testing.T) {
+				action := withDuration(action, 0)
+				require.True(t, action.Expired())
+			})
 		})
-		t.Run("expired", func(t *testing.T) {
-			action := withDuration(action, 0)
-			require.True(t, action.Expired())
+
+		t.Run("HTTP Handler", func(t *testing.T) {
+			t.Run("Block IP", func(t *testing.T) {
+				handler, err := NewIPActionHTTPHandler(action, net.IPv4(1, 2, 3, 4))
+				require.NotNil(t, handler)
+				require.Nil(t, err)
+				// Use the handler
+				req := httptest.NewRequest(http.MethodPost, "/", nil)
+				rec := httptest.NewRecorder()
+				handler.ServeHTTP(rec, req)
+				require.Equal(t, rec.Code, 500)
+				// TODO: check the sdk event
+			})
+
+			t.Run("Block User", func(t *testing.T) {
+				handler := NewUserActionHTTPHandler(action, map[string]string{"uid": testlib.RandString(1, 250)})
+				require.NotNil(t, handler)
+				// Use the handler
+				req := httptest.NewRequest(http.MethodPost, "/", nil)
+				rec := httptest.NewRecorder()
+				handler.ServeHTTP(rec, req)
+				require.Equal(t, rec.Code, 500)
+				// TODO: check the sdk event
+			})
 		})
 	})
 
-	t.Run("HTTP Handler", func(t *testing.T) {
-		t.Run("Block IP", func(t *testing.T) {
-			handler := NewIPActionHTTPHandler(action, net.IPv4(1, 2, 3, 4))
-			require.NotNil(t, handler)
-			// Use the handler
-			req := httptest.NewRequest(http.MethodPost, "/", nil)
-			rec := httptest.NewRecorder()
-			handler.ServeHTTP(rec, req)
-			require.Equal(t, rec.Code, 500)
-			// TODO: check the sdk event
+	t.Run("Redirection action", func(t *testing.T) {
+		t.Run("invalid location url", func(t *testing.T) {
+			action, err := newRedirectAction(testlib.RandString(1, 20), "http//toto")
+			require.Nil(t, action)
+			require.Error(t, err)
 		})
 
-		t.Run("Block User", func(t *testing.T) {
-			handler := NewUserActionHTTPHandler(action, map[string]string{"uid": testlib.RandString(1, 250)})
-			require.NotNil(t, handler)
-			// Use the handler
-			req := httptest.NewRequest(http.MethodPost, "/", nil)
-			rec := httptest.NewRecorder()
-			handler.ServeHTTP(rec, req)
-			require.Equal(t, rec.Code, 500)
-			// TODO: check the sdk event
+		t.Run("valid location url", func(t *testing.T) {
+			action, err := newRedirectAction(testlib.RandString(1, 20), "http://sqreen.com")
+			require.NotNil(t, action)
+			require.NoError(t, err)
+
+			t.Run("with duration", func(t *testing.T) {
+				t.Run("not expired", func(t *testing.T) {
+					action := withDuration(action, 10*time.Hour)
+					require.False(t, action.Expired())
+				})
+				t.Run("expired", func(t *testing.T) {
+					action := withDuration(action, 0)
+					require.True(t, action.Expired())
+				})
+			})
+
+			t.Run("HTTP Handler", func(t *testing.T) {
+				t.Run("Redirect IP", func(t *testing.T) {
+					handler, err := NewIPActionHTTPHandler(action, net.IPv4(1, 2, 3, 4))
+					require.NotNil(t, handler)
+					require.Nil(t, err)
+					// Use the handler
+					req := httptest.NewRequest(http.MethodPost, "/", nil)
+					rec := httptest.NewRecorder()
+					handler.ServeHTTP(rec, req)
+					require.Equal(t, rec.Code, http.StatusSeeOther)
+					require.Equal(t, rec.Header().Get("Location"), action.URL)
+					// TODO: check the sdk event
+				})
+
+			})
 		})
 	})
+
 }

--- a/agent/internal/actor/action_test.go
+++ b/agent/internal/actor/action_test.go
@@ -44,7 +44,8 @@ func TestAction(t *testing.T) {
 			})
 
 			t.Run("Block User", func(t *testing.T) {
-				handler := NewUserActionHTTPHandler(action, map[string]string{"uid": testlib.RandString(1, 250)})
+				handler, err := NewUserActionHTTPHandler(action, map[string]string{"uid": testlib.RandString(1, 250)})
+				require.NoError(t, err)
 				require.NotNil(t, handler)
 				// Use the handler
 				req := httptest.NewRequest(http.MethodPost, "/", nil)
@@ -93,8 +94,19 @@ func TestAction(t *testing.T) {
 					// TODO: check the sdk event
 				})
 
+				t.Run("Redirect User", func(t *testing.T) {
+					handler, err := NewUserActionHTTPHandler(action, map[string]string{"uid": testlib.RandString(1, 250)})
+					require.NoError(t, err)
+					require.NotNil(t, handler)
+					// Use the handler
+					req := httptest.NewRequest(http.MethodPost, "/", nil)
+					rec := httptest.NewRecorder()
+					handler.ServeHTTP(rec, req)
+					require.Equal(t, rec.Code, http.StatusSeeOther)
+					require.Equal(t, rec.Header().Get("Location"), action.URL)
+					// TODO: check the sdk event
+				})
 			})
 		})
 	})
-
 }

--- a/agent/internal/actor/actor.go
+++ b/agent/internal/actor/actor.go
@@ -213,6 +213,8 @@ func (s *actionStore) addAction(action api.ActionsPackResponse_Action) (err erro
 		err = s.addBlockUserAction(action)
 	case actionKindRedirectIP:
 		err = s.addRedirectIPAction(action)
+	case actionKindRedirectUser:
+		err = s.addRedirectUserAction(action)
 	}
 	return err
 }
@@ -248,6 +250,23 @@ func (s *actionStore) addRedirectIPAction(action api.ActionsPackResponse_Action)
 		return errors.Errorf("could not add action `%s`: empty list of CIDRs", action.ActionId)
 	}
 	return s.addCIDRList(cidrs, redirectIP)
+}
+
+func (s *actionStore) addRedirectUserAction(action api.ActionsPackResponse_Action) error {
+	duration, err := float64ToDuration(action.Duration)
+	if err != nil {
+		return err
+	}
+	var redirectUser Action
+	redirectUser, err = newRedirectAction(action.ActionId, action.Parameters.Url)
+	if duration > 0 {
+		redirectUser = withDuration(redirectUser, duration)
+	}
+	users := action.Parameters.Users
+	if len(users) == 0 {
+		return errors.Errorf("could not add action `%s`: empty list of users", action.ActionId)
+	}
+	return s.addUserList(users, redirectUser)
 }
 
 // Convert a float64 to a `time.Duration` by making sure it doesn't overflow.

--- a/agent/internal/actor/actor.go
+++ b/agent/internal/actor/actor.go
@@ -207,10 +207,12 @@ func newActionStore(actions []api.ActionsPackResponse_Action) (*actionStore, err
 
 func (s *actionStore) addAction(action api.ActionsPackResponse_Action) (err error) {
 	switch action.Action {
-	case actionKind_BlockIP:
+	case actionKindBlockIP:
 		err = s.addBlockIPAction(action)
-	case actionKind_BlockUser:
+	case actionKindBlockUser:
 		err = s.addBlockUserAction(action)
+	case actionKindRedirectIP:
+		err = s.addRedirectIPAction(action)
 	}
 	return err
 }
@@ -229,6 +231,23 @@ func (s *actionStore) addBlockIPAction(action api.ActionsPackResponse_Action) er
 		return errors.Errorf("could not add action `%s`: empty list of CIDRs", action.ActionId)
 	}
 	return s.addCIDRList(cidrs, blockIP)
+}
+
+func (s *actionStore) addRedirectIPAction(action api.ActionsPackResponse_Action) error {
+	duration, err := float64ToDuration(action.Duration)
+	if err != nil {
+		return err
+	}
+	var redirectIP Action
+	redirectIP, err = newRedirectAction(action.ActionId, action.Parameters.Url)
+	if duration > 0 {
+		redirectIP = withDuration(redirectIP, duration)
+	}
+	cidrs := action.Parameters.IpCidr
+	if len(cidrs) == 0 {
+		return errors.Errorf("could not add action `%s`: empty list of CIDRs", action.ActionId)
+	}
+	return s.addCIDRList(cidrs, redirectIP)
 }
 
 // Convert a float64 to a `time.Duration` by making sure it doesn't overflow.

--- a/agent/internal/actor/http.go
+++ b/agent/internal/actor/http.go
@@ -18,9 +18,10 @@ import (
 
 // Event names.
 const (
-	blockIPEventName    = "app.sqreen.action.block_ip"
-	blockUserEventName  = "app.sqreen.action.block_user"
-	redirectIPEventName = "app.sqreen.action.redirect_ip"
+	blockIPEventName      = "app.sqreen.action.block_ip"
+	blockUserEventName    = "app.sqreen.action.block_user"
+	redirectIPEventName   = "app.sqreen.action.redirect_ip"
+	redirectUserEventName = "app.sqreen.action.redirect_user"
 )
 
 // NewIPActionHTTPHandler returns a HTTP handler that should be applied at the
@@ -37,8 +38,14 @@ func NewIPActionHTTPHandler(action Action, ip net.IP) (http.Handler, error) {
 
 // NewUserActionHTTPHandler returns a HTTP handler that should be applied at
 // the request handler level to perform the security response.
-func NewUserActionHTTPHandler(action Action, userID map[string]string) http.Handler {
-	return newBlockHTTPHandler(blockUserEventName, newBlockedUserEventProperties(action, userID))
+func NewUserActionHTTPHandler(action Action, userID map[string]string) (http.Handler, error) {
+	switch actual := action.(type) {
+	case blockAction:
+		return newBlockHTTPHandler(blockUserEventName, newBlockedUserEventProperties(actual, userID)), nil
+	case *redirectAction:
+		return newRedirectHTTPHandler(redirectUserEventName, newRedirectedUserEventProperties(actual, userID), actual.URL), nil
+	}
+	return nil, sqerrors.Errorf("unexpected user action type `%T`", action)
 }
 
 // blockHTTPHandler implements the http.Handler interface and holds the event
@@ -96,7 +103,7 @@ func (p *blockedIPEventProperties) GetIpAddress() string {
 	return p.ip.String()
 }
 
-// blockedIPEventProperties implements `types.EventProperties` to be marshaled
+// blockedUserEventProperties implements `types.EventProperties` to be marshaled
 // to an SDK event property structure.
 type blockedUserEventProperties struct {
 	action Action
@@ -120,10 +127,40 @@ func (p *blockedUserEventProperties) MarshalJSON() ([]byte, error) {
 func (p *blockedUserEventProperties) GetActionId() string {
 	return p.action.ActionID()
 }
-func (p *blockedUserEventProperties) GetOutput() api.BlockedUserEventProperties_Output {
-	return *api.NewBlockedUserEventProperties_OutputFromFace(p)
+func (p *blockedUserEventProperties) GetOutput() api.BlockedUserEventPropertiesOutput {
+	return *api.NewBlockedUserEventPropertiesOutputFromFace(p)
 }
 func (p *blockedUserEventProperties) GetUser() map[string]string {
+	return p.userID
+}
+
+// redirectedUserEventProperties implements `types.EventProperties` to be marshaled
+// to an SDK event property structure.
+type redirectedUserEventProperties struct {
+	action Action
+	userID map[string]string
+}
+
+// Static assert that redirectedUserEventProperties implements `types.EventProperties`.
+var _ types.EventProperties = &redirectedUserEventProperties{}
+
+func newRedirectedUserEventProperties(action Action, userID map[string]string) *redirectedUserEventProperties {
+	return &redirectedUserEventProperties{
+		action: action,
+		userID: userID,
+	}
+}
+func (p *redirectedUserEventProperties) MarshalJSON() ([]byte, error) {
+	pb := api.NewRedirectedUserEventPropertiesFromFace(p)
+	return json.Marshal(pb)
+}
+func (p *redirectedUserEventProperties) GetActionId() string {
+	return p.action.ActionID()
+}
+func (p *redirectedUserEventProperties) GetOutput() api.RedirectedUserEventPropertiesOutput {
+	return *api.NewRedirectedUserEventPropertiesOutputFromFace(p)
+}
+func (p *redirectedUserEventProperties) GetUser() map[string]string {
 	return p.userID
 }
 

--- a/agent/internal/backend/api/api.go
+++ b/agent/internal/backend/api/api.go
@@ -181,10 +181,17 @@ type RuleData struct {
 
 type RuleDataEntry Struct
 
-const CustomErrorPageType = "custom_error_page"
+const (
+	CustomErrorPageType = "custom_error_page"
+	RedirectionType     = "redirection"
+)
 
 type CustomErrorPageRuleDataEntry struct {
 	StatusCode int `json:"status_code"`
+}
+
+type RedirectionRuleDataEntry struct {
+	RedirectionURL string `json:"redirection_url"`
 }
 
 type Dependency struct {

--- a/agent/internal/backend/api/api.go
+++ b/agent/internal/backend/api/api.go
@@ -799,11 +799,11 @@ func NewBlockedIPEventProperties_OutputFromFace(that BlockedIPEventProperties_Ou
 }
 
 type BlockedUserEventProperties struct {
-	ActionId string                            `json:"action_id"`
-	Output   BlockedUserEventProperties_Output `json:"output"`
+	ActionId string                           `json:"action_id"`
+	Output   BlockedUserEventPropertiesOutput `json:"output"`
 }
 
-type BlockedUserEventProperties_Output struct {
+type BlockedUserEventPropertiesOutput struct {
 	User map[string]string `json:"user"`
 }
 
@@ -816,15 +816,15 @@ func NewBlockedUserEventPropertiesFromFace(that BlockedUserEventPropertiesFace) 
 
 type BlockedUserEventPropertiesFace interface {
 	GetActionId() string
-	GetOutput() BlockedUserEventProperties_Output
+	GetOutput() BlockedUserEventPropertiesOutput
 }
 
-type BlockedUserEventProperties_OutputFace interface {
+type BlockedUserEventPropertiesOutputFace interface {
 	GetUser() map[string]string
 }
 
-func NewBlockedUserEventProperties_OutputFromFace(that BlockedUserEventProperties_OutputFace) *BlockedUserEventProperties_Output {
-	this := &BlockedUserEventProperties_Output{}
+func NewBlockedUserEventPropertiesOutputFromFace(that BlockedUserEventPropertiesOutputFace) *BlockedUserEventPropertiesOutput {
+	this := &BlockedUserEventPropertiesOutput{}
 	this.User = that.GetUser()
 	return this
 }
@@ -861,6 +861,37 @@ func NewRedirectedIPEventPropertiesOutputFromFace(that RedirectedIPEventProperti
 		IpAddress: that.GetIpAddress(),
 		URL:       that.GetURL(),
 	}
+}
+
+type RedirectedUserEventProperties struct {
+	ActionId string                              `json:"action_id"`
+	Output   RedirectedUserEventPropertiesOutput `json:"output"`
+}
+
+type RedirectedUserEventPropertiesOutput struct {
+	User map[string]string `json:"user"`
+}
+
+func NewRedirectedUserEventPropertiesFromFace(that RedirectedUserEventPropertiesFace) *RedirectedUserEventProperties {
+	return &RedirectedUserEventProperties{
+		ActionId: that.GetActionId(),
+		Output:   that.GetOutput(),
+	}
+}
+
+type RedirectedUserEventPropertiesFace interface {
+	GetActionId() string
+	GetOutput() RedirectedUserEventPropertiesOutput
+}
+
+type RedirectedUserEventPropertiesOutputFace interface {
+	GetUser() map[string]string
+}
+
+func NewRedirectedUserEventPropertiesOutputFromFace(that RedirectedUserEventPropertiesOutputFace) *RedirectedUserEventPropertiesOutput {
+	this := &RedirectedUserEventPropertiesOutput{}
+	this.User = that.GetUser()
+	return this
 }
 
 type RulesPackResponse struct {

--- a/agent/internal/backend/api/api.go
+++ b/agent/internal/backend/api/api.go
@@ -829,6 +829,40 @@ func NewBlockedUserEventProperties_OutputFromFace(that BlockedUserEventPropertie
 	return this
 }
 
+type RedirectedIPEventProperties struct {
+	ActionId string                            `json:"action_id,omitempty"`
+	Output   RedirectedIPEventPropertiesOutput `json:"output"`
+}
+
+type RedirectedIPEventPropertiesOutput struct {
+	IpAddress string `json:"ip_address"`
+	URL       string `json:"url"`
+}
+
+func NewRedirectedIPEventPropertiesFromFace(that RedirectedIPEventPropertiesFace) *RedirectedIPEventProperties {
+	return &RedirectedIPEventProperties{
+		ActionId: that.GetActionId(),
+		Output:   that.GetOutput(),
+	}
+}
+
+type RedirectedIPEventPropertiesFace interface {
+	GetActionId() string
+	GetOutput() RedirectedIPEventPropertiesOutput
+}
+
+type RedirectedIPEventPropertiesOutputFace interface {
+	GetIpAddress() string
+	GetURL() string
+}
+
+func NewRedirectedIPEventPropertiesOutputFromFace(that RedirectedIPEventPropertiesOutputFace) *RedirectedIPEventPropertiesOutput {
+	return &RedirectedIPEventPropertiesOutput{
+		IpAddress: that.GetIpAddress(),
+		URL:       that.GetURL(),
+	}
+}
+
 type RulesPackResponse struct {
 	PackID string `json:"pack_id"`
 	Rules  []Rule `json:"rules"`

--- a/agent/internal/backend/api/jsonpb.go
+++ b/agent/internal/backend/api/jsonpb.go
@@ -8,7 +8,6 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/pkg/errors"
 	"github.com/sqreen/go-agent/agent/sqlib/sqerrors"
 )
 
@@ -122,8 +121,10 @@ func (v *RuleDataEntry) UnmarshalJSON(data []byte) error {
 	switch t := discriminant.Type; t {
 	case CustomErrorPageType:
 		value = &CustomErrorPageRuleDataEntry{}
+	case RedirectionType:
+		value = &RedirectionRuleDataEntry{}
 	default:
-		return sqerrors.Wrap(errors.Errorf("unexpected type of rule data value `%s`", t), "json unmarshal")
+		return sqerrors.Errorf("unexpected type of rule data value `%s`", t)
 	}
 
 	if err := json.Unmarshal(data, value); err != nil {

--- a/agent/internal/request.go
+++ b/agent/internal/request.go
@@ -17,6 +17,7 @@ import (
 	"github.com/sqreen/go-agent/agent/internal/actor"
 	"github.com/sqreen/go-agent/agent/internal/backend/api"
 	"github.com/sqreen/go-agent/agent/internal/config"
+	"github.com/sqreen/go-agent/agent/sqlib/sqerrors"
 	"github.com/sqreen/go-agent/agent/types"
 )
 
@@ -158,7 +159,10 @@ func (ctx *HTTPRequestRecord) SecurityResponse() http.Handler {
 	if !exists {
 		return nil
 	}
-	ctx.lastSecurityResponseHandler = actor.NewIPActionHTTPHandler(action, ip)
+	ctx.lastSecurityResponseHandler, err = actor.NewIPActionHTTPHandler(action, ip)
+	if err != nil {
+		agent.logger.Error(sqerrors.Wrap(err, "security response"))
+	}
 	return ctx.lastSecurityResponseHandler
 }
 

--- a/agent/internal/request.go
+++ b/agent/internal/request.go
@@ -161,7 +161,7 @@ func (ctx *HTTPRequestRecord) SecurityResponse() http.Handler {
 	}
 	ctx.lastSecurityResponseHandler, err = actor.NewIPActionHTTPHandler(action, ip)
 	if err != nil {
-		agent.logger.Error(sqerrors.Wrap(err, "ip security response"))
+		agent.logger.Error(sqerrors.Wrap(err, fmt.Sprintf("could not create the http handler for an ip security response: action `%v` - ip `%s`:", action.ActionID(), ip)))
 	}
 	return ctx.lastSecurityResponseHandler
 }
@@ -182,7 +182,7 @@ func (ctx *HTTPRequestRecord) UserSecurityResponse() http.Handler {
 	var err error
 	ctx.lastUserSecurityResponseHandler, err = actor.NewUserActionHTTPHandler(action, userID)
 	if err != nil {
-		agent.logger.Error(sqerrors.Wrap(err, "user security response"))
+		agent.logger.Error(sqerrors.Wrap(err, fmt.Sprintf("could not create the http handler for a user security response: action `%v` - user `%v`:", action.ActionID(), userID)))
 	}
 	return ctx.lastUserSecurityResponseHandler
 }

--- a/agent/internal/request.go
+++ b/agent/internal/request.go
@@ -161,7 +161,7 @@ func (ctx *HTTPRequestRecord) SecurityResponse() http.Handler {
 	}
 	ctx.lastSecurityResponseHandler, err = actor.NewIPActionHTTPHandler(action, ip)
 	if err != nil {
-		agent.logger.Error(sqerrors.Wrap(err, "security response"))
+		agent.logger.Error(sqerrors.Wrap(err, "ip security response"))
 	}
 	return ctx.lastSecurityResponseHandler
 }
@@ -179,7 +179,11 @@ func (ctx *HTTPRequestRecord) UserSecurityResponse() http.Handler {
 	if !exists {
 		return nil
 	}
-	ctx.lastUserSecurityResponseHandler = actor.NewUserActionHTTPHandler(action, userID)
+	var err error
+	ctx.lastUserSecurityResponseHandler, err = actor.NewUserActionHTTPHandler(action, userID)
+	if err != nil {
+		agent.logger.Error(sqerrors.Wrap(err, "user security response"))
+	}
 	return ctx.lastUserSecurityResponseHandler
 }
 

--- a/agent/internal/rule/callback.go
+++ b/agent/internal/rule/callback.go
@@ -24,6 +24,8 @@ func NewCallbacks(name string, data []interface{}) (prolog, epilog sqhook.Callba
 		return nil, nil, sqerrors.Errorf("undefined callback name `%s`", name)
 	case "WriteCustomErrorPage":
 		callbacksCtor = callback.NewWriteCustomErrorPageCallbacks
+	case "WriteHTTPRedirection":
+		callbacksCtor = callback.NewWriteHTTPRedirectionCallbacks
 	}
 	return callbacksCtor(data)
 }

--- a/agent/internal/rule/callback/write-http-redirection.go
+++ b/agent/internal/rule/callback/write-http-redirection.go
@@ -1,0 +1,52 @@
+// Copyright (c) 2016 - 2019 Sqreen. All Rights Reserved.
+// Please refer to our terms for more information:
+// https://www.sqreen.io/terms.html
+
+package callback
+
+import (
+	"net/http"
+	"net/url"
+
+	"github.com/sqreen/go-agent/agent/internal/backend/api"
+	"github.com/sqreen/go-agent/agent/sqlib/sqerrors"
+	"github.com/sqreen/go-agent/agent/sqlib/sqhook"
+)
+
+// NewWriteHTTPRedirectionCallbacks returns the native prolog and epilog
+// callbacks modifying the arguments of `httphandler.WriteResponse` in order to
+// modify the http status code and headers in order to perform an HTTP
+// redirection to the URL provided by the rule's data.
+func NewWriteHTTPRedirectionCallbacks(data []interface{}) (prolog, epilog sqhook.Callback, err error) {
+	var redirectionURL string
+	if len(data) > 0 {
+		d0 := data[0]
+		cfg, ok := d0.(*api.RedirectionRuleDataEntry)
+		if !ok {
+			return nil, nil, sqerrors.Errorf("unexpected callback data type: got `%T` instead of `*api.CustomErrorPageRuleDataEntry`", d0)
+		}
+		redirectionURL = cfg.RedirectionURL
+	}
+	if redirectionURL == "" {
+		return nil, nil, sqerrors.New("unexpected empty redirection url")
+	}
+	if _, err := url.ParseRequestURI(redirectionURL); err != nil {
+		return nil, nil, sqerrors.Wrap(err, "validation error of the redirection url")
+	}
+	return newWriteHTTPRedirectionPrologCallback(redirectionURL), nil, nil
+}
+
+type WriteHTTPRedirectionPrologCallbackType = func(*sqhook.Context, *http.ResponseWriter, **http.Request, *http.Header, *int, *[]byte) error
+
+// The prolog callback modifies the function arguments in order to perform an
+// HTTP redirection.
+func newWriteHTTPRedirectionPrologCallback(url string) WriteHTTPRedirectionPrologCallbackType {
+	return func(_ *sqhook.Context, _ *http.ResponseWriter, _ **http.Request, callerHeaders *http.Header, callerStatusCode *int, _ *[]byte) error {
+		*callerStatusCode = http.StatusSeeOther
+		if *callerHeaders == nil {
+			*callerHeaders = make(http.Header)
+		}
+		callerHeaders.Set("Location", url)
+		return nil
+	}
+}

--- a/agent/internal/rule/callback/write-http-redirection_test.go
+++ b/agent/internal/rule/callback/write-http-redirection_test.go
@@ -1,0 +1,57 @@
+// Copyright (c) 2016 - 2019 Sqreen. All Rights Reserved.
+// Please refer to our terms for more information:
+// https://www.sqreen.io/terms.html
+
+package callback_test
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/sqreen/go-agent/agent/internal/backend/api"
+	"github.com/sqreen/go-agent/agent/internal/rule/callback"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewWriteHTTPRedirectionCallbacks(t *testing.T) {
+	t.Run("with incorrect data", func(t *testing.T) {
+		for _, data := range [][]interface{}{
+			nil,
+			{},
+			{33},
+			{"yet another wrong type"},
+			{&api.CustomErrorPageRuleDataEntry{}},
+			{&api.RedirectionRuleDataEntry{}},
+			{&api.RedirectionRuleDataEntry{"http//sqreen.com"}},
+		} {
+			prolog, epilog, err := callback.NewWriteHTTPRedirectionCallbacks(data)
+			require.Error(t, err)
+			require.Nil(t, prolog)
+			require.Nil(t, epilog)
+		}
+	})
+
+	t.Run("with correct data", func(t *testing.T) {
+		// Instantiate the callback with the given correct rule data
+		expectedURL := "http://sqreen.com"
+		prolog, epilog, err := callback.NewWriteHTTPRedirectionCallbacks([]interface{}{
+			&api.RedirectionRuleDataEntry{RedirectionURL: expectedURL},
+		})
+		require.NoError(t, err)
+		require.NotNil(t, prolog)
+		require.Nil(t, epilog)
+		// Call it and check the behaviour follows the rule's data
+		actualProlog, ok := prolog.(callback.WriteHTTPRedirectionPrologCallbackType)
+		require.True(t, ok)
+		var (
+			statusCode int
+			headers    http.Header
+		)
+		err = actualProlog(nil, nil, nil, &headers, &statusCode, nil)
+		// Check it behaves as expected
+		require.NoError(t, err)
+		require.Equal(t, http.StatusSeeOther, statusCode)
+		require.NotNil(t, headers)
+		require.Equal(t, expectedURL, headers.Get("Location"))
+	})
+}


### PR DESCRIPTION
Implement the redirection security response of playbooks:

- [x] Add a redirection action type whose HTTP handler performs a HTTP redirection.
- [x] Add the redirection security response for IP addresses
- [x] Add a redirection callback for blocking responses (A blocking action can actually be a redirection according to the settings)

This leads to the full support of playbooks.