### PR TITLE
Security headers

### DIFF
--- a/agent/internal/backend/api/jsonpb.go
+++ b/agent/internal/backend/api/jsonpb.go
@@ -114,7 +114,16 @@ func (v *RuleDataEntry) UnmarshalJSON(data []byte) error {
 		Type string `json:"type"`
 	}
 	if err := json.Unmarshal(data, &discriminant); err != nil {
-		return sqerrors.Wrap(err, "json unmarshal")
+		// Some rules come with values not discriminated by a `type` key
+		// So we try other types
+		// TODO: fix this in the API
+		var strArray []string
+		err = json.Unmarshal(data, &strArray)
+		if err != nil {
+			return err
+		}
+		v.Value = strArray
+		return nil
 	}
 
 	var value interface{}

--- a/agent/internal/rule/callback.go
+++ b/agent/internal/rule/callback.go
@@ -26,6 +26,8 @@ func NewCallbacks(name string, data []interface{}) (prolog, epilog sqhook.Callba
 		callbacksCtor = callback.NewWriteCustomErrorPageCallbacks
 	case "WriteHTTPRedirection":
 		callbacksCtor = callback.NewWriteHTTPRedirectionCallbacks
+	case "AddSecurityHeaders":
+		callbacksCtor = callback.NewAddSecurityHeadersCallbacks
 	}
 	return callbacksCtor(data)
 }

--- a/agent/internal/rule/callback/add-security-headers.go
+++ b/agent/internal/rule/callback/add-security-headers.go
@@ -1,0 +1,50 @@
+// Copyright (c) 2016 - 2019 Sqreen. All Rights Reserved.
+// Please refer to our terms for more information:
+// https://www.sqreen.io/terms.html
+
+package callback
+
+import (
+	"net/http"
+
+	"github.com/sqreen/go-agent/agent/sqlib/sqerrors"
+	"github.com/sqreen/go-agent/agent/sqlib/sqhook"
+)
+
+// NewAddSecurityHeadersCallbacks returns the native prolog and epilog callbacks
+// to be hooked to `sqhttp.MiddlewareWithError` in order to add HTTP headers
+// provided by the rule's data.
+func NewAddSecurityHeadersCallbacks(data []interface{}) (prolog, epilog sqhook.Callback, err error) {
+	var headers = make(http.Header, len(data))
+	for _, headersKV := range data {
+		// TODO: move to a structured list of headers to avoid dynamic type checking
+		kv, ok := headersKV.([]string)
+		if !ok {
+			err = sqerrors.Errorf("unexpected number of values: header key and values are expected but got `%d` values instead", len(kv))
+			return
+		}
+		if len(kv) != 2 {
+			err = sqerrors.Errorf("unexpected number of values: header key and values are expected but got `%d` values instead", len(kv))
+			return
+		}
+		headers.Set(kv[0], kv[1])
+	}
+	if len(headers) == 0 {
+		return nil, nil, sqerrors.New("there are no headers to add")
+	}
+	return newAddHeadersPrologCallback(headers), nil, nil
+}
+
+type AddSecurityHeadersPrologCallbackType = func(*sqhook.Context, *http.ResponseWriter) error
+
+// The prolog callback modifies the function arguments in order to replace the
+// written status code and body.
+func newAddHeadersPrologCallback(headers http.Header) AddSecurityHeadersPrologCallbackType {
+	return func(_ *sqhook.Context, w *http.ResponseWriter) error {
+		responseHeaders := (*w).Header()
+		for k, v := range headers {
+			responseHeaders[k] = v
+		}
+		return nil
+	}
+}

