### PR TITLE
Send the list of dependencies

### DIFF
--- a/agent/internal/agent.go
+++ b/agent/internal/agent.go
@@ -373,6 +373,27 @@ func (a *Agent) ActionsReload() error {
 	return a.actors.SetActions(actions.Actions)
 }
 
+func (a *Agent) SendAppBundle() error {
+	deps, sig, err := a.appInfo.Dependencies()
+	if err != nil {
+		return err
+	}
+
+	bundleDeps := make([]api.AppDependency, len(deps))
+	for i, dep := range deps {
+		bundleDeps[i] = api.AppDependency{
+			Name:    dep.Path,
+			Version: dep.Version,
+		}
+	}
+	bundle := api.AppBundle{
+		Signature:    sig,
+		Dependencies: bundleDeps,
+	}
+
+	return a.client.SendAppBundle(&bundle)
+}
+
 func (a *Agent) SetCIDRWhitelist(cidrs []string) error {
 	return a.actors.SetCIDRWhitelist(cidrs)
 }

--- a/agent/internal/backend/api/api.go
+++ b/agent/internal/backend/api/api.go
@@ -1022,3 +1022,13 @@ type RulesPackResponse struct {
 	PackID string `json:"pack_id"`
 	Rules  []Rule `json:"rules"`
 }
+
+type AppBundle struct {
+	Signature    string          `json:"bundle_signature"`
+	Dependencies []AppDependency `json:"dependencies"`
+}
+
+type AppDependency struct {
+	Name    string `json:"name"`
+	Version string `json:"version"`
+}

--- a/agent/internal/backend/client.go
+++ b/agent/internal/backend/client.go
@@ -155,6 +155,15 @@ func (c *Client) RulesPack() (*api.RulesPackResponse, error) {
 	return res, nil
 }
 
+func (c *Client) SendAppBundle(req *api.AppBundle) error {
+	httpReq, err := c.newRequest(&config.BackendHTTPAPIEndpoint.Bundle)
+	if err != nil {
+		return err
+	}
+	httpReq.Header.Set(config.BackendHTTPAPIHeaderSession, c.session)
+	return c.Do(httpReq, req)
+}
+
 // Do performs the request whose body is pbs[0] pointer, while the expected
 // response is pbs[1] pointer. They are optional, and must be used according to
 // the cases request case.

--- a/agent/internal/client.go
+++ b/agent/internal/client.go
@@ -59,9 +59,14 @@ func appLogin(ctx context.Context, logger *plog.Logger, client *backend.Client, 
 
 	procInfo := appInfo.GetProcessInfo()
 
+	_, bundleSignature, err := appInfo.Dependencies()
+	if err != nil {
+		logger.Error(sqerrors.Wrap(err, "could not retrieve the dependencies"))
+	}
+
 	appLoginReq := api.AppLoginRequest{
 		VariousInfos:    *api.NewAppLoginRequest_VariousInfosFromFace(procInfo),
-		BundleSignature: "",
+		BundleSignature: bundleSignature,
 		AgentType:       "golang",
 		AgentVersion:    version,
 		OsType:          app.GoBuildTarget(),
@@ -69,10 +74,7 @@ func appLogin(ctx context.Context, logger *plog.Logger, client *backend.Client, 
 		RuntimeVersion:  app.GoVersion(),
 	}
 
-	var (
-		appLoginRes *api.AppLoginResponse
-		err         error
-	)
+	var appLoginRes *api.AppLoginResponse
 
 	backoff := sqtime.NewBackoff(backoffStartDuration, backoffMaxDuration, backoffRate)
 	for {

--- a/agent/internal/command.go
+++ b/agent/internal/command.go
@@ -28,6 +28,7 @@ type CommandManagerAgent interface {
 	ActionsReload() error
 	SetCIDRWhitelist([]string) error
 	RulesReload() (rulespackID string, err error)
+	SendAppBundle() error
 }
 
 func NewCommandManager(agent CommandManagerAgent, logger *plog.Logger) *CommandManager {
@@ -43,6 +44,7 @@ func NewCommandManager(agent CommandManagerAgent, logger *plog.Logger) *CommandM
 		"actions_reload":         mng.ActionsReload,
 		"ips_whitelist":          mng.IPSWhitelist,
 		"rules_reload":           mng.RulesReload,
+		"get_bundle":             mng.GetBundle,
 	}
 
 	return mng
@@ -109,6 +111,10 @@ func (m *CommandManager) IPSWhitelist(args []json.RawMessage) (string, error) {
 
 func (m *CommandManager) RulesReload([]json.RawMessage) (string, error) {
 	return m.agent.RulesReload()
+}
+
+func (m *CommandManager) GetBundle([]json.RawMessage) (string, error) {
+	return "", m.agent.SendAppBundle()
 }
 
 // commandResult converts an error to a command result API object.

--- a/agent/internal/command_test.go
+++ b/agent/internal/command_test.go
@@ -91,6 +91,10 @@ func TestCommandManager(t *testing.T) {
 			AgentCallReturnError:   []interface{}{"", nil},
 			ExpectedOutput:         "my pack id",
 		},
+		{
+			Command:           "get_bundle",
+			ExpectedAgentCall: agent.ExpectSendAppBundle,
+		},
 	}
 
 	for _, tc := range testCases {
@@ -320,6 +324,15 @@ func (a *agentMockup) SetCIDRWhitelist(cidrs []string) error {
 func (a *agentMockup) RulesReload() (string, error) {
 	ret := a.Called()
 	return ret.String(0), ret.Error(1)
+}
+
+func (a *agentMockup) SendAppBundle() error {
+	ret := a.Called()
+	return ret.Error(0)
+}
+
+func (a *agentMockup) ExpectSendAppBundle(...interface{}) *mock.Call {
+	return a.On("SendAppBundle")
 }
 
 func (a *agentMockup) ExpectInstrumentationEnable(...interface{}) *mock.Call {

--- a/agent/internal/config/config.go
+++ b/agent/internal/config/config.go
@@ -54,7 +54,7 @@ var (
 
 	// List of endpoint addresses, relative to the base URL.
 	BackendHTTPAPIEndpoint = struct {
-		AppLogin, AppLogout, AppBeat, AppException, Batch, ActionsPack, RulesPack HTTPAPIEndpoint
+		AppLogin, AppLogout, AppBeat, AppException, Batch, ActionsPack, RulesPack, Bundle HTTPAPIEndpoint
 	}{
 		AppLogin:     HTTPAPIEndpoint{http.MethodPost, "/sqreen/v1/app-login"},
 		AppLogout:    HTTPAPIEndpoint{http.MethodGet, "/sqreen/v0/app-logout"},
@@ -63,6 +63,7 @@ var (
 		Batch:        HTTPAPIEndpoint{http.MethodPost, "/sqreen/v0/batch"},
 		ActionsPack:  HTTPAPIEndpoint{http.MethodGet, "/sqreen/v0/actionspack"},
 		RulesPack:    HTTPAPIEndpoint{http.MethodGet, "/sqreen/v0/rulespack"},
+		Bundle:       HTTPAPIEndpoint{http.MethodPost, "/sqreen/v0/bundle"},
 	}
 
 	// Header name of the API token.


### PR DESCRIPTION
Go programs compiled using the new Go modules support now have their list of dependencies and versions available at run time. Send them to Sqreen so that we can perform our dependency analysis.