### PR TITLE
Update the token validation with the new format

### DIFF
--- a/internal/backend/client_test.go
+++ b/internal/backend/client_test.go
@@ -408,6 +408,43 @@ func TestValidateCredentialsConfiguration(t *testing.T) {
 			AppName:    "ok",
 			ShouldFail: true,
 		},
+
+
+		{
+			Name:       "invalid credentials with valid org token but empty app-name",
+			Token:      "env_org_ok",
+			AppName:    "",
+			ShouldFail: true,
+		},
+		{
+			Name:       "invalid credentials with token ok but invalid app-name",
+			Token:      "env_org_ok",
+			AppName:    "ko\nko",
+			ShouldFail: true,
+		},
+		{
+			Name:       "invalid credentials with token ok but invalid app-name",
+			Token:      "env_org_ok",
+			AppName:    "koko\x00\x01\x02ok",
+			ShouldFail: true,
+		},
+		{
+			Name:       "invalid credentials with token ok but invalid app-name",
+			Token:      "env_org_ok",
+			AppName:    "koko\tok",
+			ShouldFail: true,
+		},
+		{
+			Name:    "valid credentials with a space in app-name",
+			Token:   "env_org_ok",
+			AppName: "ok ok ok",
+		},
+		{
+			Name:       "invalid credentials with invalid token character",
+			Token:      "env_org_ok\nko",
+			AppName:    "ok",
+			ShouldFail: true,
+		},
 	} {
 		tc := tc
 		t.Run(tc.Name, func(t *testing.T) {

--- a/internal/client.go
+++ b/internal/client.go
@@ -126,7 +126,7 @@ func ValidateCredentialsConfiguration(token, appName string) (err error) {
 	if token == "" {
 		return sqerrors.New("missing token")
 	}
-	if strings.HasPrefix(token, config.BackendHTTPAPIOrganizationTokenPrefix) && appName == "" {
+	if strings.Contains(token, config.BackendHTTPAPIOrganizationTokenSubstr) && appName == "" {
 		return sqerrors.New("missing application name")
 	}
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -78,7 +78,7 @@ var (
 	// Header name of the App name.
 	BackendHTTPAPIHeaderAppName = "X-App-Name"
 
-	BackendHTTPAPIOrganizationTokenPrefix = "org_"
+	BackendHTTPAPIOrganizationTokenSubstr = "org_"
 
 	// BackendHTTPAPIRequestRetryPeriod is the time period to retry failed backend
 	// HTTP requests.


### PR DESCRIPTION
New org tokens are now linked to an environment and their naming convention has changed from `org_*` to `env_org_*`. This leads to a wrong error message when the `app_name` isn't set. This patch loosely checks the token and checks it contains `org_` as its purpose is only about providing a better error message when the configuration is wrong. 