### PR TITLE
RASP: Shell-Injection Protection

### DIFF
--- a/internal/binding-accessor/exec.go
+++ b/internal/binding-accessor/exec.go
@@ -85,9 +85,13 @@ func execFieldAccess(value interface{}, field string) (interface{}, error) {
 	}
 }
 
-func execCall(fn interface{}, arg interface{}) (interface{}, error) {
+func execCall(fn interface{}, args ...interface{}) (interface{}, error) {
 	// TODO: func type validation
-	results := reflect.ValueOf(fn).Call([]reflect.Value{reflect.ValueOf(arg)})
+	argValues := make([]reflect.Value, len(args))
+	for i, a := range args {
+		argValues[i] = reflect.ValueOf(a)
+	}
+	results := reflect.ValueOf(fn).Call(argValues)
 
 	if r1 := results[1]; !r1.IsNil() {
 		return nil, r1.Interface().(error)

--- a/internal/rule/callback/bindingaccessor_test.go
+++ b/internal/rule/callback/bindingaccessor_test.go
@@ -1,0 +1,44 @@
+// Copyright (c) 2016 - 2020 Sqreen. All Rights Reserved.
+// Please refer to our terms for more information:
+// https://www.sqreen.io/terms.html
+
+package callback_test
+
+import (
+	"testing"
+
+	"github.com/sqreen/go-agent/internal/rule/callback"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBindingAccessorLibrary(t *testing.T) {
+	lib := callback.NewLibraryBindingAccessorContext()
+
+	t.Run("Array Library", func(t *testing.T) {
+		t.Run("Prepend", func(t *testing.T) {
+			t.Run("", func(t *testing.T) {
+				got, err := lib.Array.Prepend([]string{"b", "c", "d"}, "a")
+				require.NoError(t, err)
+				require.Equal(t, []string{"a", "b", "c", "d"}, got)
+			})
+
+			t.Run("", func(t *testing.T) {
+				got, err := lib.Array.Prepend([]int{}, 1)
+				require.NoError(t, err)
+				require.Equal(t, []int{1}, got)
+			})
+
+			t.Run("type mismatch", func(t *testing.T) {
+				require.Panics(t, func() {
+					lib.Array.Prepend([]int{}, "a")
+				})
+			})
+
+			t.Run("nil slice value", func(t *testing.T) {
+				got, err := lib.Array.Prepend(([]int)(nil), 1)
+				require.NoError(t, err)
+				require.Equal(t, []int{1}, got)
+			})
+		})
+	})
+}

--- a/sdk/sqreen-instrumentation-tool/instrumentation.go
+++ b/sdk/sqreen-instrumentation-tool/instrumentation.go
@@ -159,10 +159,21 @@ var ignoredPkgPrefixes = []string{
 	"math",
 }
 
-var limitedInstrumentationPkgPrefixes = []string{
-	"github.com/sqreen/go-agent/internal/protection",
-	"database/sql",
-}
+// List of packages to instrument when not in full instrumentation mode.
+var (
+	// List of package path prefixes to instrument. A package is instrumented
+	// iif its package path begins with one of the following prefixes.
+	limitedInstrumentationPkgPathPrefixes = []string{
+		"github.com/sqreen/go-agent/internal/protection",
+		"database/sql",
+	}
+
+	// List of package paths to instrument. A package is instrumented iif it is
+	// equal to one of the following package paths.
+	limitedInstrumentationPkgPaths = []string{
+		"os",
+	}
+)
 
 func (h *defaultPackageInstrumentation) isPackageNameIgnored() bool {
 	for _, prefix := range ignoredPkgPrefixes {
@@ -175,8 +186,14 @@ func (h *defaultPackageInstrumentation) isPackageNameIgnored() bool {
 		return false
 	}
 
-	// Non-full instrumentation mode, limited to a set of given package
-	for _, prefix := range limitedInstrumentationPkgPrefixes {
+	// Non-full instrumentation mode is limited to a set of packages
+	for _, pkgPath := range limitedInstrumentationPkgPaths {
+		if h.pkgPath == pkgPath {
+			return false
+		}
+	}
+
+	for _, prefix := range limitedInstrumentationPkgPathPrefixes {
 		if strings.HasPrefix(h.pkgPath, prefix) {
 			return false
 		}


### PR DESCRIPTION
This patch updates the instrument tool so that the `os` package is instrumented and we can monitor and protect calls to `os.StartProcess` against shell injections. Go doesn't have any shell expansion and so on in the std library, but `os.StartProcess` can be used to execute a shell or shell script and we can therefore check for injections in the list of arguments.

The rest of the patch adds support to binding accessors for function calls with multiple arguments, along with a new helper function `#.Lib.Array.Prepend` that we didn't have to use in the security rule in the end.

So the good news is that the current JS callback was already suitable for this new security rule.