### PR TITLE
sdk/middleware/{sqgin,sqecho,sqhttp}: fix monitoring of request handler status codes

### DIFF
--- a/sdk/middleware/sqecho/echo.go
+++ b/sdk/middleware/sqecho/echo.go
@@ -74,52 +74,48 @@ func FromContext(c echo.Context) *sdk.Context {
 //
 func Middleware() echo.MiddlewareFunc {
 	internal.Start()
-	return middleware(internal.Agent())
+	return func(next echo.HandlerFunc) echo.HandlerFunc {
+		return func(c echo.Context) error {
+			return middlewareHandler(internal.Agent(), next, c)
+		}
+	}
 }
 
-func middleware(agent protectioncontext.AgentFace) echo.MiddlewareFunc {
+func middlewareHandler(agent protectioncontext.AgentFace, next echo.HandlerFunc, c echo.Context) error {
 	if agent == nil {
-		return func(handler echo.HandlerFunc) echo.HandlerFunc {
-			return func(c echo.Context) error {
-				return handler(c)
-			}
-		}
+		return next(c)
 	}
 
-	return func(handler echo.HandlerFunc) echo.HandlerFunc {
-		return func(c echo.Context) error {
-			requestReader := &requestReaderImpl{c: c}
-			responseWriter := &responseWriterImpl{c: c}
+	requestReader := &requestReaderImpl{c: c}
+	responseWriter := &responseWriterImpl{c: c}
 
-			reqCtx, cancelHandlerContext := context.WithCancel(c.Request().Context())
-			defer cancelHandlerContext()
+	reqCtx, cancelHandlerContext := context.WithCancel(c.Request().Context())
+	defer cancelHandlerContext()
 
-			ctx := http_protection.NewRequestContext(agent, responseWriter, requestReader, cancelHandlerContext)
-			if ctx == nil {
-				return handler(c)
-			}
-
-			defer func() {
-				_ = ctx.Close(responseWriter.closeResponseWriter())
-			}()
-
-			c.SetRequest(c.Request().WithContext(context.WithValue(reqCtx, protectioncontext.ContextKey, ctx)))
-
-			if err := ctx.Before(); err != nil {
-				return err
-			}
-			if err := handler(c); err != nil {
-				// Handler-based protection such as user security responses or RASP
-				// protection may lead to aborted requests bubbling up the error that
-				// was returned.
-				return err
-			}
-			if err := ctx.After(); err != nil {
-				return err
-			}
-			return nil
-		}
+	ctx := http_protection.NewRequestContext(agent, responseWriter, requestReader, cancelHandlerContext)
+	if ctx == nil {
+		return next(c)
 	}
+
+	defer func() {
+		_ = ctx.Close(responseWriter.closeResponseWriter())
+	}()
+
+	c.SetRequest(c.Request().WithContext(context.WithValue(reqCtx, protectioncontext.ContextKey, ctx)))
+
+	if err := ctx.Before(); err != nil {
+		return err
+	}
+	if err := next(c); err != nil {
+		// Handler-based protection such as user security responses or RASP
+		// protection may lead to aborted requests bubbling up the error that
+		// was returned.
+		return err
+	}
+	if err := ctx.After(); err != nil {
+		return err
+	}
+	return nil
 }
 
 type requestReaderImpl struct {

--- a/sdk/middleware/sqecho/echo_test.go
+++ b/sdk/middleware/sqecho/echo_test.go
@@ -405,3 +405,11 @@ func TestMiddleware(t *testing.T) {
 
 
 }
+
+func middleware(agent protectioncontext.AgentFace) echo.MiddlewareFunc {
+	return func(next echo.HandlerFunc) echo.HandlerFunc {
+		return func(c echo.Context) error {
+			return middlewareHandler(agent, next, c)
+		}
+	}
+}

--- a/sdk/middleware/sqecho/echo_test.go
+++ b/sdk/middleware/sqecho/echo_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/labstack/echo"
 	protectioncontext "github.com/sqreen/go-agent/internal/protection/context"
+	"github.com/sqreen/go-agent/internal/protection/http/types"
 	"github.com/sqreen/go-agent/sdk"
 	"github.com/sqreen/go-agent/sdk/middleware/_testlib/mockups"
 	"github.com/sqreen/go-agent/tools/testlib"
@@ -365,4 +366,42 @@ func TestMiddleware(t *testing.T) {
 			})
 		}
 	})
+
+	t.Run("response observation", func(t *testing.T) {
+		expectedStatusCode := 433
+
+		agent := &mockups.AgentMockup{}
+		agent.ExpectConfig().Return(&mockups.AgentConfigMockup{}).Once()
+		agent.ExpectIsIPWhitelisted(mock.Anything).Return(false).Once()
+		var responseStatusCode int
+		agent.ExpectSendClosedRequestContext(mock.MatchedBy(func(recorded types.ClosedRequestContextFace) bool {
+			resp := recorded.Response()
+			responseStatusCode = resp.Status()
+			return true
+		})).Return(nil)
+		defer agent.AssertExpectations(t)
+
+		// Create a route
+		router := echo.New()
+		router.Use(middleware(agent))
+		router.GET("/", func(c echo.Context) error {
+			return c.NoContent(expectedStatusCode)
+		})
+
+		// Perform the request and record the output
+		rec := httptest.NewRecorder()
+		req, _ := http.NewRequest("GET", "/", nil)
+		var err error
+		router.HTTPErrorHandler = func(e error, _ echo.Context) {
+			err = e
+		}
+		router.ServeHTTP(rec, req)
+
+		// Check the result
+		require.NoError(t, err)
+		require.Equal(t, expectedStatusCode, responseStatusCode)
+		require.Equal(t, expectedStatusCode, rec.Code)
+	})
+
+
 }

