### PR TITLE
CSP security headers

### DIFF
--- a/agent/internal/rule/callback.go
+++ b/agent/internal/rule/callback.go
@@ -13,11 +13,11 @@ import (
 // CallbackConstructorFunc is a function returning a callback function
 // configured with the given data. The data types are known by the constructor
 // that can type-assert them.
-type CallbacksConstructorFunc func(data []interface{}) (prolog, epilog sqhook.Callback, err error)
+type CallbacksConstructorFunc func(data []interface{}, nextProlog, nextEpilog sqhook.Callback) (prolog, epilog sqhook.Callback, err error)
 
 // NewCallbacks returns the prolog and epilog callbacks of the given callback
 // name. And error is returned if the callback name is unknown.
-func NewCallbacks(name string, data []interface{}) (prolog, epilog sqhook.Callback, err error) {
+func NewCallbacks(name string, data []interface{}, nextProlog, nextEpilog sqhook.Callback) (prolog, epilog sqhook.Callback, err error) {
 	var callbacksCtor CallbacksConstructorFunc
 	switch name {
 	default:
@@ -29,5 +29,5 @@ func NewCallbacks(name string, data []interface{}) (prolog, epilog sqhook.Callba
 	case "AddSecurityHeaders":
 		callbacksCtor = callback.NewAddSecurityHeadersCallbacks
 	}
-	return callbacksCtor(data)
+	return callbacksCtor(data, nextProlog, nextEpilog)
 }

--- a/agent/internal/rule/callback/add-security-headers_test.go
+++ b/agent/internal/rule/callback/add-security-headers_test.go
@@ -7,15 +7,22 @@ package callback_test
 import (
 	"net/http"
 	"net/http/httptest"
+	"reflect"
 	"testing"
 
+	"github.com/sqreen/go-agent/agent/internal/rule"
 	"github.com/sqreen/go-agent/agent/internal/rule/callback"
+	"github.com/sqreen/go-agent/agent/sqlib/sqhook"
 	"github.com/stretchr/testify/require"
 )
 
 func TestNewAddSecurityHeadersCallbacks(t *testing.T) {
-	t.Run("with incorrect data", func(t *testing.T) {
-		for _, data := range [][]interface{}{
+	RunCallbackTest(t, TestConfig{
+		CallbacksCtor: callback.NewAddSecurityHeadersCallbacks,
+		ExpectProlog:  true,
+		PrologType:    reflect.TypeOf(callback.AddSecurityHeadersPrologCallbackType(nil)),
+		EpilogType:    reflect.TypeOf(callback.AddSecurityHeadersEpilogCallbackType(nil)),
+		InvalidTestCases: [][]interface{}{
 			nil,
 			{},
 			{33},
@@ -24,36 +31,149 @@ func TestNewAddSecurityHeadersCallbacks(t *testing.T) {
 			{nil},
 			{[]string{"one"}},
 			{[]string{"one", "two", "three"}},
-		} {
-			prolog, epilog, err := callback.NewAddSecurityHeadersCallbacks(data)
+		},
+		ValidTestCases: []ValidTestCase{
+			{
+				ValidData: []interface{}{
+					[]string{"k", "v"},
+					[]string{"one", "two"},
+					[]string{"canonical-header", "the value"},
+				},
+				TestCallbacks: func(t *testing.T, prolog, epilog sqhook.Callback) {
+					expectedHeaders := http.Header{
+						"K":                []string{"v"},
+						"One":              []string{"two"},
+						"Canonical-Header": []string{"the value"},
+					}
+					actualProlog, ok := prolog.(callback.AddSecurityHeadersPrologCallbackType)
+					require.True(t, ok)
+					var rec http.ResponseWriter = httptest.NewRecorder()
+					err := actualProlog(nil, &rec)
+					// Check it behaves as expected
+					require.NoError(t, err)
+					require.Equal(t, expectedHeaders, rec.Header())
+
+					// Test the epilog if any
+					if epilog != nil {
+						actualEpilog, ok := epilog.(callback.AddSecurityHeadersEpilogCallbackType)
+						require.True(t, ok)
+						actualEpilog(&sqhook.Context{})
+					}
+				},
+			},
+		},
+	})
+}
+
+type TestConfig struct {
+	CallbacksCtor              rule.CallbacksConstructorFunc
+	ExpectEpilog, ExpectProlog bool
+	PrologType, EpilogType     reflect.Type
+	InvalidTestCases           [][]interface{}
+	ValidTestCases             []ValidTestCase
+}
+
+type ValidTestCase struct {
+	ValidData     []interface{}
+	TestCallbacks func(t *testing.T, prolog, epilog sqhook.Callback)
+}
+
+func RunCallbackTest(t *testing.T, config TestConfig) {
+	for _, data := range config.InvalidTestCases {
+		data := data
+		t.Run("with incorrect data", func(t *testing.T) {
+			prolog, epilog, err := config.CallbacksCtor(data, nil, nil)
 			require.Error(t, err)
 			require.Nil(t, prolog)
 			require.Nil(t, epilog)
-		}
-	})
-
-	t.Run("with correct data", func(t *testing.T) {
-		// Instantiate the callback with the given correct rule data
-		prolog, epilog, err := callback.NewAddSecurityHeadersCallbacks([]interface{}{
-			[]string{"k", "v"},
-			[]string{"one", "two"},
-			[]string{"canonical-header", "the value"},
 		})
-		require.NoError(t, err)
+	}
+
+	for _, tc := range config.ValidTestCases {
+		tc := tc
+		t.Run("with correct data", func(t *testing.T) {
+			t.Run("without next callbacks", func(t *testing.T) {
+				// Instantiate the callback with the given correct rule data
+				prolog, epilog, err := config.CallbacksCtor(tc.ValidData, nil, nil)
+				require.NoError(t, err)
+				checkCallbacksValues(t, config, prolog, epilog)
+				tc.TestCallbacks(t, prolog, epilog)
+			})
+
+			t.Run("with next callbacks", func(t *testing.T) {
+				t.Run("wrong next prolog type", func(t *testing.T) {
+					prolog, epilog, err := config.CallbacksCtor(tc.ValidData, 33, nil)
+					require.Error(t, err)
+					require.Nil(t, prolog)
+					require.Nil(t, epilog)
+				})
+
+				t.Run("wrong next epilog type", func(t *testing.T) {
+					prolog, epilog, err := config.CallbacksCtor(tc.ValidData, nil, func() {})
+					require.Error(t, err)
+					require.Nil(t, prolog)
+					require.Nil(t, epilog)
+				})
+
+				t.Run("with correct next prolog", func(t *testing.T) {
+					var called bool
+					nextProlog := reflect.MakeFunc(config.PrologType, func(args []reflect.Value) (results []reflect.Value) {
+						called = true
+						return []reflect.Value{reflect.Zero(reflect.TypeOf((*error)(nil)).Elem())}
+					}).Interface()
+
+					prolog, epilog, err := config.CallbacksCtor(tc.ValidData, nextProlog, nil)
+					require.NoError(t, err)
+					checkCallbacksValues(t, config, prolog, epilog)
+					require.NotNil(t, prolog)
+					tc.TestCallbacks(t, prolog, epilog)
+					require.True(t, called)
+				})
+
+				t.Run("with correct next epilog", func(t *testing.T) {
+					var called bool
+					nextEpilog := reflect.MakeFunc(config.EpilogType, func(args []reflect.Value) (results []reflect.Value) {
+						called = true
+						return
+					}).Interface()
+
+					prolog, epilog, err := config.CallbacksCtor(tc.ValidData, nil, nextEpilog)
+					require.NoError(t, err)
+					checkCallbacksValues(t, config, prolog, epilog)
+					require.NotNil(t, epilog)
+					tc.TestCallbacks(t, prolog, epilog)
+					require.True(t, called)
+				})
+
+				t.Run("with both correct next callbacks", func(t *testing.T) {
+					var calledProlog, calledEpilog bool
+					nextProlog := reflect.MakeFunc(config.PrologType, func(args []reflect.Value) (results []reflect.Value) {
+						calledProlog = true
+						return []reflect.Value{reflect.Zero(reflect.TypeOf((*error)(nil)).Elem())}
+					}).Interface()
+					nextEpilog := reflect.MakeFunc(config.EpilogType, func(args []reflect.Value) (results []reflect.Value) {
+						calledEpilog = true
+						return
+					}).Interface()
+
+					prolog, epilog, err := config.CallbacksCtor(tc.ValidData, nextProlog, nextEpilog)
+					require.NoError(t, err)
+					require.NotNil(t, prolog)
+					require.NotNil(t, epilog)
+					tc.TestCallbacks(t, prolog, epilog)
+					require.True(t, calledProlog)
+					require.True(t, calledEpilog)
+				})
+			})
+		})
+	}
+}
+
+func checkCallbacksValues(t *testing.T, config TestConfig, prolog, epilog sqhook.Callback) {
+	if config.ExpectProlog {
 		require.NotNil(t, prolog)
-		require.Nil(t, epilog)
-		// Call it and check the behaviour follows the rule's data
-		actualProlog, ok := prolog.(callback.AddSecurityHeadersPrologCallbackType)
-		require.True(t, ok)
-		var rec http.ResponseWriter = httptest.NewRecorder()
-		err = actualProlog(nil, &rec)
-		// Check it behaves as expected
-		require.NoError(t, err)
-		expectedHeaders := http.Header{
-			"K":                []string{"v"},
-			"One":              []string{"two"},
-			"Canonical-Header": []string{"the value"},
-		}
-		require.Equal(t, expectedHeaders, rec.Header())
-	})
+	}
+	if config.ExpectEpilog {
+		require.NotNil(t, prolog)
+	}
 }

--- a/agent/internal/rule/callback/write-http-redirection.go
+++ b/agent/internal/rule/callback/write-http-redirection.go
@@ -17,36 +17,51 @@ import (
 // callbacks modifying the arguments of `httphandler.WriteResponse` in order to
 // modify the http status code and headers in order to perform an HTTP
 // redirection to the URL provided by the rule's data.
-func NewWriteHTTPRedirectionCallbacks(data []interface{}) (prolog, epilog sqhook.Callback, err error) {
+func NewWriteHTTPRedirectionCallbacks(data []interface{}, nextProlog, nextEpilog sqhook.Callback) (prolog, epilog sqhook.Callback, err error) {
 	var redirectionURL string
 	if len(data) > 0 {
 		d0 := data[0]
 		cfg, ok := d0.(*api.RedirectionRuleDataEntry)
 		if !ok {
-			return nil, nil, sqerrors.Errorf("unexpected callback data type: got `%T` instead of `*api.CustomErrorPageRuleDataEntry`", d0)
+			err = sqerrors.Errorf("unexpected callback data type: got `%T` instead of `*api.CustomErrorPageRuleDataEntry`", d0)
+			return
 		}
 		redirectionURL = cfg.RedirectionURL
 	}
 	if redirectionURL == "" {
-		return nil, nil, sqerrors.New("unexpected empty redirection url")
+		err = sqerrors.New("unexpected empty redirection url")
+		return
 	}
-	if _, err := url.ParseRequestURI(redirectionURL); err != nil {
-		return nil, nil, sqerrors.Wrap(err, "validation error of the redirection url")
+	if _, err = url.ParseRequestURI(redirectionURL); err != nil {
+		err = sqerrors.Wrap(err, "validation error of the redirection url")
+		return
 	}
-	return newWriteHTTPRedirectionPrologCallback(redirectionURL), nil, nil
+
+	// Next callbacks to call
+	actualNextProlog, ok := nextProlog.(WriteHTTPRedirectionPrologCallbackType)
+	if nextProlog != nil && !ok {
+		err = sqerrors.Errorf("unexpected next prolog type `%T`", nextProlog)
+		return
+	}
+	// No epilog in this callback, so simply pass the given one
+	return newWriteHTTPRedirectionPrologCallback(redirectionURL, actualNextProlog), nextEpilog, nil
 }
 
 type WriteHTTPRedirectionPrologCallbackType = func(*sqhook.Context, *http.ResponseWriter, **http.Request, *http.Header, *int, *[]byte) error
 
 // The prolog callback modifies the function arguments in order to perform an
 // HTTP redirection.
-func newWriteHTTPRedirectionPrologCallback(url string) WriteHTTPRedirectionPrologCallbackType {
-	return func(_ *sqhook.Context, _ *http.ResponseWriter, _ **http.Request, callerHeaders *http.Header, callerStatusCode *int, _ *[]byte) error {
+func newWriteHTTPRedirectionPrologCallback(url string, next WriteHTTPRedirectionPrologCallbackType) WriteHTTPRedirectionPrologCallbackType {
+	return func(ctx *sqhook.Context, callerWriter *http.ResponseWriter, callerRequest **http.Request, callerHeaders *http.Header, callerStatusCode *int, callerBody *[]byte) error {
 		*callerStatusCode = http.StatusSeeOther
 		if *callerHeaders == nil {
 			*callerHeaders = make(http.Header)
 		}
 		callerHeaders.Set("Location", url)
-		return nil
+
+		if next == nil {
+			return nil
+		}
+		return next(ctx, callerWriter, callerRequest, callerHeaders, callerStatusCode, callerBody)
 	}
 }

--- a/agent/internal/rule/callback/write-http-redirection_test.go
+++ b/agent/internal/rule/callback/write-http-redirection_test.go
@@ -24,7 +24,7 @@ func TestNewWriteHTTPRedirectionCallbacks(t *testing.T) {
 			{&api.RedirectionRuleDataEntry{}},
 			{&api.RedirectionRuleDataEntry{"http//sqreen.com"}},
 		} {
-			prolog, epilog, err := callback.NewWriteHTTPRedirectionCallbacks(data)
+			prolog, epilog, err := callback.NewWriteHTTPRedirectionCallbacks(data, nil, nil)
 			require.Error(t, err)
 			require.Nil(t, prolog)
 			require.Nil(t, epilog)
@@ -36,7 +36,7 @@ func TestNewWriteHTTPRedirectionCallbacks(t *testing.T) {
 		expectedURL := "http://sqreen.com"
 		prolog, epilog, err := callback.NewWriteHTTPRedirectionCallbacks([]interface{}{
 			&api.RedirectionRuleDataEntry{RedirectionURL: expectedURL},
-		})
+		}, nil, nil)
 		require.NoError(t, err)
 		require.NotNil(t, prolog)
 		require.Nil(t, epilog)

--- a/agent/internal/rule/callback_test.go
+++ b/agent/internal/rule/callback_test.go
@@ -42,7 +42,7 @@ func TestNewCallbacks(t *testing.T) {
 	} {
 		tc := tc
 		t.Run(tc.testName, func(t *testing.T) {
-			_, _, err := rule.NewCallbacks(tc.name, tc.data)
+			_, _, err := rule.NewCallbacks(tc.name, tc.data, nil, nil)
 			if tc.shouldSucceed {
 				require.NoError(t, err)
 			} else {

--- a/agent/sqlib/sqhook/hook.go
+++ b/agent/sqlib/sqhook/hook.go
@@ -104,6 +104,8 @@ type Hook struct {
 	// Pointer to a structure containing the callbacks in order to be able to
 	// atomically modify the pointer.
 	attached *callbacks
+	// Symbol name where the hook is used. Required for the stringer.
+	symbol string
 }
 
 type callbacks struct {
@@ -160,6 +162,7 @@ func New(fn interface{}) *Hook {
 	}
 	// Create the hook, store it in the map and return it.
 	hook := &Hook{
+		symbol: symbol,
 		fnType: fnType,
 	}
 	index[symbol] = hook
@@ -276,4 +279,8 @@ func validateCallback(callback Callback, argTypes []reflect.Type) (err error) {
 		}
 	}
 	return nil
+}
+
+func (h *Hook) String() string {
+	return fmt.Sprintf("%s (%s)", h.symbol, h.fnType)
 }


### PR DESCRIPTION
The CSP security headers rule attaches a callback to the same hook point as the security headers rule. Since the agent has the full list of callbacks and hook points, it can therefore chain them together when instantiating the callback. So now, a prolog callback has a pointer to the next prolog callback, and same for epilog callbacks. This callback-level chaining allows to:

- keep `sqhook` library as it is, without introducing an array of callbacks that would have been heavier to atomically modify.
- keep the fast dispatch we have for native callbacks by using type-assertion instead of `reflect.Call`.