--- a/agent/internal/rule/callback/add-security-headers_test.go
+++ b/agent/internal/rule/callback/add-security-headers_test.go
@@ -1,0 +1,59 @@
+// Copyright (c) 2016 - 2019 Sqreen. All Rights Reserved.
+// Please refer to our terms for more information:
+// https://www.sqreen.io/terms.html
+
+package callback_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/sqreen/go-agent/agent/internal/rule/callback"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewAddSecurityHeadersCallbacks(t *testing.T) {
+	t.Run("with incorrect data", func(t *testing.T) {
+		for _, data := range [][]interface{}{
+			nil,
+			{},
+			{33},
+			{"yet another wrong type"},
+			{[]string{}},
+			{nil},
+			{[]string{"one"}},
+			{[]string{"one", "two", "three"}},
+		} {
+			prolog, epilog, err := callback.NewAddSecurityHeadersCallbacks(data)
+			require.Error(t, err)
+			require.Nil(t, prolog)
+			require.Nil(t, epilog)
+		}
+	})
+
+	t.Run("with correct data", func(t *testing.T) {
+		// Instantiate the callback with the given correct rule data
+		prolog, epilog, err := callback.NewAddSecurityHeadersCallbacks([]interface{}{
+			[]string{"k", "v"},
+			[]string{"one", "two"},
+			[]string{"canonical-header", "the value"},
+		})
+		require.NoError(t, err)
+		require.NotNil(t, prolog)
+		require.Nil(t, epilog)
+		// Call it and check the behaviour follows the rule's data
+		actualProlog, ok := prolog.(callback.AddSecurityHeadersPrologCallbackType)
+		require.True(t, ok)
+		var rec http.ResponseWriter = httptest.NewRecorder()
+		err = actualProlog(nil, &rec)
+		// Check it behaves as expected
+		require.NoError(t, err)
+		expectedHeaders := http.Header{
+			"K":                []string{"v"},
+			"One":              []string{"two"},
+			"Canonical-Header": []string{"the value"},
+		}
+		require.Equal(t, expectedHeaders, rec.Header())
+	})
+}

--- a/sdk/middleware/sqecho/echo_test.go
+++ b/sdk/middleware/sqecho/echo_test.go
@@ -15,8 +15,10 @@ import (
 	"github.com/labstack/echo"
 	"github.com/sqreen/go-agent/sdk"
 	"github.com/sqreen/go-agent/sdk/middleware/sqecho"
+	"github.com/sqreen/go-agent/sdk/middleware/sqhttp"
 	"github.com/sqreen/go-agent/tools/testlib"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/xerrors"
 )
 
 func TestMiddleware(t *testing.T) {
@@ -164,7 +166,8 @@ func TestMiddleware(t *testing.T) {
 			mw := sqecho.Middleware()
 			err := mw(h)(c)
 			// Check the request was performed as expected
-			require.NoError(t, err)
+			require.Error(t, err)
+			require.True(t, xerrors.Is(err, sqhttp.AbortRequestError{}))
 			require.Equal(t, rec.Code, status)
 			require.Equal(t, rec.Body.String(), "")
 		})
@@ -201,9 +204,9 @@ func TestMiddleware(t *testing.T) {
 			mw := sqecho.Middleware()
 			err := mw(h)(c)
 			// Check the request was performed as expected
-			require.NoError(t, err)
-			require.Equal(t, rec.Code, status)
-			require.Equal(t, rec.Body.String(), "")
+			require.Error(t, err)
+			require.Equal(t, status, rec.Code)
+			require.Equal(t, "", rec.Body.String())
 		})
 	})
 }

--- a/sdk/middleware/sqhttp/http.go
+++ b/sdk/middleware/sqhttp/http.go
@@ -7,7 +7,9 @@ package sqhttp
 import (
 	"net/http"
 
+	"github.com/sqreen/go-agent/agent/sqlib/sqhook"
 	"github.com/sqreen/go-agent/sdk"
+	"golang.org/x/xerrors"
 )
 
 // Middleware is Sqreen's middleware function for `net/http` to monitor and
