### PR TITLE
HTTP Status Code Metrics

### DIFF
--- a/agent/internal/backend/api/api.go
+++ b/agent/internal/backend/api/api.go
@@ -164,9 +164,16 @@ type BatchRequest_Event struct {
 }
 
 type Rule struct {
-	Name      string    `json:"name"`
-	Hookpoint Hookpoint `json:"hookpoint"`
-	Data      RuleData  `json:"data"`
+	Name      string             `json:"name"`
+	Hookpoint Hookpoint          `json:"hookpoint"`
+	Data      RuleData           `json:"data"`
+	Metrics   []MetricDefinition `json:"metrics"`
+}
+
+type MetricDefinition struct {
+	Kind   string `json:"kind"`
+	Name   string `json:"name"`
+	Period int64  `json:"period"`
 }
 
 type Hookpoint struct {

--- a/agent/internal/metrics.go
+++ b/agent/internal/metrics.go
@@ -4,175 +4,28 @@
 
 package internal
 
-import (
-	"context"
-	"sync"
-	"sync/atomic"
-	"time"
-
-	"github.com/pkg/errors"
-	"github.com/sqreen/go-agent/agent/internal/backend/api"
-	"github.com/sqreen/go-agent/agent/internal/plog"
-	"github.com/sqreen/go-agent/agent/sqlib/sqsafe"
-)
-
-type metricsManager struct {
-	ctx       context.Context
-	logger    *plog.Logger
-	metrics   sync.Map
-	readyLock sync.Mutex
-	ready     []api.MetricResponse
-}
-
-func newMetricsManager(ctx context.Context, logger *plog.Logger) *metricsManager {
-	return &metricsManager{
-		ctx:    ctx,
-		logger: logger,
-	}
-}
-
-type metricsStore struct {
-	done     func(start, finish time.Time, observations sync.Map)
-	period   time.Duration
-	entries  sync.Map
-	once     sync.Once
-	swapLock sync.RWMutex
-	expired  bool
-	logger   *plog.Logger
-}
-
-type metricEntry interface {
-	// Deterministic marshaling if possible...
-	bucketID() (string, error)
-}
-
-func (m *metricsManager) get(name string) *metricsStore {
-	store := &metricsStore{
-		logger: m.logger,
-		period: time.Minute,
-		done: func(start, finish time.Time, observations sync.Map) {
-			m.metrics.Delete(name)
-			m.logger.Debug("metrics `", name, "` ready")
-			m.addObservations(name, start, finish, observations)
-		},
-	}
-
-	actual, _ := m.metrics.LoadOrStore(name, store)
-	store = actual.(*metricsStore)
-	store.once.Do(func() {
-		_ = sqsafe.Go(func() error {
-			m.logger.Debug("bookkeeping metrics `", name, "` with period `", store.period, "`")
-			store.monitor(m.ctx, time.Now())
-			return nil
-		})
-	})
-
-	return store
-}
-
-func (m *metricsManager) addObservations(name string, start, finish time.Time, observations sync.Map) {
-	observation := make(map[string]uint64)
-	observations.Range(func(k, v interface{}) bool {
-		key, ok := k.(string)
-		if !ok {
-			m.logger.Error(errors.New("unexpected metric key type"))
-			return true
-		}
-
-		value, ok := v.(*uint64)
-		if !ok {
-			m.logger.Error(errors.New("unexpected metric value type"))
-			return true
-		}
-
-		observation[key] = *value
-		return true
-	})
-
-	metric := api.MetricResponse{
-		Name:        name,
-		Start:       start,
-		Finish:      finish,
-		Observation: api.Struct{observation},
-	}
-
-	m.readyLock.Lock()
-	defer m.readyLock.Unlock()
-	m.ready = append(m.ready, metric)
-}
-
-func (m *metricsManager) getObservations() []api.MetricResponse {
-	m.readyLock.Lock()
-	defer m.readyLock.Unlock()
-	ready := m.ready
-	m.ready = m.ready[0:0]
-	return ready
-}
-
-func (s *metricsStore) add(e metricEntry) {
-	s.swapLock.RLock()
-	defer s.swapLock.RUnlock()
-
-	if s.expired {
-		// FIXME: better design preventing this case
-		// For now, a few events may be dropped.
-		return
-	}
-
-	var n uint64 = 1
-	key, err := e.bucketID()
-	if err != nil {
-		// Log the error and continue.
-		s.logger.Error(errors.Wrap(err, "could not compute the bucket id of the metric key"))
-		return
-	}
-	actual, loaded := s.entries.LoadOrStore(key, &n)
-	if loaded {
-		newVal := atomic.AddUint64(actual.(*uint64), 1)
-		s.logger.Debug("metric store value of `", key, "` set to ", newVal)
-	} else {
-		s.logger.Debug("metric store value of `", key, "` set to ", n)
-	}
-}
-
-func (s *metricsStore) monitor(ctx context.Context, start time.Time) {
-	var finish time.Time
-	select {
-	case <-ctx.Done():
-		finish = time.Now()
-	case finish = <-time.After(s.period):
-	}
-
-	s.swapLock.Lock()
-	entries := s.entries
-	s.entries = sync.Map{}
-	s.expired = true
-	s.swapLock.Unlock()
-
-	s.done(start, finish, entries)
-}
+import "github.com/sqreen/go-agent/agent/internal/metrics"
 
 func (a *Agent) addUserEvent(event userEventFace) {
-	if a.config.Disable() || a.metricsMng == nil {
+	if a.config.Disable() || a.metrics == nil {
 		// Disabled or not yet initialized agent
 		return
 	}
-
-	var store *metricsStore
+	var store *metrics.Store
 	switch actual := event.(type) {
 	case *authUserEvent:
 		if actual.loginSuccess {
-			store = a.metricsMng.get("sdk-login-success")
+			store = a.staticMetrics.sdkUserLoginSuccess
 		} else {
-			store = a.metricsMng.get("sdk-login-fail")
+			store = a.staticMetrics.sdkUserLoginFailure
 		}
 	case *signupUserEvent:
-		store = a.metricsMng.get("sdk-signup")
+		store = a.staticMetrics.sdkUserSignup
 	default:
+		// TODO: log error
 		return
 	}
-
-	store.add(event)
+	store.Add(event, 1)
 }
 
 type WhitelistedIP struct {
@@ -184,11 +37,11 @@ func (m WhitelistedIP) bucketID() (string, error) {
 }
 
 func (a *Agent) addWhitelistEvent(matchedWhitelistEntry string) {
-	if a.config.Disable() || a.metricsMng == nil {
+	if a.config.Disable() || a.metrics == nil {
 		// Agent is disabled or not yet initialized
 		return
 	}
-	a.metricsMng.get("whitelisted").add(WhitelistedIP{
+	a.staticMetrics.whitelistedIP.Add(WhitelistedIP{
 		MatchedWhitelistEntry: matchedWhitelistEntry,
-	})
+	}, 1)
 }

--- a/agent/internal/metrics/metrics.go
+++ b/agent/internal/metrics/metrics.go
@@ -1,0 +1,240 @@
+// Copyright (c) 2016 - 2019 Sqreen. All Rights Reserved.
+// Please refer to our terms for more information:
+// https://www.sqreen.io/terms.html
+
+// Package metrics provides shared metrics stores. A metrics store is a
+// key/value store with a given time period after which the data is considered
+// ready. This package provides an implementation optimized for writes updating
+// already existing keys: lots of goroutines updating a smaller set of keys.
+// The metrics engine allows to create and register new metrics stores that a
+// single reader (Sqreen's agent) can concurrently read. Read and write
+// operations and mutually exclusive - slow polling is better for aggregating
+// more data while not blocking the writers too often.
+//
+// Main requirements:
+//
+// - Loss-less kv-stores.
+// - Near zero time impact on the hot path (updates): no need to switch to
+//   another goroutines, no blocking locks.
+//
+// Design decisions:
+//
+// The former first implementation was using channels and dedicated goroutines
+// sleeping until the period was passed. The major issue was the case when
+// the channels were full, with the choice of either blocking the sending
+// goroutine, or dropping the data to avoid blocking it.
+// This design is now considered not suitable for metrics as they happen at a
+// too frequently to go through a channel. A channel indeed needs at least one
+// extra reader goroutine that would require too much CPU time to aggregate
+// all the metrics values.
+//
+// Metrics store operations, insertions and updates of integer values, are
+// therefore considered shorter than any "pure-Go" approach with channels and
+// so on. The main challenge here comes from the map whose index cannot be
+// modified concurrently. So the idea is to use a RWLock it in order to
+// mutually exclude the insertions of new values, updates of existing values and
+// retrieval of expired values.
+// The hot path being updates of existing values, the Add() method first tries
+// to only RLock the store in order to avoid locking every other
+// updating-goroutine. The value being a uint64, it can be atomically updated
+// without using an lock for the value.
+//
+// The metrics stores and engine provide a polling interface to retrieve stores
+// whose period are passed. No goroutine is started to automatically swap the
+// stores. This is due to the fact that metrics are sent by the Sqreen agent
+// only during the heartbeat; it can therefore check for expired stores.
+// Metrics stores can therefore be longer than their period and will actually
+// last until they are flushed by the reader goroutine.
+package metrics
+
+import (
+	"reflect"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/sqreen/go-agent/agent/internal/plog"
+	"github.com/sqreen/go-agent/agent/sqlib/sqerrors"
+)
+
+// Engine manages the metrics stores in oder to create new one, and to poll
+// the existing ones. Engine's methods are not thread-safe and designed to be
+// used by a single goroutine.
+type Engine struct {
+	logger plog.DebugLogger
+	stores map[string]*Store
+}
+
+func NewEngine(logger plog.DebugLogger) *Engine {
+	return &Engine{
+		logger: logger,
+		stores: make(map[string]*Store),
+	}
+}
+
+// NewStore creates and registers a new metrics store.
+func (e *Engine) NewStore(id string, period time.Duration) *Store {
+	store := newStore(period)
+	e.stores[id] = store
+	return store
+}
+
+// ReadyMetrics returns the set of ready stores (ie. having data and a passed
+// period). This operation blocks metrics stores operations and should be
+// wisely used.
+func (e *Engine) ReadyMetrics() (expiredMetrics map[string]*ReadyStore) {
+	expiredMetrics = make(map[string]*ReadyStore)
+	for id, s := range e.stores {
+		if s.Ready() {
+			ready := s.Flush()
+			expiredMetrics[id] = ready
+			e.logger.Debugf("metrics: store `%s` ready with `%d` entries", id, len(ready.Metrics()))
+		}
+	}
+	if len(expiredMetrics) == 0 {
+		return nil
+	}
+	return expiredMetrics
+}
+
+// Store is a metrics store optimized for write accesses to already existing
+// keys (cf. Add). It has a period of time after which the data is considered
+// ready to be retrieved. An empty store is never considered ready and the
+// deadline is computed when the first value is inserted.
+type Store struct {
+	// Map of comparable types to uint64 pointers.
+	set  StoreMap
+	lock sync.RWMutex
+	// Next deadline, computed when the first value is inserted.
+	deadline time.Time
+	// Minimum time duration the data should be kept.
+	period time.Duration
+}
+
+type StoreMap map[interface{}]*uint64
+type ReadyStoreMap map[interface{}]uint64
+
+func newStore(period time.Duration) *Store {
+	return &Store{
+		set:    make(StoreMap),
+		period: period,
+	}
+}
+
+// Add delta to the given key, inserting it if it doesn't exist. This method
+// is thread-safe and optimized for updating existing key which is lock-free
+// when not concurrently retrieving (method `Flush()`) or inserting a new key.
+func (s *Store) Add(key interface{}, delta uint64) error {
+	// Avoid panic-ing by checking the key type is not nil and comparable.
+	if key == nil {
+		return sqerrors.New("unexpected key value `nil`")
+	} else if !reflect.TypeOf(key).Comparable() {
+		return sqerrors.Errorf("unexpected non-comparable type `%T`", key)
+	}
+
+	// Fast hot path: concurrently updating the value of an existing key.
+	// Lock the store for reading only.
+	s.lock.RLock()
+	// Lookup the value
+	value, exists := s.set[key]
+	if exists {
+		// The key already exists.
+		// Atomically update the value.
+		// This update operation can be therefore done concurrently.
+		atomic.AddUint64(value, delta)
+		// It is important to do it in this write-safe section that is mutually
+		// exclusive with Flush() which replaces the store's map using Lock().
+	}
+	// Unlock the store
+	s.lock.RUnlock()
+
+	// Slow path: the key does not exist
+	if !exists {
+		// Exclusively lock the store
+		s.lock.Lock()
+		defer s.lock.Unlock()
+		// Check again in case the value has been inserted while getting here.
+		value, exists = s.set[key]
+		if exists {
+			// The value was inserted by another concurrent goroutine.
+			// We can update the value without atomic operation as we exclusively
+			// have the lock.
+			*value += delta
+			// Note that this is not possible to unlock and perform the atomic
+			// operation because of possible concurrent `Flush()`.
+		} else {
+			// The value still doesn't exist and we need to insert it into the store's
+			// map.
+			value := delta
+			s.set[key] = &value
+			// Set the deadline when the first value inserted into the metrics store
+			if s.deadline.IsZero() {
+				s.deadline = time.Now().Add(s.period)
+			}
+		}
+	}
+
+	return nil
+}
+
+// Flush returns the stored data and the corresponding time window the data was
+// held. It should be used when the store is `Ready()`. This method is
+// thead-safe.
+func (s *Store) Flush() (flushed *ReadyStore) {
+	// Read current time before swapping the stores in order to avoid making it in
+	// the critical-section. Reading it before is important in order to get
+	// old.finish <= new.start.
+	now := time.Now()
+
+	// Exclusively lock the store in order to get the values and replace it.
+	s.lock.Lock()
+	oldMap := s.set
+	startedAt := s.deadline.Add(-s.period)
+	// Create a new map with the same capacity as the old one to avoid allocation
+	// time when still used the same way after the flush.
+	s.set = make(StoreMap, len(oldMap))
+	s.deadline = time.Time{} // time.Time zero value
+	// Unlock the store which is ready to be used again by concurrent goroutines.
+	s.lock.Unlock()
+
+	// Compute the map of values getting rid of the pointers (less GC-pressure).
+	readyMap := make(ReadyStoreMap, len(oldMap))
+	for k, v := range oldMap {
+		readyMap[k] = *v
+	}
+	return &ReadyStore{
+		set:    readyMap,
+		start:  startedAt,
+		finish: now,
+	}
+}
+
+// Ready returns true when the store has values and the period passed.
+// This method is thread-safe. Note that the atomic operation
+// "Ready() + Flush()" doesn't exist, they should therefore be used by a single
+// "flusher" goroutine. The locking of `Ready()` is indeed weaker than `Flush()`
+// as it only lock the store for reading in order to avoid blocking other
+// concurrent updates.
+func (s *Store) Ready() bool {
+	s.lock.RLock()
+	defer s.lock.RUnlock()
+	return !s.deadline.IsZero() && time.Now().After(s.deadline)
+}
+
+// ReadyStore provides methods to get the values and the time window.
+type ReadyStore struct {
+	set           ReadyStoreMap
+	start, finish time.Time
+}
+
+func (s *ReadyStore) Start() time.Time {
+	return s.start
+}
+
+func (s *ReadyStore) Finish() time.Time {
+	return s.finish
+}
+
+func (s *ReadyStore) Metrics() ReadyStoreMap {
+	return s.set
+}

--- a/agent/internal/metrics/metrics_test.go
+++ b/agent/internal/metrics/metrics_test.go
@@ -1,0 +1,533 @@
+// Copyright (c) 2016 - 2019 Sqreen. All Rights Reserved.
+// Please refer to our terms for more information:
+// https://www.sqreen.io/terms.html
+
+package metrics_test
+
+import (
+	"fmt"
+	"math"
+	"os"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/sqreen/go-agent/agent/internal/metrics"
+	"github.com/sqreen/go-agent/agent/internal/plog"
+	"github.com/sqreen/go-agent/tools/testlib"
+	"github.com/stretchr/testify/require"
+)
+
+var logger = plog.NewLogger(plog.Debug, os.Stderr, 0)
+
+func TestUsage(t *testing.T) {
+	engine := metrics.NewEngine(logger)
+
+	t.Run("store usage", func(t *testing.T) {
+		t.Run("empty stores are never ready", func(t *testing.T) {
+			store := engine.NewStore("id 1", time.Microsecond)
+			require.False(t, store.Ready())
+			time.Sleep(time.Microsecond)
+			require.False(t, store.Ready())
+		})
+
+		t.Run("non-empty stores get ready starting as soon as a value was added", func(t *testing.T) {
+			store := engine.NewStore("id 1", time.Millisecond)
+			require.False(t, store.Ready())
+			time.Sleep(time.Millisecond)
+			// Should be still not ready because no values were added
+			require.False(t, store.Ready())
+			// Now add a value
+			store.Add("key 1", 1)
+			// Should be started but still not expired
+			require.False(t, store.Ready())
+			time.Sleep(time.Microsecond)
+			// Should be still not expired
+			require.False(t, store.Ready())
+			time.Sleep(time.Millisecond)
+			// Now should be expired
+			require.True(t, store.Ready())
+			// Flushing the store should give the map and "restart" the store
+			old := store.Flush()
+			require.False(t, store.Ready())
+			// Should not be expired while empty
+			time.Sleep(time.Millisecond)
+			require.False(t, store.Ready())
+			// The old store should have the stored values
+			require.Equal(t, metrics.ReadyStoreMap{"key 1": 1}, old.Metrics())
+			// Adding a new value to the store and then waiting for it to become ready
+			// should return the net value
+			store.Add("key 2", 3)
+			time.Sleep(time.Millisecond)
+			require.True(t, store.Ready())
+			old = store.Flush()
+			require.Equal(t, metrics.ReadyStoreMap{"key 2": 3}, old.Metrics())
+		})
+
+		t.Run("adding values to a store that is ready is possible", func(t *testing.T) {
+			store := engine.NewStore("id 1", time.Millisecond)
+			require.False(t, store.Ready())
+			store.Add("key 1", 1)
+			time.Sleep(time.Millisecond)
+			require.True(t, store.Ready())
+			store.Add("key 1", 1)
+			store.Add("key 2", 33)
+			store.Add("key 3", 33)
+			store.Add("key 3", 1)
+
+			require.True(t, store.Ready())
+			old := store.Flush()
+			require.Equal(t, metrics.ReadyStoreMap{
+				"key 1": 2,
+				"key 2": 33,
+				"key 3": 34,
+			}, old.Metrics())
+		})
+
+		t.Run("key types", func(t *testing.T) {
+			store := engine.NewStore("id 1", time.Millisecond)
+
+			t.Run("non comparable key types are not allowed and do not panic", func(t *testing.T) {
+				type Struct2 struct {
+					a int
+					b string
+					c float32
+					d []byte
+				}
+
+				require.NotPanics(t, func() {
+					require.Error(t, store.Add([]byte("no slices"), 1))
+					require.Error(t, store.Add(Struct2{
+						a: 33,
+						b: "string",
+						c: 4.815162342,
+						d: []byte("no slice"),
+					}, 1))
+				})
+			})
+
+			t.Run("comparable key types are allowed and do not panic", func(t *testing.T) {
+				type Struct struct {
+					a int
+					b string
+					c float32
+					d [33]byte
+				}
+
+				ptr := &Struct{}
+
+				require.NotPanics(t, func() {
+					require.NoError(t, store.Add("string", 1))
+					require.NoError(t, store.Add(33, 1))
+					require.NoError(t, store.Add(Struct{
+						a: 33,
+						b: "string",
+						c: 4.815162342,
+						d: [33]byte{},
+					}, 1))
+					require.NoError(t, store.Add(ptr, 1))
+					// Nil is comparable but not allowed
+					require.Error(t, store.Add(nil, 1))
+				})
+
+				time.Sleep(time.Millisecond)
+				require.True(t, store.Ready())
+				old := store.Flush()
+				require.Equal(t, metrics.ReadyStoreMap{
+					"string": 1,
+					33:       1,
+					Struct{
+						a: 33,
+						b: "string",
+						c: 4.815162342,
+						d: [33]byte{},
+					}: 1,
+					ptr: 1,
+				}, old.Metrics())
+			})
+		})
+	})
+
+	t.Run("one reader - 8000 writers", func(t *testing.T) {
+		// Create a store that will be checked more often than actually required by
+		// its period. So that we cover the case where the store is not always
+		// ready.
+		engine := metrics.NewEngine(logger)
+		// The reader will be awaken 4 times per store period, so only it will see
+		// a ready store only once out of four.
+		readerPeriod := time.Microsecond
+		metricsStorePeriod := 4 * readerPeriod
+		tick := time.Tick(readerPeriod)
+		store := engine.NewStore("id", metricsStorePeriod)
+
+		// Signal channel between this test and the reader to tear down the test
+		done := make(chan struct{})
+
+		// Array of metrics flushed by the reader
+		var metricsArray []*metrics.ReadyStore
+		// Time the test finished - it will be compared to the last metrics store
+		// finish time
+		var finished time.Time
+
+		// One reader
+		go func() {
+			for {
+				select {
+				case <-tick:
+					if store.Ready() {
+						ready := store.Flush()
+						metricsArray = append(metricsArray, ready)
+					}
+
+				case <-done:
+					// All goroutines are done, so read get the last data left
+					if ready := store.Flush(); len(ready.Metrics()) > 0 {
+						metricsArray = append(metricsArray, ready)
+					}
+					finished = time.Now()
+					// Notify we are done and so the data is ready to be checked
+					close(done)
+					return
+				}
+			}
+		}()
+
+		// Start 8000 writers that will write 1000 times
+		nbWriters := 8000
+		nbWrites := 1000
+
+		var startBarrier, stopBarrier sync.WaitGroup
+		// Create a start barrier to synchronize every goroutine's launch
+		startBarrier.Add(nbWriters)
+		// Create a stopBarrier to signal when all goroutines are done writing
+		// their values
+		stopBarrier.Add(nbWriters)
+
+		for n := 0; n < nbWriters; n++ {
+			go func() {
+				startBarrier.Wait()      // Sync the starts of the goroutines
+				defer stopBarrier.Done() // Signal we are done when returning
+				for c := 0; c < nbWrites; c++ {
+					_ = store.Add(c, 1)
+				}
+			}()
+		}
+
+		// Save the test start time to compare it to the first metrics store's
+		// that should be latter.
+		started := time.Now()
+
+		startBarrier.Add(-nbWriters) // Unblock the writer goroutines
+		stopBarrier.Wait()           // Wait for the writer goroutines to be done
+		done <- struct{}{}           // Signal the reader they are done
+		<-done                       // Wait for the reader to be done
+
+		// Make sure there is no data left by sleeping more than needed and checking
+		// the store.
+		time.Sleep(2 * metricsStorePeriod)
+		require.False(t, store.Ready())
+
+		// Aggregate the ready metrics the reader retrieved and check the previous
+		// store finish time is before the current store start time.
+		results := make(metrics.ReadyStoreMap)
+		lastStoreFinish := started
+		for _, store := range metricsArray {
+			for k, v := range store.Metrics() {
+				results[k] += v
+			}
+			if !lastStoreFinish.IsZero() {
+				require.True(t, lastStoreFinish.Before(store.Start()), fmt.Sprint(lastStoreFinish, store))
+			}
+			lastStoreFinish = store.Finish()
+		}
+		require.True(t, lastStoreFinish.Before(finished))
+
+		// Check each writer wrote the expected number of times.
+		for n := 0; n < nbWrites; n++ {
+			v, exists := results[n]
+			require.True(t, exists)
+			require.Equal(t, uint64(nbWriters), v)
+		}
+	})
+}
+
+func BenchmarkStore(b *testing.B) {
+	engine := metrics.NewEngine(logger)
+
+	type structKeyType struct {
+		n int
+		s string
+	}
+
+	b.Run("non-concurrent insertion", func(b *testing.B) {
+		b.Run("integer key type", func(b *testing.B) {
+			b.Run("non existing keys", func(b *testing.B) {
+				b.Run("using MetricsStore", func(b *testing.B) {
+					store := engine.NewStore("id", time.Minute)
+					b.ResetTimer()
+					for n := 0; n < b.N; n++ {
+						_ = store.Add(n, 1)
+					}
+				})
+
+				b.Run("using sync.Map", func(b *testing.B) {
+					var store sync.Map
+					b.ResetTimer()
+					for n := 0; n < b.N; n++ {
+						store.Store(n, 1)
+					}
+				})
+			})
+
+			b.Run("already existing key", func(b *testing.B) {
+				b.Run("using MetricsStore", func(b *testing.B) {
+					store := engine.NewStore("id", time.Minute)
+					b.ResetTimer()
+					for n := 0; n < b.N; n++ {
+						_ = store.Add(42, 1)
+					}
+				})
+
+				b.Run("using sync.Map", func(b *testing.B) {
+					var store sync.Map
+					b.ResetTimer()
+					for n := 0; n < b.N; n++ {
+						store.Store(42, 1)
+					}
+				})
+			})
+		})
+
+		b.Run("structure key type", func(b *testing.B) {
+			b.Run("non existing keys", func(b *testing.B) {
+				key := structKeyType{
+					s: testlib.RandString(50),
+				}
+
+				b.Run("using MetricsStore", func(b *testing.B) {
+					store := engine.NewStore("id", time.Minute)
+					b.ResetTimer()
+					for n := 0; n < b.N; n++ {
+						key.n = n
+						_ = store.Add(key, 1)
+					}
+				})
+
+				b.Run("using sync.Map", func(b *testing.B) {
+					var store sync.Map
+					b.ResetTimer()
+					for n := 0; n < b.N; n++ {
+						key.n = n
+						store.Store(key, 1)
+					}
+				})
+			})
+
+			b.Run("already existing key", func(b *testing.B) {
+				key := structKeyType{
+					n: 42,
+					s: testlib.RandString(50),
+				}
+				b.Run("using MetricsStore", func(b *testing.B) {
+					store := engine.NewStore("id", time.Minute)
+					b.ResetTimer()
+					for n := 0; n < b.N; n++ {
+						_ = store.Add(key, 1)
+					}
+				})
+
+				b.Run("using sync.Map", func(b *testing.B) {
+					var store sync.Map
+					b.ResetTimer()
+					for n := 0; n < b.N; n++ {
+						store.Store(key, 1)
+					}
+				})
+			})
+		})
+	})
+
+	b.Run("concurrent insertion", func(b *testing.B) {
+		for p := 1; p <= 1000; p *= 10 {
+			p := p
+			b.Run(fmt.Sprintf("%d", p), func(b *testing.B) {
+				b.Run("integer key type", func(b *testing.B) {
+					b.Run("same non existing keys", func(b *testing.B) {
+						b.Run("using MetricsStore", func(b *testing.B) {
+							store := engine.NewStore("id", time.Minute)
+							b.ResetTimer()
+							b.SetParallelism(p)
+							b.RunParallel(func(pb *testing.PB) {
+								n := 0
+								for pb.Next() {
+									_ = store.Add(n, 1)
+									n++
+								}
+							})
+						})
+
+						b.Run("using sync.Map", func(b *testing.B) {
+							var store sync.Map
+							b.ResetTimer()
+							b.SetParallelism(p)
+							b.RunParallel(func(pb *testing.PB) {
+								n := 0
+								for pb.Next() {
+									store.Store(n, 1)
+									n++
+								}
+							})
+						})
+					})
+
+					b.Run("same key", func(b *testing.B) {
+						b.Run("using MetricsStore", func(b *testing.B) {
+							store := engine.NewStore("id", time.Minute)
+							b.ResetTimer()
+							b.SetParallelism(p)
+							b.RunParallel(func(pb *testing.PB) {
+								for pb.Next() {
+									_ = store.Add(42, 1)
+								}
+							})
+						})
+
+						b.Run("using sync.Map", func(b *testing.B) {
+							var store sync.Map
+							b.ResetTimer()
+							b.SetParallelism(p)
+							b.RunParallel(func(pb *testing.PB) {
+								for pb.Next() {
+									store.Store(42, 1)
+								}
+							})
+						})
+					})
+				})
+				b.Run("structure key type", func(b *testing.B) {
+					b.Run("same non existing keys", func(b *testing.B) {
+						b.Run("using MetricsStore", func(b *testing.B) {
+							store := engine.NewStore("id", time.Minute)
+							b.ResetTimer()
+							b.SetParallelism(p)
+							b.RunParallel(func(pb *testing.PB) {
+								key := structKeyType{
+									s: testlib.RandString(50),
+								}
+								for pb.Next() {
+									_ = store.Add(key, 1)
+									key.n++
+								}
+							})
+						})
+
+						b.Run("using sync.Map", func(b *testing.B) {
+							var store sync.Map
+							b.ResetTimer()
+							b.SetParallelism(p)
+							b.RunParallel(func(pb *testing.PB) {
+								key := structKeyType{
+									s: testlib.RandString(50),
+								}
+								for pb.Next() {
+									store.Store(key, 1)
+									key.n++
+								}
+							})
+						})
+					})
+
+					b.Run("same key", func(b *testing.B) {
+						key := structKeyType{
+							s: testlib.RandString(50),
+							n: 42,
+						}
+
+						b.Run("using MetricsStore", func(b *testing.B) {
+							store := engine.NewStore("id", time.Minute)
+							b.ResetTimer()
+							b.SetParallelism(p)
+							b.RunParallel(func(pb *testing.PB) {
+								for pb.Next() {
+									_ = store.Add(key, 1)
+								}
+							})
+						})
+
+						b.Run("using sync.Map", func(b *testing.B) {
+							var store sync.Map
+							b.ResetTimer()
+							b.SetParallelism(p)
+							b.RunParallel(func(pb *testing.PB) {
+								for pb.Next() {
+									store.Store(key, 1)
+								}
+							})
+						})
+					})
+				})
+			})
+		}
+	})
+}
+
+func BenchmarkUsage(b *testing.B) {
+	engine := metrics.NewEngine(logger)
+
+	for p := 1; p <= 1000; p *= 10 {
+		p := p
+		b.Run(fmt.Sprintf("parallelism/%d", p), func(b *testing.B) {
+			b.Run("constant cpu time", func(b *testing.B) {
+				b.Run("reference without metrics", func(b *testing.B) {
+					b.SetParallelism(p)
+					b.RunParallel(func(pb *testing.PB) {
+						for pb.Next() {
+							doConstantCPUProcessing(1)
+						}
+					})
+				})
+
+				b.Run("integer key type", func(b *testing.B) {
+					b.Run("concurrent writes to the same key", func(b *testing.B) {
+						b.SetParallelism(p)
+						store := engine.NewStore("id", time.Minute)
+						b.ResetTimer()
+						b.RunParallel(func(pb *testing.PB) {
+							for pb.Next() {
+								_ = store.Add(418, 1)
+								_ = doConstantCPUProcessing(1)
+							}
+						})
+					})
+
+					b.Run("concurrent writes to multiple keys", func(b *testing.B) {
+						b.SetParallelism(p)
+						store := engine.NewStore("id", time.Minute)
+						b.ResetTimer()
+						b.RunParallel(func(pb *testing.PB) {
+							n := 0
+							for pb.Next() {
+								_ = store.Add(n, 1)
+								_ = doConstantCPUProcessing(1)
+								n++
+							}
+						})
+					})
+				})
+			})
+		})
+	}
+}
+
+// go:noinline
+func doConstantCPUProcessing(n int) (r int) {
+	for i := 0; i < int(math.Pow(1000, float64(n))); i++ {
+		r += useCPU(i)
+	}
+	return r
+}
+
+// go:noinline
+func useCPU(i int) int {
+	return i + 10 - 2*3
+}

--- a/agent/internal/request.go
+++ b/agent/internal/request.go
@@ -54,7 +54,6 @@ type HTTPRequestEvent struct {
 
 type userEventFace interface {
 	isUserEvent()
-	metricEntry
 }
 
 type userEvent struct {
@@ -70,12 +69,12 @@ type authUserEvent struct {
 
 func (_ *authUserEvent) isUserEvent() {}
 
-func (e *authUserEvent) bucketID() (string, error) {
+func (e *authUserEvent) MarshalJSON() ([]byte, error) {
 	k := &userMetricKey{
 		id: e.userEvent.userIdentifiers,
 		ip: e.userEvent.ip,
 	}
-	return k.bucketID()
+	return k.MarshalJSON()
 }
 
 type userMetricKey struct {
@@ -83,7 +82,7 @@ type userMetricKey struct {
 	ip net.IP
 }
 
-func (k *userMetricKey) bucketID() (string, error) {
+func (k *userMetricKey) MarshalJSON() ([]byte, error) {
 	var keys [][]interface{}
 	for prop, val := range k.id {
 		keys = append(keys, []interface{}{prop, val})
@@ -96,19 +95,19 @@ func (k *userMetricKey) bucketID() (string, error) {
 		IP:   k.ip.String(),
 	}
 	buf, err := json.Marshal(&v)
-	return string(buf), err
+	return buf, err
 }
 
 type signupUserEvent struct {
 	*userEvent
 }
 
-func (e *signupUserEvent) bucketID() (string, error) {
+func (e *signupUserEvent) MarshalJSON() ([]byte, error) {
 	k := &userMetricKey{
 		id: e.userEvent.userIdentifiers,
 		ip: e.userEvent.ip,
 	}
-	return k.bucketID()
+	return k.MarshalJSON()
 }
 
 func (_ *signupUserEvent) isUserEvent() {}

--- a/agent/internal/rule/callback.go
+++ b/agent/internal/rule/callback.go
@@ -5,6 +5,12 @@
 package rule
 
 import (
+	"fmt"
+	"time"
+
+	"github.com/sqreen/go-agent/agent/internal/backend/api"
+	"github.com/sqreen/go-agent/agent/internal/metrics"
+	"github.com/sqreen/go-agent/agent/internal/plog"
 	"github.com/sqreen/go-agent/agent/internal/rule/callback"
 	"github.com/sqreen/go-agent/agent/sqlib/sqerrors"
 	"github.com/sqreen/go-agent/agent/sqlib/sqhook"
@@ -13,11 +19,11 @@ import (
 // CallbackConstructorFunc is a function returning a callback function
 // configured with the given data. The data types are known by the constructor
 // that can type-assert them.
-type CallbacksConstructorFunc func(data []interface{}, nextProlog, nextEpilog sqhook.Callback) (prolog, epilog sqhook.Callback, err error)
+type CallbacksConstructorFunc func(rule callback.Context, nextProlog, nextEpilog sqhook.Callback) (prolog, epilog sqhook.Callback, err error)
 
 // NewCallbacks returns the prolog and epilog callbacks of the given callback
 // name. And error is returned if the callback name is unknown.
-func NewCallbacks(name string, data []interface{}, nextProlog, nextEpilog sqhook.Callback) (prolog, epilog sqhook.Callback, err error) {
+func NewCallbacks(name string, rule *CallbackContext, nextProlog, nextEpilog sqhook.Callback) (prolog, epilog sqhook.Callback, err error) {
 	var callbacksCtor CallbacksConstructorFunc
 	switch name {
 	default:
@@ -28,6 +34,64 @@ func NewCallbacks(name string, data []interface{}, nextProlog, nextEpilog sqhook
 		callbacksCtor = callback.NewWriteHTTPRedirectionCallbacks
 	case "AddSecurityHeaders":
 		callbacksCtor = callback.NewAddSecurityHeadersCallbacks
+	case "MonitorHTTPStatusCode":
+		callbacksCtor = callback.NewMonitorHTTPStatusCodeCallbacks
 	}
-	return callbacksCtor(data, nextProlog, nextEpilog)
+	return callbacksCtor(rule, nextProlog, nextEpilog)
+}
+
+type CallbackContext struct {
+	config              interface{}
+	metricsStores       map[string]*metrics.Store
+	defaultMetricsStore *metrics.Store
+	logger              plog.ErrorLogger
+	name                string
+}
+
+func NewCallbackContext(r *api.Rule, logger plog.ErrorLogger, metricsEngine *metrics.Engine) *CallbackContext {
+	config := newCallbackConfig(&r.Data)
+
+	var (
+		metricsStores       map[string]*metrics.Store
+		defaultMetricsStore *metrics.Store
+	)
+	if len(r.Metrics) > 0 {
+		metricsStores = make(map[string]*metrics.Store)
+		for _, m := range r.Metrics {
+			metricsStores[m.Name] = metricsEngine.NewStore(m.Name, time.Second*time.Duration(m.Period))
+		}
+		defaultMetricsStore = metricsStores[r.Metrics[0].Name]
+	}
+
+	return &CallbackContext{
+		config:              config,
+		metricsStores:       metricsStores,
+		defaultMetricsStore: defaultMetricsStore,
+		name:                r.Name,
+		logger:              logger,
+	}
+}
+
+func newCallbackConfig(data *api.RuleData) (config interface{}) {
+	if nbData := len(data.Values); nbData > 1 {
+		configArray := make([]interface{}, 0, nbData)
+		for _, e := range data.Values {
+			configArray = append(configArray, e.Value)
+		}
+		config = configArray
+	} else if nbData == 1 {
+		config = data.Values[0].Value
+	}
+	return config
+}
+
+func (d *CallbackContext) Config() interface{} {
+	return d.config
+}
+
+func (d *CallbackContext) AddMetricsValue(key interface{}, value uint64) {
+	err := d.defaultMetricsStore.Add(key, value)
+	if err != nil {
+		d.logger.Error(sqerrors.Wrap(err, fmt.Sprintf("rule `%s`: could not add a value to the default metrics store", d.name)))
+	}
 }

--- a/agent/internal/rule/callback.go
+++ b/agent/internal/rule/callback.go
@@ -89,7 +89,7 @@ func (d *CallbackContext) Config() interface{} {
 	return d.config
 }
 
-func (d *CallbackContext) AddMetricsValue(key interface{}, value uint64) {
+func (d *CallbackContext) PushMetricsValue(key interface{}, value uint64) {
 	err := d.defaultMetricsStore.Add(key, value)
 	if err != nil {
 		d.logger.Error(sqerrors.Wrap(err, fmt.Sprintf("rule `%s`: could not add a value to the default metrics store", d.name)))

--- a/agent/internal/rule/callback.go
+++ b/agent/internal/rule/callback.go
@@ -6,6 +6,7 @@ package rule
 
 import (
 	"fmt"
+	"reflect"
 	"time"
 
 	"github.com/sqreen/go-agent/agent/internal/backend/api"
@@ -73,14 +74,14 @@ func NewCallbackContext(r *api.Rule, logger plog.ErrorLogger, metricsEngine *met
 }
 
 func newCallbackConfig(data *api.RuleData) (config interface{}) {
-	if nbData := len(data.Values); nbData > 1 {
+	if nbData := len(data.Values); nbData == 1 && reflect.TypeOf(data.Values[0].Value).Kind() != reflect.Slice {
+		config = data.Values[0].Value
+	} else {
 		configArray := make([]interface{}, 0, nbData)
 		for _, e := range data.Values {
 			configArray = append(configArray, e.Value)
 		}
 		config = configArray
-	} else if nbData == 1 {
-		config = data.Values[0].Value
 	}
 	return config
 }

--- a/agent/internal/rule/callback/add-security-headers_test.go
+++ b/agent/internal/rule/callback/add-security-headers_test.go
@@ -10,7 +10,6 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/sqreen/go-agent/agent/internal/rule"
 	"github.com/sqreen/go-agent/agent/internal/rule/callback"
 	"github.com/sqreen/go-agent/agent/sqlib/sqhook"
 	"github.com/stretchr/testify/require"
@@ -22,24 +21,24 @@ func TestNewAddSecurityHeadersCallbacks(t *testing.T) {
 		ExpectProlog:  true,
 		PrologType:    reflect.TypeOf(callback.AddSecurityHeadersPrologCallbackType(nil)),
 		EpilogType:    reflect.TypeOf(callback.AddSecurityHeadersEpilogCallbackType(nil)),
-		InvalidTestCases: [][]interface{}{
+		InvalidTestCases: []interface{}{
 			nil,
-			{},
-			{33},
-			{"yet another wrong type"},
-			{[]string{}},
-			{nil},
-			{[]string{"one"}},
-			{[]string{"one", "two", "three"}},
+			33,
+			"yet another wrong type",
+			[]string{},
+			[]string{"one"},
+			[]string{"one", "two", "three"},
 		},
 		ValidTestCases: []ValidTestCase{
 			{
-				ValidData: []interface{}{
-					[]string{"k", "v"},
-					[]string{"one", "two"},
-					[]string{"canonical-header", "the value"},
+				Rule: &FakeRule{
+					config: []interface{}{
+						[]string{"k", "v"},
+						[]string{"one", "two"},
+						[]string{"canonical-header", "the value"},
+					},
 				},
-				TestCallbacks: func(t *testing.T, prolog, epilog sqhook.Callback) {
+				TestCallbacks: func(t *testing.T, _ *FakeRule, prolog, epilog sqhook.Callback) {
 					expectedHeaders := http.Header{
 						"K":                []string{"v"},
 						"One":              []string{"two"},
@@ -63,117 +62,4 @@ func TestNewAddSecurityHeadersCallbacks(t *testing.T) {
 			},
 		},
 	})
-}
-
-type TestConfig struct {
-	CallbacksCtor              rule.CallbacksConstructorFunc
-	ExpectEpilog, ExpectProlog bool
-	PrologType, EpilogType     reflect.Type
-	InvalidTestCases           [][]interface{}
-	ValidTestCases             []ValidTestCase
-}
-
-type ValidTestCase struct {
-	ValidData     []interface{}
-	TestCallbacks func(t *testing.T, prolog, epilog sqhook.Callback)
-}
-
-func RunCallbackTest(t *testing.T, config TestConfig) {
-	for _, data := range config.InvalidTestCases {
-		data := data
-		t.Run("with incorrect data", func(t *testing.T) {
-			prolog, epilog, err := config.CallbacksCtor(data, nil, nil)
-			require.Error(t, err)
-			require.Nil(t, prolog)
-			require.Nil(t, epilog)
-		})
-	}
-
-	for _, tc := range config.ValidTestCases {
-		tc := tc
-		t.Run("with correct data", func(t *testing.T) {
-			t.Run("without next callbacks", func(t *testing.T) {
-				// Instantiate the callback with the given correct rule data
-				prolog, epilog, err := config.CallbacksCtor(tc.ValidData, nil, nil)
-				require.NoError(t, err)
-				checkCallbacksValues(t, config, prolog, epilog)
-				tc.TestCallbacks(t, prolog, epilog)
-			})
-
-			t.Run("with next callbacks", func(t *testing.T) {
-				t.Run("wrong next prolog type", func(t *testing.T) {
-					prolog, epilog, err := config.CallbacksCtor(tc.ValidData, 33, nil)
-					require.Error(t, err)
-					require.Nil(t, prolog)
-					require.Nil(t, epilog)
-				})
-
-				t.Run("wrong next epilog type", func(t *testing.T) {
-					prolog, epilog, err := config.CallbacksCtor(tc.ValidData, nil, func() {})
-					require.Error(t, err)
-					require.Nil(t, prolog)
-					require.Nil(t, epilog)
-				})
-
-				t.Run("with correct next prolog", func(t *testing.T) {
-					var called bool
-					nextProlog := reflect.MakeFunc(config.PrologType, func(args []reflect.Value) (results []reflect.Value) {
-						called = true
-						return []reflect.Value{reflect.Zero(reflect.TypeOf((*error)(nil)).Elem())}
-					}).Interface()
-
-					prolog, epilog, err := config.CallbacksCtor(tc.ValidData, nextProlog, nil)
-					require.NoError(t, err)
-					checkCallbacksValues(t, config, prolog, epilog)
-					require.NotNil(t, prolog)
-					tc.TestCallbacks(t, prolog, epilog)
-					require.True(t, called)
-				})
-
-				t.Run("with correct next epilog", func(t *testing.T) {
-					var called bool
-					nextEpilog := reflect.MakeFunc(config.EpilogType, func(args []reflect.Value) (results []reflect.Value) {
-						called = true
-						return
-					}).Interface()
-
-					prolog, epilog, err := config.CallbacksCtor(tc.ValidData, nil, nextEpilog)
-					require.NoError(t, err)
-					checkCallbacksValues(t, config, prolog, epilog)
-					require.NotNil(t, epilog)
-					tc.TestCallbacks(t, prolog, epilog)
-					require.True(t, called)
-				})
-
-				t.Run("with both correct next callbacks", func(t *testing.T) {
-					var calledProlog, calledEpilog bool
-					nextProlog := reflect.MakeFunc(config.PrologType, func(args []reflect.Value) (results []reflect.Value) {
-						calledProlog = true
-						return []reflect.Value{reflect.Zero(reflect.TypeOf((*error)(nil)).Elem())}
-					}).Interface()
-					nextEpilog := reflect.MakeFunc(config.EpilogType, func(args []reflect.Value) (results []reflect.Value) {
-						calledEpilog = true
-						return
-					}).Interface()
-
-					prolog, epilog, err := config.CallbacksCtor(tc.ValidData, nextProlog, nextEpilog)
-					require.NoError(t, err)
-					require.NotNil(t, prolog)
-					require.NotNil(t, epilog)
-					tc.TestCallbacks(t, prolog, epilog)
-					require.True(t, calledProlog)
-					require.True(t, calledEpilog)
-				})
-			})
-		})
-	}
-}
-
-func checkCallbacksValues(t *testing.T, config TestConfig, prolog, epilog sqhook.Callback) {
-	if config.ExpectProlog {
-		require.NotNil(t, prolog)
-	}
-	if config.ExpectEpilog {
-		require.NotNil(t, prolog)
-	}
 }

--- a/agent/internal/rule/callback/callback_test.go
+++ b/agent/internal/rule/callback/callback_test.go
@@ -132,7 +132,7 @@ type FakeRule struct {
 	mock.Mock
 }
 
-func (r *FakeRule) AddMetricsValue(key interface{}, value uint64) {
+func (r *FakeRule) PushMetricsValue(key interface{}, value uint64) {
 	r.Called(key, value)
 }
 

--- a/agent/internal/rule/callback/callback_test.go
+++ b/agent/internal/rule/callback/callback_test.go
@@ -1,0 +1,141 @@
+// Copyright (c) 2016 - 2019 Sqreen. All Rights Reserved.
+// Please refer to our terms for more information:
+// https://www.sqreen.io/terms.html
+
+package callback_test
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/sqreen/go-agent/agent/internal/rule"
+	"github.com/sqreen/go-agent/agent/sqlib/sqhook"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+type TestConfig struct {
+	CallbacksCtor              rule.CallbacksConstructorFunc
+	ExpectEpilog, ExpectProlog bool
+	PrologType, EpilogType     reflect.Type
+	InvalidTestCases           []interface{}
+	ValidTestCases             []ValidTestCase
+}
+
+type ValidTestCase struct {
+	Rule          *FakeRule
+	TestCallbacks func(t *testing.T, rule *FakeRule, prolog, epilog sqhook.Callback)
+}
+
+func RunCallbackTest(t *testing.T, config TestConfig) {
+	for _, data := range config.InvalidTestCases {
+		data := data
+		t.Run("with incorrect data", func(t *testing.T) {
+			prolog, epilog, err := config.CallbacksCtor(&FakeRule{config: data}, nil, nil)
+			require.Error(t, err)
+			require.Nil(t, prolog)
+			require.Nil(t, epilog)
+		})
+	}
+
+	for _, tc := range config.ValidTestCases {
+		tc := tc
+		t.Run("with correct data", func(t *testing.T) {
+			t.Run("without next callbacks", func(t *testing.T) {
+				// Instantiate the callback with the given correct rule data
+				prolog, epilog, err := config.CallbacksCtor(tc.Rule, nil, nil)
+				require.NoError(t, err)
+				checkCallbacksValues(t, config, prolog, epilog)
+				tc.TestCallbacks(t, tc.Rule, prolog, epilog)
+			})
+
+			t.Run("with next callbacks", func(t *testing.T) {
+				t.Run("wrong next prolog type", func(t *testing.T) {
+					prolog, epilog, err := config.CallbacksCtor(tc.Rule, 33, nil)
+					require.Error(t, err)
+					require.Nil(t, prolog)
+					require.Nil(t, epilog)
+				})
+
+				t.Run("wrong next epilog type", func(t *testing.T) {
+					prolog, epilog, err := config.CallbacksCtor(tc.Rule, nil, func() {})
+					require.Error(t, err)
+					require.Nil(t, prolog)
+					require.Nil(t, epilog)
+				})
+
+				t.Run("with correct next prolog", func(t *testing.T) {
+					var called bool
+					nextProlog := reflect.MakeFunc(config.PrologType, func(args []reflect.Value) (results []reflect.Value) {
+						called = true
+						return []reflect.Value{reflect.Zero(reflect.TypeOf((*error)(nil)).Elem())}
+					}).Interface()
+
+					prolog, epilog, err := config.CallbacksCtor(tc.Rule, nextProlog, nil)
+					require.NoError(t, err)
+					checkCallbacksValues(t, config, prolog, epilog)
+					require.NotNil(t, prolog)
+					tc.TestCallbacks(t, tc.Rule, prolog, epilog)
+					require.True(t, called)
+				})
+
+				t.Run("with correct next epilog", func(t *testing.T) {
+					var called bool
+					nextEpilog := reflect.MakeFunc(config.EpilogType, func(args []reflect.Value) (results []reflect.Value) {
+						called = true
+						return
+					}).Interface()
+
+					prolog, epilog, err := config.CallbacksCtor(tc.Rule, nil, nextEpilog)
+					require.NoError(t, err)
+					checkCallbacksValues(t, config, prolog, epilog)
+					require.NotNil(t, epilog)
+					tc.TestCallbacks(t, tc.Rule, prolog, epilog)
+					require.True(t, called)
+				})
+
+				t.Run("with both correct next callbacks", func(t *testing.T) {
+					var calledProlog, calledEpilog bool
+					nextProlog := reflect.MakeFunc(config.PrologType, func(args []reflect.Value) (results []reflect.Value) {
+						calledProlog = true
+						return []reflect.Value{reflect.Zero(reflect.TypeOf((*error)(nil)).Elem())}
+					}).Interface()
+					nextEpilog := reflect.MakeFunc(config.EpilogType, func(args []reflect.Value) (results []reflect.Value) {
+						calledEpilog = true
+						return
+					}).Interface()
+
+					prolog, epilog, err := config.CallbacksCtor(tc.Rule, nextProlog, nextEpilog)
+					require.NoError(t, err)
+					require.NotNil(t, prolog)
+					require.NotNil(t, epilog)
+					tc.TestCallbacks(t, tc.Rule, prolog, epilog)
+					require.True(t, calledProlog)
+					require.True(t, calledEpilog)
+				})
+			})
+		})
+	}
+}
+
+func checkCallbacksValues(t *testing.T, config TestConfig, prolog, epilog sqhook.Callback) {
+	if config.ExpectProlog {
+		require.NotNil(t, prolog)
+	}
+	if config.ExpectEpilog {
+		require.NotNil(t, epilog)
+	}
+}
+
+type FakeRule struct {
+	config interface{}
+	mock.Mock
+}
+
+func (r *FakeRule) AddMetricsValue(key interface{}, value uint64) {
+	r.Called(key, value)
+}
+
+func (r *FakeRule) Config() interface{} {
+	return r.config
+}

--- a/agent/internal/rule/callback/monitor-http-status-code.go
+++ b/agent/internal/rule/callback/monitor-http-status-code.go
@@ -26,9 +26,7 @@ func NewMonitorHTTPStatusCodeCallbacks(rule Context, nextProlog, nextEpilog sqho
 
 func newMonitorHTTPStatusCodePrologCallback(rule Context, next MonitorHTTPStatusCodePrologCallbackType) MonitorHTTPStatusCodePrologCallbackType {
 	return func(ctx *sqhook.Context, code *int) error {
-		//if status := *code; status >= 400 && status <= 500 {
 		rule.AddMetricsValue(*code, 1)
-		//}
 
 		if next == nil {
 			return nil

--- a/agent/internal/rule/callback/monitor-http-status-code.go
+++ b/agent/internal/rule/callback/monitor-http-status-code.go
@@ -26,7 +26,7 @@ func NewMonitorHTTPStatusCodeCallbacks(rule Context, nextProlog, nextEpilog sqho
 
 func newMonitorHTTPStatusCodePrologCallback(rule Context, next MonitorHTTPStatusCodePrologCallbackType) MonitorHTTPStatusCodePrologCallbackType {
 	return func(ctx *sqhook.Context, code *int) error {
-		rule.AddMetricsValue(*code, 1)
+		rule.PushMetricsValue(*code, 1)
 
 		if next == nil {
 			return nil

--- a/agent/internal/rule/callback/monitor-http-status-code.go
+++ b/agent/internal/rule/callback/monitor-http-status-code.go
@@ -1,0 +1,41 @@
+// Copyright (c) 2016 - 2019 Sqreen. All Rights Reserved.
+// Please refer to our terms for more information:
+// https://www.sqreen.io/terms.html
+
+package callback
+
+import (
+	"github.com/sqreen/go-agent/agent/sqlib/sqerrors"
+	"github.com/sqreen/go-agent/agent/sqlib/sqhook"
+)
+
+func NewMonitorHTTPStatusCodeCallbacks(rule Context, nextProlog, nextEpilog sqhook.Callback) (prolog, epilog sqhook.Callback, err error) {
+	// Next callbacks to call
+	actualNextProlog, ok := nextProlog.(MonitorHTTPStatusCodePrologCallbackType)
+	if nextProlog != nil && !ok {
+		err = sqerrors.Errorf("unexpected next prolog type `%T` instead of `%T`", nextProlog, MonitorHTTPStatusCodePrologCallbackType(nil))
+		return
+	}
+	// No epilog in this callback, so simply check and pass the given one
+	if _, ok := nextEpilog.(MonitorHTTPStatusCodeEpilogCallbackType); nextEpilog != nil && !ok {
+		err = sqerrors.Errorf("unexpected next epilog type `%T` instead of `%T`", nextEpilog, MonitorHTTPStatusCodeEpilogCallbackType(nil))
+		return
+	}
+	return newMonitorHTTPStatusCodePrologCallback(rule, actualNextProlog), nextEpilog, nil
+}
+
+func newMonitorHTTPStatusCodePrologCallback(rule Context, next MonitorHTTPStatusCodePrologCallbackType) MonitorHTTPStatusCodePrologCallbackType {
+	return func(ctx *sqhook.Context, code *int) error {
+		//if status := *code; status >= 400 && status <= 500 {
+		rule.AddMetricsValue(*code, 1)
+		//}
+
+		if next == nil {
+			return nil
+		}
+		return next(ctx, code)
+	}
+}
+
+type MonitorHTTPStatusCodePrologCallbackType = func(*sqhook.Context, *int) error
+type MonitorHTTPStatusCodeEpilogCallbackType = func(*sqhook.Context)

--- a/agent/internal/rule/callback/monitor-http-status-code_test.go
+++ b/agent/internal/rule/callback/monitor-http-status-code_test.go
@@ -1,0 +1,45 @@
+// Copyright (c) 2016 - 2019 Sqreen. All Rights Reserved.
+// Please refer to our terms for more information:
+// https://www.sqreen.io/terms.html
+
+package callback_test
+
+import (
+	"math/rand"
+	"reflect"
+	"testing"
+
+	"github.com/sqreen/go-agent/agent/internal/rule/callback"
+	"github.com/sqreen/go-agent/agent/sqlib/sqhook"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewMonitorHTTPStatusCodeCallbacks(t *testing.T) {
+	RunCallbackTest(t, TestConfig{
+		CallbacksCtor: callback.NewMonitorHTTPStatusCodeCallbacks,
+		ExpectProlog:  true,
+		PrologType:    reflect.TypeOf(callback.MonitorHTTPStatusCodePrologCallbackType(nil)),
+		EpilogType:    reflect.TypeOf(callback.MonitorHTTPStatusCodeEpilogCallbackType(nil)),
+		ValidTestCases: []ValidTestCase{
+			{
+				Rule: &FakeRule{},
+				TestCallbacks: func(t *testing.T, rule *FakeRule, prolog, epilog sqhook.Callback) {
+					actualProlog, ok := prolog.(callback.MonitorHTTPStatusCodePrologCallbackType)
+					require.True(t, ok)
+					code := rand.Int()
+					rule.On("AddMetricsValue", code, uint64(1)).Return().Once()
+					err := actualProlog(nil, &code)
+					// Check it behaves as expected
+					require.NoError(t, err)
+
+					// Test the epilog if any
+					if epilog != nil {
+						actualEpilog, ok := epilog.(callback.MonitorHTTPStatusCodeEpilogCallbackType)
+						require.True(t, ok)
+						actualEpilog(&sqhook.Context{})
+					}
+				},
+			},
+		},
+	})
+}

--- a/agent/internal/rule/callback/monitor-http-status-code_test.go
+++ b/agent/internal/rule/callback/monitor-http-status-code_test.go
@@ -27,7 +27,7 @@ func TestNewMonitorHTTPStatusCodeCallbacks(t *testing.T) {
 					actualProlog, ok := prolog.(callback.MonitorHTTPStatusCodePrologCallbackType)
 					require.True(t, ok)
 					code := rand.Int()
-					rule.On("AddMetricsValue", code, uint64(1)).Return().Once()
+					rule.On("PushMetricsValue", code, uint64(1)).Return().Once()
 					err := actualProlog(nil, &code)
 					// Check it behaves as expected
 					require.NoError(t, err)

--- a/agent/internal/rule/callback/types.go
+++ b/agent/internal/rule/callback/types.go
@@ -1,0 +1,13 @@
+// Copyright (c) 2016 - 2019 Sqreen. All Rights Reserved.
+// Please refer to our terms for more information:
+// https://www.sqreen.io/terms.html
+
+package callback
+
+type Context interface {
+	// Get the rule configuration.
+	Config() interface{}
+	// Add a new metrics value for the given key to the default metrics store
+	// given by the rule.
+	AddMetricsValue(key interface{}, value uint64)
+}

--- a/agent/internal/rule/callback/types.go
+++ b/agent/internal/rule/callback/types.go
@@ -7,7 +7,7 @@ package callback
 type Context interface {
 	// Get the rule configuration.
 	Config() interface{}
-	// Add a new metrics value for the given key to the default metrics store
+	// Push a new metrics value for the given key into the default metrics store
 	// given by the rule.
-	AddMetricsValue(key interface{}, value uint64)
+	PushMetricsValue(key interface{}, value uint64)
 }

--- a/agent/internal/rule/callback/write-custom-error-page.go
+++ b/agent/internal/rule/callback/write-custom-error-page.go
@@ -16,13 +16,12 @@ import (
 // callbacks modifying the arguments of `httphandler.WriteResponse` in order to
 // modify the http status code and error page that are provided by the rule's
 // data.
-func NewWriteCustomErrorPageCallbacks(data []interface{}, nextProlog, nextEpilog sqhook.Callback) (prolog, epilog sqhook.Callback, err error) {
+func NewWriteCustomErrorPageCallbacks(rule Context, nextProlog, nextEpilog sqhook.Callback) (prolog, epilog sqhook.Callback, err error) {
 	var statusCode = 500
-	if len(data) > 0 {
-		d0 := data[0]
-		cfg, ok := d0.(*api.CustomErrorPageRuleDataEntry)
+	if cfg := rule.Config(); cfg != nil {
+		cfg, ok := cfg.(*api.CustomErrorPageRuleDataEntry)
 		if !ok {
-			err = sqerrors.Errorf("unexpected callback data type: got `%T` instead of `*api.CustomErrorPageRuleDataEntry`", d0)
+			err = sqerrors.Errorf("unexpected callback data type: got `%T` instead of `*api.CustomErrorPageRuleDataEntry`", cfg)
 			return
 		}
 		statusCode = cfg.StatusCode

--- a/agent/internal/rule/callback/write-custom-error-page_test.go
+++ b/agent/internal/rule/callback/write-custom-error-page_test.go
@@ -20,22 +20,18 @@ func TestNewWriteCustomErrorPageCallbacks(t *testing.T) {
 		ExpectProlog:  true,
 		PrologType:    reflect.TypeOf(callback.WriteCustomErrorPagePrologCallbackType(nil)),
 		EpilogType:    reflect.TypeOf(callback.WriteCustomErrorPageEpilogCallbackType(nil)),
-		InvalidTestCases: [][]interface{}{
-			{33},
-			{"yet another wrong type"},
+		InvalidTestCases: []interface{}{
+			33,
+			"yet another wrong type",
 		},
 		ValidTestCases: []ValidTestCase{
 			{
-				ValidData:     nil,
+				Rule:          &FakeRule{},
 				TestCallbacks: testWriteCustomErrorPageCallbacks(500),
 			},
 			{
-				ValidData:     []interface{}{},
-				TestCallbacks: testWriteCustomErrorPageCallbacks(500),
-			},
-			{
-				ValidData: []interface{}{
-					&api.CustomErrorPageRuleDataEntry{StatusCode: 33},
+				Rule: &FakeRule{
+					config: &api.CustomErrorPageRuleDataEntry{StatusCode: 33},
 				},
 				TestCallbacks: testWriteCustomErrorPageCallbacks(33),
 			},
@@ -43,8 +39,8 @@ func TestNewWriteCustomErrorPageCallbacks(t *testing.T) {
 	})
 }
 
-func testWriteCustomErrorPageCallbacks(expectedStatusCode int) func(t *testing.T, prolog sqhook.Callback, epilog sqhook.Callback) {
-	return func(t *testing.T, prolog, epilog sqhook.Callback) {
+func testWriteCustomErrorPageCallbacks(expectedStatusCode int) func(t *testing.T, rule *FakeRule, prolog sqhook.Callback, epilog sqhook.Callback) {
+	return func(t *testing.T, _ *FakeRule, prolog, epilog sqhook.Callback) {
 		actualProlog, ok := prolog.(callback.WriteCustomErrorPagePrologCallbackType)
 		require.True(t, ok)
 		var (

--- a/agent/internal/rule/callback/write-http-redirection_test.go
+++ b/agent/internal/rule/callback/write-http-redirection_test.go
@@ -6,52 +6,57 @@ package callback_test
 
 import (
 	"net/http"
+	"reflect"
 	"testing"
 
 	"github.com/sqreen/go-agent/agent/internal/backend/api"
 	"github.com/sqreen/go-agent/agent/internal/rule/callback"
+	"github.com/sqreen/go-agent/agent/sqlib/sqhook"
 	"github.com/stretchr/testify/require"
 )
 
 func TestNewWriteHTTPRedirectionCallbacks(t *testing.T) {
-	t.Run("with incorrect data", func(t *testing.T) {
-		for _, data := range [][]interface{}{
+	RunCallbackTest(t, TestConfig{
+		CallbacksCtor: callback.NewWriteHTTPRedirectionCallbacks,
+		ExpectProlog:  true,
+		PrologType:    reflect.TypeOf(callback.WriteHTTPRedirectionPrologCallbackType(nil)),
+		EpilogType:    reflect.TypeOf(callback.WriteHTTPRedirectionEpilogCallbackType(nil)),
+		InvalidTestCases: []interface{}{
 			nil,
-			{},
-			{33},
-			{"yet another wrong type"},
-			{&api.CustomErrorPageRuleDataEntry{}},
-			{&api.RedirectionRuleDataEntry{}},
-			{&api.RedirectionRuleDataEntry{"http//sqreen.com"}},
-		} {
-			prolog, epilog, err := callback.NewWriteHTTPRedirectionCallbacks(data, nil, nil)
-			require.Error(t, err)
-			require.Nil(t, prolog)
-			require.Nil(t, epilog)
-		}
-	})
+			33,
+			"yet another wrong type",
+			&api.CustomErrorPageRuleDataEntry{},
+			&api.RedirectionRuleDataEntry{},
+			&api.RedirectionRuleDataEntry{"http//sqreen.com"},
+		},
+		ValidTestCases: []ValidTestCase{
+			{
+				Rule: &FakeRule{
+					config: &api.RedirectionRuleDataEntry{"http://sqreen.com"},
+				},
+				TestCallbacks: func(t *testing.T, rule *FakeRule, prolog, epilog sqhook.Callback) {
+					// Call it and check the behaviour follows the rule's data
+					actualProlog, ok := prolog.(callback.WriteHTTPRedirectionPrologCallbackType)
+					require.True(t, ok)
+					var (
+						statusCode int
+						headers    http.Header
+					)
+					err := actualProlog(nil, nil, nil, &headers, &statusCode, nil)
+					// Check it behaves as expected
+					require.NoError(t, err)
+					require.Equal(t, http.StatusSeeOther, statusCode)
+					require.NotNil(t, headers)
+					require.Equal(t, "http://sqreen.com", headers.Get("Location"))
 
-	t.Run("with correct data", func(t *testing.T) {
-		// Instantiate the callback with the given correct rule data
-		expectedURL := "http://sqreen.com"
-		prolog, epilog, err := callback.NewWriteHTTPRedirectionCallbacks([]interface{}{
-			&api.RedirectionRuleDataEntry{RedirectionURL: expectedURL},
-		}, nil, nil)
-		require.NoError(t, err)
-		require.NotNil(t, prolog)
-		require.Nil(t, epilog)
-		// Call it and check the behaviour follows the rule's data
-		actualProlog, ok := prolog.(callback.WriteHTTPRedirectionPrologCallbackType)
-		require.True(t, ok)
-		var (
-			statusCode int
-			headers    http.Header
-		)
-		err = actualProlog(nil, nil, nil, &headers, &statusCode, nil)
-		// Check it behaves as expected
-		require.NoError(t, err)
-		require.Equal(t, http.StatusSeeOther, statusCode)
-		require.NotNil(t, headers)
-		require.Equal(t, expectedURL, headers.Get("Location"))
+					// Test the epilog if any
+					if epilog != nil {
+						actualEpilog, ok := epilog.(callback.WriteHTTPRedirectionEpilogCallbackType)
+						require.True(t, ok)
+						actualEpilog(&sqhook.Context{})
+					}
+				},
+			},
+		},
 	})
 }

--- a/agent/internal/rule/callback_test.go
+++ b/agent/internal/rule/callback_test.go
@@ -16,33 +16,37 @@ func TestNewCallbacks(t *testing.T) {
 	for _, tc := range []struct {
 		testName      string
 		name          string
-		data          []interface{}
+		rule          *rule.CallbackContext
 		shouldSucceed bool
 	}{
 		{
 			testName:      "not existing",
 			name:          "iDontExist",
-			data:          nil,
+			rule:          nil,
 			shouldSucceed: false,
 		},
 		{
 			testName:      "empty string",
 			name:          "",
-			data:          nil,
+			rule:          nil,
 			shouldSucceed: false,
 		},
 		{
 			testName: "WriteCustomErrorPage",
 			name:     "WriteCustomErrorPage",
-			data: []interface{}{
-				&api.CustomErrorPageRuleDataEntry{},
-			},
+			rule: rule.NewCallbackContext(&api.Rule{
+				Data: api.RuleData{
+					Values: []api.RuleDataEntry{
+						{&api.CustomErrorPageRuleDataEntry{}},
+					},
+				},
+			}, nil, nil),
 			shouldSucceed: true,
 		},
 	} {
 		tc := tc
 		t.Run(tc.testName, func(t *testing.T) {
-			_, _, err := rule.NewCallbacks(tc.name, tc.data, nil, nil)
+			_, _, err := rule.NewCallbacks(tc.name, tc.rule, nil, nil)
 			if tc.shouldSucceed {
 				require.NoError(t, err)
 			} else {

--- a/agent/internal/rule/rule_test.go
+++ b/agent/internal/rule/rule_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/sqreen/go-agent/agent/internal/backend/api"
+	"github.com/sqreen/go-agent/agent/internal/metrics"
 	"github.com/sqreen/go-agent/agent/internal/plog"
 	"github.com/sqreen/go-agent/agent/internal/rule"
 	"github.com/sqreen/go-agent/agent/sqlib/sqhook"
@@ -24,7 +25,7 @@ type empty struct{}
 
 func TestEngineUsage(t *testing.T) {
 	logger := plog.NewLogger(plog.Debug, os.Stderr, 0)
-	engine := rule.NewEngine(logger)
+	engine := rule.NewEngine(logger, metrics.NewEngine(plog.NewLogger(plog.Debug, os.Stderr, 0)))
 	hookFunc1 := sqhook.New(func1)
 	require.NotNil(t, hookFunc1)
 	hookFunc2 := sqhook.New(func2)
@@ -52,6 +53,11 @@ func TestEngineUsage(t *testing.T) {
 					Method:   "func1",
 					Callback: "WriteCustomErrorPage",
 				},
+				Data: api.RuleData{
+					Values: []api.RuleDataEntry{
+						{&api.CustomErrorPageRuleDataEntry{}},
+					},
+				},
 			},
 			{
 				Name: "another valid rule",
@@ -59,6 +65,11 @@ func TestEngineUsage(t *testing.T) {
 					Class:    reflect.TypeOf(empty{}).PkgPath(),
 					Method:   "func2",
 					Callback: "WriteCustomErrorPage",
+				},
+				Data: api.RuleData{
+					Values: []api.RuleDataEntry{
+						{&api.CustomErrorPageRuleDataEntry{}},
+					},
 				},
 			},
 		})
@@ -119,6 +130,11 @@ func TestEngineUsage(t *testing.T) {
 					Class:    reflect.TypeOf(empty{}).PkgPath(),
 					Method:   "func2",
 					Callback: "WriteCustomErrorPage",
+				},
+				Data: api.RuleData{
+					Values: []api.RuleDataEntry{
+						{&api.CustomErrorPageRuleDataEntry{}},
+					},
 				},
 			},
 		})

--- a/sdk/middleware/sqecho/echo.go
+++ b/sdk/middleware/sqecho/echo.go
@@ -65,7 +65,7 @@ func Middleware() echo.MiddlewareFunc {
 				contextKey := sdk.HTTPRequestRecordContextKey.String
 				c.Set(contextKey, sdk.FromContext(r.Context()))
 				c.Response().After(func() {
-					// Hack for now to monitor the status code because Gin doesn't use the
+					// Hack for now to monitor the status code because Echo doesn't use the
 					// HTTP ResponseWriter when overwriting it through c.Writer = ...
 					sqhttp.ResponseWriter{}.WriteHeader(c.Response().Status)
 				})

--- a/sdk/middleware/sqecho/echo.go
+++ b/sdk/middleware/sqecho/echo.go
@@ -58,12 +58,17 @@ func Middleware() echo.MiddlewareFunc {
 	// Create a middleware function by adapting to sqhttp's
 	return func(next echo.HandlerFunc) echo.HandlerFunc {
 		return func(c echo.Context) error {
-			return sqhttp.MiddlewareWithError(sqhttp.HandlerFunc(func(w http.ResponseWriter, r *http.Request) error {
+			return sqhttp.MiddlewareWithError(sqhttp.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) error {
 				c.SetRequest(r)
 				// Echo defines its own context interface, so we need to store it in
 				// Echo's context. Echo expects string keys.
 				contextKey := sdk.HTTPRequestRecordContextKey.String
 				c.Set(contextKey, sdk.FromContext(r.Context()))
+				c.Response().After(func() {
+					// Hack for now to monitor the status code because Gin doesn't use the
+					// HTTP ResponseWriter when overwriting it through c.Writer = ...
+					sqhttp.ResponseWriter{}.WriteHeader(c.Response().Status)
+				})
 				return next(c)
 			})).ServeHTTP(c.Response(), c.Request())
 		}

--- a/sdk/middleware/sqgin/gin.go
+++ b/sdk/middleware/sqgin/gin.go
@@ -67,10 +67,17 @@ func Middleware() gingonic.HandlerFunc {
 			contextKey := sdk.HTTPRequestRecordContextKey.String
 			c.Set(contextKey, sdk.FromContext(r.Context()))
 			c.Next()
+			monitorHTTPStatusCode(c.Writer.Status())
 			return nil
 		})).ServeHTTP(c.Writer, c.Request)
 		if err != nil {
 			c.Abort()
 		}
 	}
+}
+
+func monitorHTTPStatusCode(statusCode int) {
+	// Hack for now to monitor the status code because Gin doesn't use the
+	// HTTP ResponseWriter when overwriting it through c.Writer = ...
+	sqhttp.ResponseWriter{}.WriteHeader(statusCode)
 }


### PR DESCRIPTION
The monitoring of http status codes is attached to the http response writer. Unfortunately, most frameworks don't use the standard http response writer that we instrument and I had to implement a hack for Gin and Echo to monitor the status code.

As of gRPC, it doesn't seem to be possible to get the http status code it will return from the interceptors so we will wait for the future compiler-inserted hook points in order to attach to internal gRPC http transport methods in order to get the status code.

- [x] Add a simple http status code monitoring callback.
- [x] Add a single hookpoint to the middlewares.
- [x] Implement a new metrics engine to get rid of the time and memory consumption we had and optimized for this status code monitoring use-case.
- [x] Adapt the agent logic to the new polling API of the metrics engine.