--- a/sdk/middleware/sqgin/gin.go
+++ b/sdk/middleware/sqgin/gin.go
@@ -187,7 +187,6 @@ func (r *requestReaderImpl) RemoteAddr() string {
 
 type responseWriterImpl struct {
 	c      *gingonic.Context
-	status int
 	closed bool
 }
 
@@ -223,7 +222,6 @@ func (w *responseWriterImpl) WriteHeader(statusCode int) {
 	if w.closed {
 		return
 	}
-	w.status = statusCode
 	w.c.Writer.WriteHeader(statusCode)
 }
 
@@ -238,6 +236,7 @@ func newObservedResponse(r *responseWriterImpl) *observedResponse {
 	// Content-Type will be not empty only when explicitly set.
 	// It could be guessed as net/http does. Not implemented for now.
 	ct := r.Header().Get("Content-Type")
+
 	// Content-Length is either explicitly set or the amount of written data.
 	cl := int64(r.c.Writer.Size())
 	if contentLength := r.Header().Get("Content-Length"); contentLength != "" {
@@ -245,10 +244,13 @@ func newObservedResponse(r *responseWriterImpl) *observedResponse {
 			cl = l
 		}
 	}
+
+	status := r.c.Writer.Status()
+
 	return &observedResponse{
 		contentType:   ct,
 		contentLength: cl,
-		status:        r.status,
+		status:        status,
 	}
 }
 

--- a/sdk/middleware/sqgin/gin_test.go
+++ b/sdk/middleware/sqgin/gin_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	protectioncontext "github.com/sqreen/go-agent/internal/protection/context"
+	"github.com/sqreen/go-agent/internal/protection/http/types"
 	"github.com/sqreen/go-agent/sdk"
 	"github.com/sqreen/go-agent/sdk/middleware/_testlib/mockups"
 	"github.com/sqreen/go-agent/tools/testlib"
@@ -311,5 +312,36 @@ func TestMiddleware(t *testing.T) {
 				}
 			})
 		}
+	})
+
+	t.Run("response observation", func(t *testing.T) {
+		expectedStatusCode := 433
+
+		agent := &mockups.AgentMockup{}
+		agent.ExpectConfig().Return(&mockups.AgentConfigMockup{}).Once()
+		agent.ExpectIsIPWhitelisted(mock.Anything).Return(false).Once()
+		var responseStatusCode int
+		agent.ExpectSendClosedRequestContext(mock.MatchedBy(func(recorded types.ClosedRequestContextFace) bool {
+			resp := recorded.Response()
+			responseStatusCode = resp.Status()
+			return true
+		})).Return(nil)
+		defer agent.AssertExpectations(t)
+
+		// Create a route
+		router := gin.New()
+		router.Use(middleware(agent))
+		router.GET("/", func(c *gin.Context) {
+			c.Status(expectedStatusCode)
+		})
+
+		// Perform the request and record the output
+		rec := httptest.NewRecorder()
+		req, _ := http.NewRequest("GET", "/", nil)
+		router.ServeHTTP(rec, req)
+
+		// Check the result
+		require.Equal(t, expectedStatusCode, responseStatusCode)
+		require.Equal(t, expectedStatusCode, responseStatusCode)
 	})
 }

--- a/sdk/middleware/sqgin/gin_test.go
+++ b/sdk/middleware/sqgin/gin_test.go
@@ -345,3 +345,9 @@ func TestMiddleware(t *testing.T) {
 		require.Equal(t, expectedStatusCode, responseStatusCode)
 	})
 }
+
+func middleware(agent protectioncontext.AgentFace) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		middlewareHandler(agent, c)
+	}
+}

--- a/sdk/middleware/sqhttp/http.go
+++ b/sdk/middleware/sqhttp/http.go
@@ -81,7 +81,7 @@ func middleware(handler http.Handler, agent protection_context.AgentFace) http.H
 		if err := ctx.Before(); err != nil {
 			return
 		}
-		handler.ServeHTTP(w, requestReader.Request)
+		handler.ServeHTTP(responseWriter, requestReader.Request)
 		if err := ctx.After(); err != nil {
 			return
 		}

--- a/sdk/middleware/sqhttp/http_test.go
+++ b/sdk/middleware/sqhttp/http_test.go
@@ -207,3 +207,9 @@ func TestMiddleware(t *testing.T) {
 		require.Equal(t, expectedStatusCode, rec.Code)
 	})
 }
+
+func middleware(next http.HandlerFunc, agent protectioncontext.AgentFace) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		middlewareHandler(agent, next, w, r)
+	})
+}


### PR DESCRIPTION
Fix the monitoring of status codes set by request handlers:

- on gin and echo: simply use the status field of the response field of the
  request context value.
- on net/http: pass the response writer that is already used by sqreen handlers.