@@ -44,28 +46,109 @@ import (
 //	http.Handle("/foo", sqhttp.Middleware(http.HandlerFunc(fn)))
 //
 func Middleware(next http.Handler) http.Handler {
+	// Simply adapt http.Handler to Handler in order to call MiddlewareWithError
+	// to get the middleware function.
+	m := MiddlewareWithError(HandlerFunc(func(w http.ResponseWriter, r *http.Request) error {
+		next.ServeHTTP(w, r)
+		return nil
+	}))
+	// And now return a function adapting Handler to http.Handler
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = m.ServeHTTP(w, r)
+	})
+}
+
+// MiddlewareWithError is a helper middleware to define other middlewares for
+// other frameworks thanks to the error returned by the handlers in order
+// to know if a request is being aborted.
+func MiddlewareWithError(next Handler) Handler {
+	// TODO: move this middleware function into the agent internal package (which
+	//  needs restructuring the SDK)
+	return HandlerFunc(func(w http.ResponseWriter, r *http.Request) (err error) {
+		if err := addSecurityHeaders(w); err != nil {
+			return err
+		}
 		// Create a new sqreen request wrapper.
 		req := sdk.NewHTTPRequest(r)
 		defer req.Close()
 		// Use the newly created request compliant with `sdk.FromContext()`.
 		r = req.Request()
-
 		// Check if an early security action is already required such as based on
 		// the request IP address.
 		if handler := req.SecurityResponse(); handler != nil {
 			handler.ServeHTTP(w, r)
-			return
+			return AbortRequestError{}
 		}
-
 		// Call next handler.
-		next.ServeHTTP(w, r)
-
-		// Check if a security response should be applied now after having used
-		// `Identify()` and `MatchSecurityResponse()`.
+		err = next.ServeHTTP(w, r)
+		// If the returned error is not nil nor a security response, return it now.
+		var secResponse sdk.SecurityResponseMatch
+		if err != nil && !xerrors.As(err, &secResponse) {
+			return err
+		}
+		// Otherwise check if a security response should be applied now, after
+		// having used `Identify()` and `MatchSecurityResponse()`.
 		if handler := req.UserSecurityResponse(); handler != nil {
 			handler.ServeHTTP(w, r)
-			return
+			return AbortRequestError{}
 		}
+		return nil
 	})
+}
+
+// Handler is equivalent to http.Handler but returns an error when the request
+// should no longer be handled.
+type Handler interface {
+	ServeHTTP(w http.ResponseWriter, r *http.Request) error
+}
+
+// HandlerFunc is equivalent to http.HandlerFunc but returns an error when the
+// request should no longer be handled.
+type HandlerFunc func(http.ResponseWriter, *http.Request) error
+
+// ServeHTTP calls f(w, r).
+func (f HandlerFunc) ServeHTTP(w http.ResponseWriter, r *http.Request) error {
+	return f(w, r)
+}
+
+// AbortRequestError is returned by handlers when some security response was
+// triggered and handled the response. The request handling should therefore
+// stop.
+type AbortRequestError struct {
+	Message string
+}
+
+func (AbortRequestError) Error() string {
+	return "request aborted"
+}
+
+// addSecurityHeaders is a mean to add a hook to the function closure returned
+// by MiddlewareWithError() since it is not possible to get the symbol of
+// function closures at compilation-time, so it is not possible to create a hook
+// with the address of the function closure. The solution for this precise case
+// where only a prolog is enough is therefore to simply define a function having
+// a hook and called by the closure.
+func addSecurityHeaders(w http.ResponseWriter) (err error) {
+	{
+		type Prolog = func(*sqhook.Context, *http.ResponseWriter) error
+		type Epilog = func(*sqhook.Context, *error)
+		ctx := sqhook.Context{}
+		prolog, epilog := addSecurityHeaderHook.Callbacks()
+		if epilog, ok := epilog.(Epilog); ok {
+			defer epilog(&ctx, &err)
+		}
+		if prolog, ok := prolog.(Prolog); ok {
+			if err := prolog(&ctx, &w); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+var addSecurityHeaderHook *sqhook.Hook
+
+func init() {
+	addSecurityHeaderHook = sqhook.New(addSecurityHeaders)
 }


### PR DESCRIPTION
Add the support for the security headers rule by having a new hook point allowing to insert headers. To do so, a common HTTP middlewares is created and used to create other middlewares for other Go web frameworks.

- [x] Extract a common http middleware including a hook point
- [x] Create the header-insertion callback for this hook point
- [x] Implement other middlewares (gRPC, gin and echo) using the new common http one
