### PR TITLE
PII scrubbing of every batched events

### DIFF
--- a/agent/internal/agent.go
+++ b/agent/internal/agent.go
@@ -26,6 +26,7 @@ import (
 	"github.com/sqreen/go-agent/agent/internal/rule"
 	"github.com/sqreen/go-agent/agent/sqlib/sqerrors"
 	"github.com/sqreen/go-agent/agent/sqlib/sqsafe"
+	"github.com/sqreen/go-agent/agent/sqlib/sqsanitize"
 	"github.com/sqreen/go-agent/agent/sqlib/sqtime"
 	"github.com/sqreen/go-agent/agent/types"
 	"github.com/sqreen/go-agent/sdk"
@@ -139,6 +140,7 @@ type Agent struct {
 	client        *backend.Client
 	actors        *actor.Store
 	rules         *rule.Engine
+	piiScrubber   *sqsanitize.Scrubber
 }
 
 func (a *Agent) FindActionByIP(ip net.IP) (action actor.Action, exists bool, err error) {
@@ -182,6 +184,12 @@ func New(cfg *config.Config) *Agent {
 	sdkMetricsPeriod := time.Duration(cfg.SDKMetricsPeriod()) * time.Second
 	logger.Debugf("using sdk metrics store period of %s", sdkMetricsPeriod)
 
+	piiScrubber, err := sqsanitize.NewScrubber(config.ScrubberKeyRegexp, config.ScrubberValueRegexp, config.ScrubberRedactedString)
+	if err != nil {
+		logger.Error(sqerrors.Wrap(err, "ecdsa public key"))
+		return nil
+	}
+
 	// Agent graceful stopping using context cancellation.
 	ctx, cancel := context.WithCancel(context.Background())
 	return &Agent{
@@ -195,19 +203,19 @@ func New(cfg *config.Config) *Agent {
 			whitelistedIP:       metrics.NewStore("whitelisted", sdkMetricsPeriod),
 			errors:              metrics.NewStore("errors", config.ErrorMetricsPeriod),
 		},
-		ctx:     ctx,
-		cancel:  cancel,
-		config:  cfg,
-		appInfo: app.NewInfo(logger),
-		client:  backend.NewClient(cfg.BackendHTTPAPIBaseURL(), cfg, logger),
-		actors:  actor.NewStore(logger),
-		rules:   rulesEngine,
+		ctx:         ctx,
+		cancel:      cancel,
+		config:      cfg,
+		appInfo:     app.NewInfo(logger),
+		client:      backend.NewClient(cfg.BackendHTTPAPIBaseURL(), cfg, logger),
+		actors:      actor.NewStore(logger),
+		rules:       rulesEngine,
+		piiScrubber: piiScrubber,
 	}
 }
 
 func (a *Agent) NewRequestRecord(req *http.Request) (types.RequestRecord, *http.Request) {
-	rr, req := record.NewRequestRecord(a, a.logger, req, a.config)
-	return rr, req
+	return record.NewRequestRecord(a, a.logger, req, a.config)
 }
 
 func (a *Agent) Serve() error {
@@ -248,7 +256,7 @@ func (a *Agent) Serve() error {
 
 	batchSize := int(appLoginRes.Features.BatchSize)
 	if batchSize == 0 {
-		batchSize = config.MaxEventsPerHeatbeat
+		batchSize = config.EventBatchMaxEventsPerHeartbeat
 	}
 	maxStaleness := time.Duration(appLoginRes.Features.MaxStaleness) * time.Second
 	if maxStaleness == 0 {
@@ -489,6 +497,11 @@ func (m *eventManager) send(client *backend.Client, batch []Event) {
 			event = (*api.RequestRecordEvent)(api.NewRequestRecordFromFace(actual))
 		case *ExceptionEvent:
 			event = api.NewExceptionEventFromFace(actual)
+		}
+		if _, err := m.agent.piiScrubber.Scrub(event); err != nil {
+			// Only log this unexpected error and keep the event that may have been
+			// partially scrubbed.
+			m.agent.logger.Error(errors.Wrap(err, "could not send the event batch"))
 		}
 		req.Batch = append(req.Batch, *api.NewBatchRequest_EventFromFace(event))
 	}

--- a/agent/internal/config/config.go
+++ b/agent/internal/config/config.go
@@ -93,15 +93,32 @@ var (
 	// BackendHTTPAPIDefaultHeartbeatDelay is the default heartbeat delay when not
 	// correctly provided by the backend.
 	BackendHTTPAPIDefaultHeartbeatDelay = time.Minute
-
-	// EventBatchMaxStaleness is the time when the data in the event manager's
-	// batch is considered too long, and is therefore immediatly sent to the
-	// backend, without waiting for the batch to become full.
-	EventBatchMaxStaleness = 20 * time.Second
 )
 
+// Event batch configuration.
 const (
-	MaxEventsPerHeatbeat = 1000
+	// EventBatchMaxStaleness is the time when the data in the event manager's
+	// batch is considered too long, and is therefore immediately sent to the
+	// backend, without waiting for the batch to become full.
+	EventBatchMaxStaleness = 20 * time.Second
+	// EventBatchMaxEventsPerHeartbeat is the maximum amount of events that can
+	// be sent per heartbeat. The bigger, the more memory it uses to batch the
+	// events.
+	EventBatchMaxEventsPerHeartbeat = 1000
+)
+
+// Data sanitization configuration.
+const (
+	// ScrubberKeyRegexp is the scrubber key regular expression (cf. scrubber doc
+	// for usage). It is a case-insensitive regexp matching passwd, password,
+	// passphrase, secret, authorization, api_key, apikey, accesstoken,
+	// access_token and token.
+	ScrubberKeyRegexp = `(?i)(passw(((or)?d))|(phrase))|(secret)|(authorization)|(api_?key)|((access_?)?token)`
+	// ScrubberValueRegexp is the scrubber value regular expression (cf. scrubber
+	// doc for usage). It matches credit card numbers with space, dash or no
+	// number separators.
+	ScrubberValueRegexp    = `(?:\d[ -]*?){13,16}`
+	ScrubberRedactedString = `<Redacted by Sqreen>`
 )
 
 var (

--- a/agent/sqlib/sqsanitize/sanitize.go
+++ b/agent/sqlib/sqsanitize/sanitize.go
@@ -1,0 +1,181 @@
+// Copyright (c) 2016 - 2019 Sqreen. All Rights Reserved.
+// Please refer to our terms for more information:
+// https://www.sqreen.io/terms.html
+
+package sqsanitize
+
+import (
+	"reflect"
+	"regexp"
+
+	"github.com/sqreen/go-agent/agent/sqlib/sqerrors"
+)
+
+// Scrubber scrubs values according to the key and value regular expressions
+// given to `NewScrubber()`. Field names and map keys of type string will be
+// checked against the regular expression for keys, while string values will be
+// checked against the regular expression for values. A matching value is
+// replaced by the given redaction string, while
+type Scrubber struct {
+	// keyRegexp is the regular expression matching keys that need to be
+	// scrubbed. Their values are completely replaced by `redactedValueMask`.
+	keyRegexp regex
+	// valueRegexp is the regular expression matching values that need to be
+	// scrubbed. Only the matching part is replaced by `redactedValueMask`
+	valueRegexp regex
+	// redactValueMask is the string replacing a scrubbed value.
+	redactedValueMask string
+}
+
+// NewScrubber returns a new scrubber configured to redact values matching the
+// given regular expressions:
+//   - Values matching `valueRegexp` are replaced by `redactedValueMask` (only
+//     the matching part).
+//   - Map values with keys matching `keyRegexp` are replaced by
+//     `redactedValueMask`.
+// An error can be returned if the regular expressions cannot be compiled.
+func NewScrubber(keyRegexp, valueRegexp, redactedValueMask string) (*Scrubber, error) {
+	keyRE, err := compile(keyRegexp)
+	if err != nil {
+		return nil, err
+	}
+
+	valueRE, err := compile(valueRegexp)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Scrubber{
+		keyRegexp:         keyRE,
+		valueRegexp:       valueRE,
+		redactedValueMask: redactedValueMask,
+	}, nil
+}
+
+func (p *Scrubber) Scrub(v interface{}) error {
+	return p.scrubValue(reflect.ValueOf(v))
+}
+
+func (p *Scrubber) scrubValue(v reflect.Value) error {
+walk:
+	switch v.Kind() {
+	case reflect.Ptr:
+		v = v.Elem()
+		goto walk
+
+	case reflect.Array:
+		fallthrough
+	case reflect.Slice:
+		return p.scrubSlice(v)
+
+	case reflect.Map:
+		return p.scrubMap(v)
+
+	case reflect.Struct:
+		return p.scrubStruct(v)
+
+	case reflect.String:
+		return p.scrubString(v)
+	}
+	return nil
+}
+
+func (p *Scrubber) scrubString(v reflect.Value) error {
+	str := v.String()
+	redacted := p.valueRegexp.ReplaceAllString(str, p.redactedValueMask)
+	if str != redacted {
+		v.SetString(redacted)
+	}
+	return nil
+}
+
+func (s *Scrubber) scrubSlice(v reflect.Value) error {
+	// TODO: ignore when unsupported type or return false to stop the recursion?
+	// if _, ok := supported[v.Type().Kind]; !ok { ///// }
+	l := v.Len()
+	for i := 0; i < l; i++ {
+		// Scrub &v[i]
+		if err := s.scrubValue(v.Index(i).Addr()); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (s *Scrubber) scrubMap(v reflect.Value) error {
+	vt := v.Type().Elem()
+	//hasStringKeyType := v.Type().Key().Kind() == reflect.String
+	for iter := v.MapRange(); iter.Next(); {
+		key := iter.Key()
+		//if hasStringKeyType && s.keyRegexp.MatchString(key.String()) {
+		//	// TODO: scrub every string?
+		//	v.SetMapIndex(key, reflect.Value{})
+		//}
+
+		val := iter.Value()
+		if val.CanSet() {
+			return s.scrubValue(val)
+		}
+
+		newVal := reflect.New(vt).Elem()
+		newVal.Set(val)
+		if err := s.scrubValue(newVal); err != nil {
+			return err
+		}
+		v.SetMapIndex(key, newVal)
+	}
+	return nil
+}
+
+func (s *Scrubber) scrubStruct(v reflect.Value) error {
+	l := v.NumField()
+	vt := v.Type()
+	for i := 0; i < l; i++ {
+		ft := vt.Field(i)
+		if ft.PkgPath != "" {
+			// Ignore unexported fields
+			continue
+		}
+		if ft.Type.Kind() == reflect.String && s.keyRegexp.MatchString(ft.Name) { // TODO: recursive key check
+			// TODO: scrub every string?
+			v.Field(i).Set(reflect.Zero(vt))
+		}
+		// Scrub &v.Field
+		if err := s.scrubValue(v.Field(i).Addr().Elem()); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// regex is a helper structure wrapping a regexp and handling when the regexp is
+// disabled by matching nothing.
+type regex struct {
+	re *regexp.Regexp
+}
+
+func compile(r string) (regex, error) {
+	if r == "" {
+		return regex{}, nil
+	}
+
+	re, err := regexp.Compile(r)
+	if err != nil {
+		return regex{}, sqerrors.Wrapf(err, "could not compile regular expression `%q`", r)
+	}
+	return regex{re: re}, nil
+}
+
+func (r regex) MatchString(s string) bool {
+	if r.re == nil {
+		return false
+	}
+	return r.re.MatchString(s)
+}
+
+func (r regex) ReplaceAllString(src, repl string) string {
+	if r.re == nil {
+		return src
+	}
+	return r.re.ReplaceAllString(src, repl)
+}

--- a/agent/sqlib/sqsanitize/sanitize_test.go
+++ b/agent/sqlib/sqsanitize/sanitize_test.go
@@ -174,7 +174,7 @@ func TestScrubber(t *testing.T) {
 			t.Run(tc.name, func(t *testing.T) {
 				s, err := sqsanitize.NewScrubber(testlib.RandUTF8String(), tc.valueRegexp, expectedMask)
 				require.NoError(t, err)
-				err = s.Scrub(&tc.value)
+				_, err = s.Scrub(&tc.value)
 				require.NoError(t, err)
 				require.Equal(t, tc.expected, tc.value)
 			})
@@ -1024,7 +1024,7 @@ func TestScrubber(t *testing.T) {
 										expected = tc.expected.withBothDisabled
 									}
 								}
-								err = s.Scrub(value)
+								_, err = s.Scrub(value)
 								require.NoError(t, err)
 								require.Equal(t, expected, value)
 							})
@@ -1047,7 +1047,7 @@ func TestScrubber(t *testing.T) {
 				"other": []string{"forbidden", "whatforbidden", randString, "key"},
 				"":      []string{"forbidden", "forbiddenwhat", randString, "key"},
 			}
-			err = s.Scrub(values)
+			_, err = s.Scrub(values)
 			require.NoError(t, err)
 			expected := url.Values{
 				"Password":   []string{expectedMask, expectedMask, expectedMask, expectedMask, expectedMask},

--- a/agent/sqlib/sqsanitize/sanitize_test.go
+++ b/agent/sqlib/sqsanitize/sanitize_test.go
@@ -1,0 +1,317 @@
+// Copyright (c) 2016 - 2019 Sqreen. All Rights Reserved.
+// Please refer to our terms for more information:
+// https://www.sqreen.io/terms.html
+
+package sqsanitize_test
+
+import (
+	"fmt"
+	"net/url"
+	"regexp"
+	"testing"
+
+	"github.com/sqreen/go-agent/agent/sqlib/sqsanitize"
+	"github.com/sqreen/go-agent/tools/testlib"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGoAssumptions(t *testing.T) {
+	t.Run("an empty regular expression matches everything", func(t *testing.T) {
+		re := regexp.MustCompile("")
+		require.True(t, re.MatchString("hello"))
+	})
+}
+
+func TestScrubber(t *testing.T) {
+	expectedMask := `<Redacted by Sqreen>`
+
+	randString := testlib.RandUTF8String(512, 1024)
+
+	t.Run("NewScrubber", func(t *testing.T) {
+		type args struct {
+			keyRegexp         string
+			valueRegexp       string
+			redactedValueMask string
+		}
+		tests := []struct {
+			name    string
+			args    args
+			want    *sqsanitize.Scrubber
+			wantErr bool
+		}{
+			{
+				name: "key regexp should not compile",
+				args: args{
+					keyRegexp:         "o(ops",
+					valueRegexp:       "",
+					redactedValueMask: expectedMask,
+				},
+				wantErr: true,
+			},
+			{
+				name: "value regexp should not compile",
+				args: args{
+					keyRegexp:         "",
+					valueRegexp:       "o(ops",
+					redactedValueMask: expectedMask,
+				},
+				wantErr: true,
+			},
+			{
+				name: "no regexps",
+				args: args{
+					keyRegexp:         "",
+					valueRegexp:       "",
+					redactedValueMask: expectedMask,
+				},
+			},
+			{
+				name: "key regexp only",
+				args: args{
+					keyRegexp:         "ok",
+					valueRegexp:       "",
+					redactedValueMask: expectedMask,
+				},
+			},
+			{
+				name: "value regexp only",
+				args: args{
+					keyRegexp:         "",
+					valueRegexp:       "ok",
+					redactedValueMask: expectedMask,
+				},
+			},
+		}
+		for _, tc := range tests {
+			tc := tc
+			t.Run(tc.name, func(t *testing.T) {
+				got, err := sqsanitize.NewScrubber(tc.args.keyRegexp, tc.args.valueRegexp, tc.args.redactedValueMask)
+				if tc.wantErr {
+					require.Error(t, err)
+				} else {
+					require.NoError(t, err)
+					require.NotNil(t, got)
+				}
+			})
+		}
+	})
+
+	t.Run("string regexps", func(t *testing.T) {
+		tests := []struct {
+			name        string
+			valueRegexp string
+			value       string
+			expected    string
+		}{
+			{
+				name:        "full string",
+				valueRegexp: "^every+thing$",
+				value:       "everyyyyyyyyyyyything",
+				expected:    expectedMask,
+			},
+			{
+				name:        "ends with",
+				valueRegexp: "end$",
+				value:       fmt.Sprintf("%send", randString),
+				expected:    fmt.Sprintf("%s%s", randString, expectedMask),
+			},
+			{
+				name:        "starts with",
+				valueRegexp: "^start",
+				value:       fmt.Sprintf("start%s", randString),
+				expected:    fmt.Sprintf("%s%s", expectedMask, randString),
+			},
+			{
+				name:        "every submatch",
+				valueRegexp: "any*where",
+				value:       fmt.Sprintf("%sanywhere%sanyyyyyywhere%sanwhere%s", randString, randString, randString, randString),
+				expected:    fmt.Sprintf("%s%s%s%s%s%s%s", randString, expectedMask, randString, expectedMask, randString, expectedMask, randString),
+			},
+			{
+				name:        "no match",
+				valueRegexp: "anywhere",
+				value:       randString,
+				expected:    randString,
+			},
+			{
+				name:        "disabled",
+				valueRegexp: "",
+				value:       randString,
+				expected:    randString,
+			},
+		}
+		for _, tc := range tests {
+			tc := tc
+			t.Run(tc.name, func(t *testing.T) {
+				s, err := sqsanitize.NewScrubber(testlib.RandUTF8String(), tc.valueRegexp, expectedMask)
+				require.NoError(t, err)
+				s.Scrub(&tc.value)
+				require.Equal(t, tc.expected, tc.value)
+			})
+
+		}
+	})
+
+	t.Run("Scrub", func(t *testing.T) {
+		type myStruct struct {
+			a string
+			B string
+			C int
+			D string
+			E *myStruct
+		}
+
+		type TestCase struct {
+			name     string
+			value    interface{}
+			expected interface{}
+		}
+
+		valueRegexp := `^everything$`
+
+		tests := []TestCase{
+			{
+				name:     "string",
+				value:    "",
+				expected: "",
+			},
+			{
+				name:     "string",
+				value:    "not everything",
+				expected: "not everything",
+			},
+			{
+				name:     "string",
+				value:    "everything",
+				expected: expectedMask,
+			},
+			{
+				name:     "slice",
+				value:    nil,
+				expected: nil,
+			},
+			{
+				name:     "slice",
+				value:    []string{},
+				expected: []string{},
+			},
+			{
+				name:     "slice",
+				value:    []string{"f", "fo", "foo"},
+				expected: []string{"f", "fo", "foo"},
+			},
+			{
+				name:     "slice",
+				value:    []string{"everything", "everithing", "not everything", "everything not", "everything"},
+				expected: []string{expectedMask, "everithing", "not everything", "everything not", expectedMask},
+			},
+			{
+				name:     "map",
+				value:    nil,
+				expected: nil,
+			},
+			{
+				name:     "map",
+				value:    map[string]string{},
+				expected: map[string]string{},
+			},
+			{
+				name:     "map",
+				value:    map[string]string{"k1": "v1", "k2": "v2", "k3": "v3"},
+				expected: map[string]string{"k1": "v1", "k2": "v2", "k3": "v3"},
+			},
+			{
+				name:     "map",
+				value:    map[string]string{"key": "everything"},
+				expected: map[string]string{"key": expectedMask},
+			},
+			{
+				name:     "map",
+				value:    map[string]string{"k1": "everything", "k2": "everithing", "k3": "not everything", "k4": "everything not", "k5": "everything"},
+				expected: map[string]string{"k1": expectedMask, "k2": "everithing", "k3": "not everything", "k4": "everything not", "k5": expectedMask},
+			},
+			{
+				name: "struct",
+				value: &myStruct{
+					a: "everything",
+					B: "everything",
+					C: 33,
+					D: "not everything",
+				},
+				expected: &myStruct{
+					a: "everything",
+					B: expectedMask,
+					C: 33,
+					D: "not everything",
+				},
+			},
+			{
+				name: "struct",
+				value: &myStruct{
+					E: &myStruct{
+						a: "everything",
+						B: "everything",
+						C: 33,
+						D: "not everything",
+					},
+				},
+				expected: &myStruct{
+					E: &myStruct{
+						a: "everything",
+						B: expectedMask,
+						C: 33,
+						D: "not everything",
+					},
+				},
+			},
+		}
+
+		s, err := sqsanitize.NewScrubber(testlib.RandUTF8String(), valueRegexp, expectedMask)
+		require.NoError(t, err)
+		for _, tc := range tests {
+			tc := tc
+			var value, expected interface{}
+			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
+				switch v := tc.value.(type) {
+				case string:
+					// Need a string that can be set - hence using the address of the
+					// local variable v
+					value = &v
+					// expected must have the *string type in order to have deep equal
+					// working
+					want := tc.expected.(string)
+					expected = &want
+				default:
+					value = tc.value
+					expected = tc.expected
+				}
+				err := s.Scrub(value)
+				require.NoError(t, err)
+				require.Equal(t, expected, value)
+			})
+
+		}
+	})
+
+	t.Run("Usage", func(t *testing.T) {
+		s, err := sqsanitize.NewScrubber("", "forbidden", expectedMask)
+		require.NoError(t, err)
+
+		t.Run("URL Values", func(t *testing.T) {
+			values := url.Values{
+				"password": []string{"no", "pass", randString, "forbidden", randString}, // TODO
+				"other":    []string{"forbidden", "whatforbidden", randString, "key"},
+				"":         []string{"forbidden", "forbiddenwhat", randString, "key"},
+			}
+			err := s.Scrub(values)
+			require.NoError(t, err)
+			expected := url.Values{
+				"password": []string{"no", "pass", randString, expectedMask, randString}, // TODO
+				"other":    []string{expectedMask, "what" + expectedMask, randString, "key"},
+				"":         []string{expectedMask, expectedMask + "what", randString, "key"},
+			}
+			require.Equal(t, expected, values)
+		})
+	})
+}

--- a/agent/sqlib/sqsanitize/sanitize_test.go
+++ b/agent/sqlib/sqsanitize/sanitize_test.go
@@ -174,7 +174,7 @@ func TestScrubber(t *testing.T) {
 			t.Run(tc.name, func(t *testing.T) {
 				s, err := sqsanitize.NewScrubber(testlib.RandUTF8String(), tc.valueRegexp, expectedMask)
 				require.NoError(t, err)
-				s.Scrub(&tc.value)
+				err = s.Scrub(&tc.value)
 				require.NoError(t, err)
 				require.Equal(t, tc.expected, tc.value)
 			})
@@ -1024,7 +1024,8 @@ func TestScrubber(t *testing.T) {
 										expected = tc.expected.withBothDisabled
 									}
 								}
-								s.Scrub(value)
+								err = s.Scrub(value)
+								require.NoError(t, err)
 								require.Equal(t, expected, value)
 							})
 						}
@@ -1046,7 +1047,8 @@ func TestScrubber(t *testing.T) {
 				"other": []string{"forbidden", "whatforbidden", randString, "key"},
 				"":      []string{"forbidden", "forbiddenwhat", randString, "key"},
 			}
-			s.Scrub(values)
+			err = s.Scrub(values)
+			require.NoError(t, err)
 			expected := url.Values{
 				"Password":   []string{expectedMask, expectedMask, expectedMask, expectedMask, expectedMask},
 				"_paSSwoRD ": []string{expectedMask, expectedMask, expectedMask, expectedMask, expectedMask},

--- a/tools/testlib/testmock/request-record.go
+++ b/tools/testlib/testmock/request-record.go
@@ -20,6 +20,10 @@ func (rr *RequestRecordMockup) Request() *http.Request {
 	return rr.Called().Get(0).(*http.Request)
 }
 
+func (rr *RequestRecordMockup) SetRequest(r *http.Request) {
+	rr.Called(r)
+}
+
 func (rr *RequestRecordMockup) NewCustomEvent(event string) types.CustomEvent {
 	rr.Called(event)
 	return rr


### PR DESCRIPTION
Every batched event is now scrubbed after being converted into a backend API value and before adding it into the backend API batch.

The scrubber settings are statically defined for now and matches our doc (https://docs.sqreen.com/guides/how-sqreen-works/#pii-scrubbing).