### PR TITLE
agent: goroutine local storage integration

### DIFF
--- a/internal/backend/api/api.go
+++ b/internal/backend/api/api.go
@@ -262,8 +262,7 @@ type ReflectedCallbackHTTPProtectionContextConfig struct {
 }
 
 type ReflectedCallbackHTTPProtectionConfig struct {
-	Context       ReflectedCallbackHTTPProtectionContextConfig `json:"context"`
-	BlockStrategy ReflectedCallbackBlockStrategyConfig         `json:"block_strategy"`
+	BlockStrategy ReflectedCallbackBlockStrategyConfig `json:"block_strategy"`
 }
 
 type ReflectedCallbackProtectionConfig struct {

--- a/internal/protection/http/http.go
+++ b/internal/protection/http/http.go
@@ -19,6 +19,7 @@ import (
 	"github.com/sqreen/go-agent/internal/event"
 	protection_context "github.com/sqreen/go-agent/internal/protection/context"
 	"github.com/sqreen/go-agent/internal/protection/http/types"
+	"github.com/sqreen/go-agent/internal/sqlib/sqgls"
 )
 
 type RequestContext struct {
@@ -80,6 +81,14 @@ func FromContext(ctx context.Context) *RequestContext {
 	return c
 }
 
+func FromGLS() *RequestContext {
+	ctx := sqgls.Get()
+	if ctx == nil {
+		return nil
+	}
+	return ctx.(*RequestContext)
+}
+
 func NewRequestContext(agent protection_context.AgentFace, w types.ResponseWriter, r types.RequestReader, cancelHandlerContextFunc context.CancelFunc) *RequestContext {
 	if r.ClientIP() == nil {
 		cfg := agent.Config()
@@ -97,6 +106,9 @@ func NewRequestContext(agent protection_context.AgentFace, w types.ResponseWrite
 		RequestReader:            r,
 		cancelHandlerContextFunc: cancelHandlerContextFunc,
 	}
+	// Set the current goroutine local storage to this request storage to be able
+	// to retrieve it from lower-level functions.
+	sqgls.Set(ctx)
 	return ctx
 }
 

--- a/internal/rule/callback/javascript.go
+++ b/internal/rule/callback/javascript.go
@@ -7,7 +7,6 @@
 package callback
 
 import (
-	"context"
 	"reflect"
 	"sync"
 
@@ -216,10 +215,7 @@ func call(vm *goja.Runtime, descr *jsCallbackFunc, baCtx bindingaccessor.Context
 }
 
 func getProtectionContext(protection *api.ReflectedCallbackProtectionConfig, params []reflect.Value) *httpprotection.RequestContext {
-	// Get the HTTP protection context out of the Go context taken from the
-	// function call arguments according to the strategy definition.
-	goCtx := params[protection.Context.ArgIndex].Elem().Interface().(context.Context)
-	return httpprotection.FromContext(goCtx)
+	return httpprotection.FromGLS()
 }
 
 type noScrub map[string]interface{}

--- a/internal/sqlib/sqgls/gls.go
+++ b/internal/sqlib/sqgls/gls.go
@@ -1,0 +1,13 @@
+// Copyright (c) 2016 - 2020 Sqreen. All Rights Reserved.
+// Please refer to our terms for more information:
+// https://www.sqreen.io/terms.html
+
+package sqgls
+
+func Get() interface{} {
+	return get()
+}
+
+func Set(v interface{}) {
+	set(v)
+}

--- a/internal/sqlib/sqgls/gls_sqreen.go
+++ b/internal/sqlib/sqgls/gls_sqreen.go
@@ -1,0 +1,17 @@
+// Copyright (c) 2016 - 2020 Sqreen. All Rights Reserved.
+// Please refer to our terms for more information:
+// https://www.sqreen.io/terms.html
+
+package sqgls
+
+import _ "unsafe" // for go:linkname
+
+//go:linkname _sqreen_gls_get _sqreen_gls_get
+func _sqreen_gls_get() interface{}
+
+//go:linkname _sqreen_gls_set _sqreen_gls_set
+func _sqreen_gls_set(interface{})
+
+func get() interface{} { return _sqreen_gls_get() }
+
+func set(v interface{}) { _sqreen_gls_set(v) }

--- a/sdk/sqreen-instrumentation-tool/instrumentation.go
+++ b/sdk/sqreen-instrumentation-tool/instrumentation.go
@@ -346,11 +346,11 @@ import _ "unsafe" // for go:linkname
 
 //go:nosplit
 //go:linkname _sqreen_gls_get _sqreen_gls_get
-func _sqreen_gls_get() uintptr { return getg().m.curg.sqgls }
+func _sqreen_gls_get() interface{} { return getg().m.curg.sqgls }
 
 //go:nosplit
 //go:linkname _sqreen_gls_set _sqreen_gls_set
-func _sqreen_gls_set(v uintptr)  { getg().m.curg.sqgls = v }
+func _sqreen_gls_set(v interface{})  { getg().m.curg.sqgls = v }
 `), 0644); err != nil {
 		return nil, err
 	}
@@ -382,7 +382,7 @@ func (v *runtimeInstrumentationVisitor) instrument(root *dst.Package) (instrumen
 			}
 			st.Fields.List = append(st.Fields.List, &dst.Field{
 				Names: []*dst.Ident{dst.NewIdent("sqgls")},
-				Type:  dst.NewIdent("uintptr"),
+				Type:  dst.NewIdent("interface{}"),
 			})
 			instrumented = true
 			return true


### PR DESCRIPTION
Store the HTTP protection context in the GLS when it is created, so that
functions not having direct access to it, nor to the request context, can now
access it through the GLS. Therefore, the security rules no longer need the
`context` field that was specifying how to access it through function arguments.
Therefore, GLS is now mandatory, as most of the RASP protections need it. For
example, functions like `os.Open()` or `exec.(*Command).Run()` can now be
protected thanks to this change.