### PR TITLE
Configurable PII sanitizer

### DIFF
--- a/internal/backend/api/json_test.go
+++ b/internal/backend/api/json_test.go
@@ -6,6 +6,7 @@ package api_test
 
 import (
 	"encoding/json"
+	"regexp"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -110,7 +111,7 @@ func TestJSON(t *testing.T) {
 
 func TestCustomScrubber(t *testing.T) {
 	expectedMask := "scrubbed"
-	scrubber, err := sqsanitize.NewScrubber("password", "forbidden", expectedMask)
+	scrubber, err := sqsanitize.NewScrubber(regexp.MustCompile("password"), regexp.MustCompile("forbidden"), expectedMask)
 	require.NoError(t, err)
 
 	t.Run("without attack", func(t *testing.T) {

--- a/internal/backend/client.go
+++ b/internal/backend/client.go
@@ -39,9 +39,9 @@ type Client struct {
 	infra        *signal.AgentInfra
 }
 
-func NewClient(backendURL string, cfg *config.Config, logger *plog.Logger) *Client {
+func NewClient(backendURL string, proxy string, logger *plog.Logger) *Client {
 	var transport *http.Transport
-	if proxySettings := cfg.BackendHTTPAPIProxy(); proxySettings == "" {
+	if proxy == "" {
 		// No user settings. The default transport uses standard global proxy
 		// settings *_PROXY environment variables.
 		dummyReq, _ := http.NewRequest("GET", backendURL, nil)
@@ -51,9 +51,9 @@ func NewClient(backendURL string, cfg *config.Config, logger *plog.Logger) *Clie
 		transport = (http.DefaultTransport).(*http.Transport)
 	} else {
 		// Use the settings.
-		logger.Infof("client: using configured https proxy `%s`", proxySettings)
+		logger.Infof("client: using configured https proxy `%s`", proxy)
 		proxyCfg := httpproxy.Config{
-			HTTPSProxy: proxySettings,
+			HTTPSProxy: proxy,
 		}
 		proxyURL := proxyCfg.ProxyFunc()
 		proxy := func(req *http.Request) (*url.URL, error) {

--- a/internal/backend/client_test.go
+++ b/internal/backend/client_test.go
@@ -13,18 +13,15 @@ import (
 	fuzz "github.com/google/gofuzz"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/ghttp"
-	"github.com/sqreen/go-agent/internal"
 	"github.com/sqreen/go-agent/internal/backend"
 	"github.com/sqreen/go-agent/internal/backend/api"
 	"github.com/sqreen/go-agent/internal/config"
 	"github.com/sqreen/go-agent/internal/plog"
 	"github.com/sqreen/go-agent/tools/testlib"
-	"github.com/stretchr/testify/require"
 )
 
 var (
 	logger = plog.NewLogger(plog.Debug, os.Stderr, 0)
-	cfg    = config.New(logger)
 	fuzzer = fuzz.New().Funcs(FuzzStruct, FuzzCommandRequest, FuzzRuleDataValue, FuzzRule)
 )
 
@@ -52,7 +49,7 @@ func TestClient(t *testing.T) {
 		server := initFakeServer(endpointCfg, request, response, statusCode, headers)
 		defer server.Close()
 
-		client := backend.NewClient(server.URL(), cfg, logger)
+		client := backend.NewClient(server.URL(), "", logger)
 
 		res, err := client.AppLogin(request, token, appName, false)
 		g.Expect(err).NotTo(HaveOccurred())
@@ -185,7 +182,7 @@ func initFakeServerSession(endpointCfg *config.HTTPAPIEndpoint, request, respons
 	loginRes.Status = true
 	server.AppendHandlers(ghttp.RespondWithJSONEncoded(http.StatusOK, loginRes))
 
-	client = backend.NewClient(server.URL(), cfg, logger)
+	client = backend.NewClient(server.URL(), "", logger)
 
 	token := testlib.RandHTTPHeaderValue(2, 50)
 	appName := testlib.RandHTTPHeaderValue(2, 50)
@@ -222,57 +219,11 @@ func initFakeServerSession(endpointCfg *config.HTTPAPIEndpoint, request, respons
 	return client, server
 }
 
-func TestProxy(t *testing.T) {
-	// ghttp uses gomega global functions so globally register `t` to gomega.
-	RegisterTestingT(t)
-	t.Run("HTTPS_PROXY", func(t *testing.T) { testProxy(t, "HTTPS_PROXY") })
-	t.Run("SQREEN_PROXY", func(t *testing.T) { testProxy(t, "SQREEN_PROXY") })
-}
-
-func testProxy(t *testing.T, envVar string) {
-	t.Skip()
-	// FIXME: (i) use an actual proxy, (ii) check requests go through it, (iii)
-	// use a fake backend and check the requests exactly like previous tests
-	// (ideally reuse them and add the proxy).
-	http.DefaultTransport.(*http.Transport).CloseIdleConnections()
-	// Create a fake proxy checking it receives a CONNECT request.
-	proxy := ghttp.NewServer()
-	defer proxy.Close()
-	proxy.AppendHandlers(ghttp.CombineHandlers(
-		ghttp.VerifyRequest(http.MethodConnect, ""),
-		ghttp.RespondWith(http.StatusOK, nil),
-	))
-
-	//back := ghttp.NewUnstartedServer()
-	//back.HTTPTestServer.Listener.Close()
-	//listener, _ := net.Listen("tcp", testlib.GetNonLoopbackIP().String()+":0")
-	//back.HTTPTestServer.Listener = listener
-	//back.start()
-	//defer back.Close()
-	//back.AppendHandlers(ghttp.CombineHandlers(
-	//	ghttp.VerifyRequest(http.MethodPost, "/sqreen/v1/app-login"),
-	//	ghttp.RespondWith(http.StatusOK, nil),
-	//))
-
-	// Setup the configuration
-	os.Setenv(envVar, proxy.URL())
-	defer os.Unsetenv(envVar)
-	require.Equal(t, os.Getenv(envVar), proxy.URL())
-
-	// The new client should take the proxy into account.
-	client := backend.NewClient(cfg.BackendHTTPAPIBaseURL(), cfg, logger)
-	// Perform a request that should go through the proxy.
-	request := NewRandomAppLoginRequest()
-	_, err := client.AppLogin(request, "my-token", "my-app", false)
-	require.NoError(t, err)
-	// A request has been received:
-	//require.NotEqual(t, len(back.ReceivedRequests()), 0, "0 request received")
-	require.NotEqual(t, len(proxy.ReceivedRequests()), 0, "0 request received")
-}
-
 func NewRandomAppLoginResponse() *api.AppLoginResponse {
 	pb := new(api.AppLoginResponse)
 	fuzzer.Fuzz(pb)
+	// We don't want to use signals in these tests.
+	pb.Features.UseSignals = false
 	return pb
 }
 
@@ -345,115 +296,4 @@ func FuzzRuleDataValue(e *api.RuleDataEntry, c fuzz.Continue) {
 func FuzzRule(e *api.Rule, c fuzz.Continue) {
 	c.Fuzz(e)
 	e.Signature = api.RuleSignature{ECDSASignature: api.ECDSASignature{Message: []byte(`{}`)}}
-}
-
-func TestValidateCredentialsConfiguration(t *testing.T) {
-	for _, tc := range []struct {
-		Name, Token, AppName string
-		ShouldFail           bool
-	}{
-		{
-			Name:    "valid org token strings",
-			Token:   "org_ok",
-			AppName: "ok",
-		},
-		{
-			Name:  "valid non-org",
-			Token: "ok",
-		},
-		{
-			Name:       "invalid credentials with empty strings",
-			Token:      "",
-			AppName:    "",
-			ShouldFail: true,
-		},
-		{
-			Name:       "invalid credentials with empty token and non-empty app-name",
-			Token:      "",
-			AppName:    "ok",
-			ShouldFail: true,
-		},
-		{
-			Name:       "invalid credentials with valid org token but empty app-name",
-			Token:      "org_ok",
-			AppName:    "",
-			ShouldFail: true,
-		},
-		{
-			Name:       "invalid credentials with token ok but invalid app-name",
-			Token:      "org_ok",
-			AppName:    "ko\nko",
-			ShouldFail: true,
-		},
-		{
-			Name:       "invalid credentials with token ok but invalid app-name",
-			Token:      "org_ok",
-			AppName:    "koko\x00\x01\x02ok",
-			ShouldFail: true,
-		},
-		{
-			Name:       "invalid credentials with token ok but invalid app-name",
-			Token:      "org_ok",
-			AppName:    "koko\tok",
-			ShouldFail: true,
-		},
-		{
-			Name:    "valid credentials with a space in app-name",
-			Token:   "org_ok",
-			AppName: "ok ok ok",
-		},
-		{
-			Name:       "invalid credentials with invalid token character",
-			Token:      "org_ok\nko",
-			AppName:    "ok",
-			ShouldFail: true,
-		},
-
-
-		{
-			Name:       "invalid credentials with valid org token but empty app-name",
-			Token:      "env_org_ok",
-			AppName:    "",
-			ShouldFail: true,
-		},
-		{
-			Name:       "invalid credentials with token ok but invalid app-name",
-			Token:      "env_org_ok",
-			AppName:    "ko\nko",
-			ShouldFail: true,
-		},
-		{
-			Name:       "invalid credentials with token ok but invalid app-name",
-			Token:      "env_org_ok",
-			AppName:    "koko\x00\x01\x02ok",
-			ShouldFail: true,
-		},
-		{
-			Name:       "invalid credentials with token ok but invalid app-name",
-			Token:      "env_org_ok",
-			AppName:    "koko\tok",
-			ShouldFail: true,
-		},
-		{
-			Name:    "valid credentials with a space in app-name",
-			Token:   "env_org_ok",
-			AppName: "ok ok ok",
-		},
-		{
-			Name:       "invalid credentials with invalid token character",
-			Token:      "env_org_ok\nko",
-			AppName:    "ok",
-			ShouldFail: true,
-		},
-	} {
-		tc := tc
-		t.Run(tc.Name, func(t *testing.T) {
-			err := internal.ValidateCredentialsConfiguration(tc.Token, tc.AppName)
-			if tc.ShouldFail {
-				require.Error(t, err)
-			} else {
-				require.NoError(t, err)
-			}
-		})
-	}
 }


### PR DESCRIPTION
The PII sanitizer - aka PII scrubber - is now configurable using
`strip_sensitive_key_regexp` and `stip_sensitive_value_regexp` configuration
entries.

Because those regular expressions are critical, configuration validation was
added to make sure the regular expressions are valid. The agent doesn't start if
invalid, displaying an error message in the logs.

Some rework around the configuration validation was therefore also performed,
such as the app credential validation.