### PR TITLE
agent/waf: advanced error management

### DIFF
--- a/agent/internal/backend/api/api.go
+++ b/agent/internal/backend/api/api.go
@@ -99,6 +99,7 @@ type ExceptionEvent struct {
 	Message     string           `json:"message"`
 	RulespackID string           `json:"rulespack_id"`
 	Context     ExceptionContext `json:"context"`
+	Infos       interface{}      `json:"infos,omitempty"`
 }
 
 type ExceptionEventFace interface {
@@ -107,6 +108,7 @@ type ExceptionEventFace interface {
 	GetMessage() string
 	GetRulespackID() string
 	GetContext() ExceptionContext
+	GetInfos() interface{}
 }
 
 func NewExceptionEventFromFace(e ExceptionEventFace) *ExceptionEvent {
@@ -116,6 +118,7 @@ func NewExceptionEventFromFace(e ExceptionEventFace) *ExceptionEvent {
 		Message:     e.GetMessage(),
 		Context:     e.GetContext(),
 		RulespackID: e.GetRulespackID(),
+		Infos:       e.GetInfos(),
 	}
 }
 

--- a/agent/internal/batch.go
+++ b/agent/internal/batch.go
@@ -73,6 +73,10 @@ func (e *ExceptionEvent) GetBacktrace() []api.StackFrame {
 	return bt
 }
 
+func (e *ExceptionEvent) GetInfos() interface{} {
+	return sqerrors.Info(e.err)
+}
+
 type apiStackFrame sqerrors.Frame
 
 func (f apiStackFrame) GetMethod() string {

--- a/agent/sqlib/sqerrors/errors_test.go
+++ b/agent/sqlib/sqerrors/errors_test.go
@@ -1,0 +1,48 @@
+// Copyright (c) 2016 - 2019 Sqreen. All Rights Reserved.
+// Please refer to our terms for more information:
+// https://www.sqreen.io/terms.html
+
+package sqerrors_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/sqreen/go-agent/agent/sqlib/sqerrors"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWithInfo(t *testing.T) {
+	t.Run("single info", func(t *testing.T) {
+		err := errors.New("an error")
+		info := map[string]string{
+			"k1": "v1",
+			"k2": "v2",
+		}
+		err = sqerrors.WithInfo(err, info)
+		err = sqerrors.Wrap(err, "an error occurred")
+		got := sqerrors.Info(err)
+		require.Equal(t, info, got)
+	})
+
+	t.Run("multiple info", func(t *testing.T) {
+		err := errors.New("an error")
+		info := map[string]string{
+			"k1": "v1",
+			"k2": "v2",
+		}
+		err = sqerrors.WithInfo(err, info)
+		err = sqerrors.Wrap(err, "an error occurred")
+		err = sqerrors.WithInfo(err, map[string]string{"key": "value"})
+		err = sqerrors.Wrap(err, "an error occurred")
+		err = sqerrors.Wrap(err, "an error occurred")
+		err = sqerrors.WithInfo(err, "what ever")
+		err = sqerrors.Wrap(err, "an error occurred")
+		err = sqerrors.Wrap(err, "an error occurred")
+		err = sqerrors.WithInfo(err, 33)
+
+		// Check that we get the deepest level
+		got := sqerrors.Info(err)
+		require.Equal(t, info, got)
+	})
+}


### PR DESCRIPTION
Further manage the WAF errors by:
- ignoring timeout error instead of reporting them as errors.
- add extra information to the reported error.