### PR TITLE
Simpler installation by importing the Agent from the SDK

### DIFF
--- a/sdk/middleware/sqhttp/http.go
+++ b/sdk/middleware/sqhttp/http.go
@@ -7,6 +7,7 @@ package sqhttp
 import (
 	"net/http"
 
+	_ "github.com/sqreen/go-agent/agent"
 	"github.com/sqreen/go-agent/sdk"
 	"golang.org/x/xerrors"
 )


### PR DESCRIPTION
Add the agent import into the SDK so that it is no longer required to import the agent into the main package. The SDK middleware functions were already mandatory to integrate the agent into the app framework. 