### PR TITLE
Fix HTTP header marshaling

### DIFF
--- a/internal/backend/api/json.go
+++ b/internal/backend/api/json.go
@@ -17,10 +17,11 @@ import (
 var RequestRecordVersion = "20171208"
 
 func (h *RequestRecord_Request_Header) MarshalJSON() ([]byte, error) {
-	if h == nil {
-		return []byte("[]"), nil
+	var kv []string
+	if h != nil {
+		kv = []string{h.Key, h.Value}
 	}
-	return []byte(`["` + h.Key + `", "` + h.Value + `"]`), nil
+	return json.Marshal(kv)
 }
 
 type ListValue []interface{}


### PR DESCRIPTION
Avoid the string concatenation and rather use `json.Marshal` to safely marshal header keys and values.