### PR TITLE
Add IP denylist support

### DIFF
--- a/internal/actor/action.go
+++ b/internal/actor/action.go
@@ -95,17 +95,17 @@ func (a *timedAction) Expired() bool {
 	return time.Now().After(a.deadline)
 }
 
-type whitelistAction struct {
+type ipListAction struct {
 	// The CIDR is used as action ID
 	CIDR string
 }
 
-func newWhitelistAction(cidr string) whitelistAction {
-	return whitelistAction{
+func newIPListAction(cidr string) ipListAction {
+	return ipListAction{
 		CIDR: cidr,
 	}
 }
 
-func (a whitelistAction) ActionID() string {
+func (a ipListAction) ActionID() string {
 	return a.CIDR
 }

--- a/internal/actor/iplist.go
+++ b/internal/actor/iplist.go
@@ -12,58 +12,60 @@ import (
 	"github.com/kentik/patricia"
 )
 
-// CIDRWhitelistStore is the set of data-structures to store CIDR IPv6 and IPv4
-// whitelists. Locking is avoided by not having concurrent insertions and
-// lookups. Therefore, a second whitelistStore is created when a new whitelist
-// is received, and only swapping the whitelistStore pointer needs to be
-// thread-safe.
-type CIDRWhitelistStore struct {
-	treeV4 *WhitelistTreeV4
-	treeV6 *WhitelistTreeV6
-}
+type (
+	// CIDRIPListStore is the set of data-structures to store CIDR IPv6 and IPv4
+	// IPLists. Locking is avoided by not having concurrent insertions and
+	// lookups. Therefore, a second IPListStore is created when a new IPList
+	// is received, and only swapping the IPListStore pointer needs to be
+	// thread-safe.
+	CIDRIPListStore struct {
+		treeV4 *IPListTreeV4
+		treeV6 *IPListTreeV6
+	}
 
-type WhitelistTreeV4 actionTreeV4
-type WhitelistTreeV6 actionTreeV6
+	IPListTreeV4 actionTreeV4
+	IPListTreeV6 actionTreeV6
+)
 
-func NewCIDRWhitelistStore(cidrs []string) (*CIDRWhitelistStore, error) {
+func NewCIDRIPListStore(cidrs []string) (*CIDRIPListStore, error) {
 	if len(cidrs) == 0 {
 		return nil, nil
 	}
-	whitelistv4 := newActionTreeV4(maxStoreActions)
-	whitelistv6 := newActionTreeV6(maxStoreActions)
+	IPListv4 := newActionTreeV4(maxStoreActions)
+	IPListv6 := newActionTreeV6(maxStoreActions)
 	var hasIPv4, hasIPv6 bool // true when at least one IP was added to the tree
 	for _, cidr := range cidrs {
-		action := newWhitelistAction(cidr)
+		action := newIPListAction(cidr)
 		ipv4, ipv6, err := patricia.ParseIPFromString(cidr)
 		if err != nil {
 			return nil, err
 		}
 		if ipv4 != nil {
-			if err := whitelistv4.addAction(ipv4, action); err != nil {
+			if err := IPListv4.addAction(ipv4, action); err != nil {
 				return nil, err
 			}
 			hasIPv4 = true
 		} else if ipv6 != nil {
-			if err := whitelistv6.addAction(ipv6, action); err != nil {
+			if err := IPListv6.addAction(ipv6, action); err != nil {
 				return nil, err
 			}
 			hasIPv6 = true
 		}
 	}
-	// Release empty whitelist trees when nothing was added to them.
+	// Release empty IPList trees when nothing was added to them.
 	if !hasIPv4 {
-		whitelistv4 = nil
+		IPListv4 = nil
 	}
 	if !hasIPv6 {
-		whitelistv6 = nil
+		IPListv6 = nil
 	}
-	return &CIDRWhitelistStore{
-		treeV4: (*WhitelistTreeV4)(whitelistv4),
-		treeV6: (*WhitelistTreeV6)(whitelistv6),
+	return &CIDRIPListStore{
+		treeV4: (*IPListTreeV4)(IPListv4),
+		treeV6: (*IPListTreeV6)(IPListv6),
 	}, nil
 }
 
-func (s *CIDRWhitelistStore) Find(ip net.IP) (whitelisted bool, matched string, err error) {
+func (s *CIDRIPListStore) Find(ip net.IP) (exists bool, matched string, err error) {
 	var action Action
 	if stdIPv4 := ip.To4(); stdIPv4 != nil {
 		tree := (*actionTreeV4)(s.treeV4)

--- a/internal/adapter.go
+++ b/internal/adapter.go
@@ -302,6 +302,13 @@ func newMetricsAPIAdapter(logger plog.ErrorLogger, expiredMetrics map[string]*me
 		for name, values := range readyMetrics {
 			observations := make(map[string]int64, len(values.Metrics()))
 			for k, v := range values.Metrics() {
+				// String keys are directly added
+				if s, ok := k.(string); ok {
+					observations[s] = v
+					continue
+				}
+
+				// Non-string keys are serialized into json
 				jsonKey, err := json.Marshal(k)
 				if err != nil {
 					logger.Error(sqerrors.Wrapf(err, "could not marshal to json key the value `%v` of type `%T`", k, k))

--- a/internal/metrics.go
+++ b/internal/metrics.go
@@ -57,11 +57,10 @@ func (a *AgentType) addUserEvent(e event.UserEventFace) {
 	}
 }
 
-func (a *AgentType) addWhitelistEvent(matchedWhitelistEntry string) {
-	a.logger.Debugf("request whitelisted for `%s`", matchedWhitelistEntry)
-	err := a.staticMetrics.whitelistedIP.Add(matchedWhitelistEntry, 1)
+func (a *AgentType) addPassListEvent(matchedPasslistEntry string) {
+	err := a.staticMetrics.allowedIP.Add(matchedPasslistEntry, 1)
 	if err != nil {
-		sqErr := sqerrors.Wrap(err, "whitelist event: could not update the whitelist metrics store")
+		sqErr := sqerrors.Wrap(err, "passlist event: could not update the passlist metrics store")
 		switch actualErr := err.(type) {
 		case metrics.MaxMetricsStoreLengthError:
 			a.logger.Debug(sqErr)

--- a/internal/protection/context/context.go
+++ b/internal/protection/context/context.go
@@ -80,7 +80,7 @@ type AgentFace interface {
 	// Send the closed request context to the agent. An error is when the object
 	// could not be sent (eg. full channel).
 	SendClosedRequestContext(ClosedRequestContextFace) error
-	IsIPWhitelisted(ip net.IP) bool
+	IsIPAllowed(ip net.IP) bool
 }
 
 type ClosedRequestContextFace interface{}

--- a/internal/protection/http/bindingaccessor.go
+++ b/internal/protection/http/bindingaccessor.go
@@ -83,15 +83,3 @@ func (r *RequestBindingAccessorContext) Params() RequestParamsSet {
 func (r *RequestBindingAccessorContext) Header(h string) (*string, error) {
 	return r.RequestReader.Header(h), nil
 }
-
-// Helper types for callbacks who must be designed for this protection so that
-// they are the source of truth and so that the compiler catches type issues
-// when compiling (versus when the callback is attached).
-type (
-	NonBlockingPrologCallbackType        = func(**RequestContext) (NonBlockingEpilogCallbackType, error)
-	BlockingPrologCallbackType           = func(**RequestContext) (BlockingEpilogCallbackType, error)
-	IdentifyUserPrologCallbackType       = func(**RequestContext, *map[string]string) (BlockingEpilogCallbackType, error)
-	ResponseMonitoringPrologCallbackType = func(**RequestContext, *types.ResponseFace) (NonBlockingEpilogCallbackType, error)
-	NonBlockingEpilogCallbackType        = func()
-	BlockingEpilogCallbackType           = func(*error)
-)

--- a/internal/protection/http/http.go
+++ b/internal/protection/http/http.go
@@ -17,13 +17,13 @@ import (
 	"github.com/pkg/errors"
 	"github.com/sqreen/go-agent/internal/config"
 	"github.com/sqreen/go-agent/internal/event"
-	protection_context "github.com/sqreen/go-agent/internal/protection/context"
+	protectioncontext "github.com/sqreen/go-agent/internal/protection/context"
 	"github.com/sqreen/go-agent/internal/protection/http/types"
 	"github.com/sqreen/go-agent/internal/sqlib/sqgls"
 )
 
 type RequestContext struct {
-	*protection_context.RequestContext
+	*protectioncontext.RequestContext
 	RequestReader              types.RequestReader
 	ResponseWriter             types.ResponseWriter
 	events                     event.Record
@@ -37,13 +37,26 @@ type RequestContext struct {
 	contextHandlerCanceled bool
 }
 
+// Helper types for callbacks who must be designed for this protection so that
+// they are the source of truth and so that the compiler catches type issues
+// when compiling (versus when the callback is attached).
+type (
+	BlockingPrologCallbackType = func(**RequestContext) (BlockingEpilogCallbackType, error)
+	BlockingEpilogCallbackType = func(*error)
+
+	NonBlockingPrologCallbackType = func(**RequestContext) (NonBlockingEpilogCallbackType, error)
+	NonBlockingEpilogCallbackType = func()
+
+	IdentifyUserPrologCallbackType = func(**RequestContext, *map[string]string) (BlockingEpilogCallbackType, error)
+
+	ResponseMonitoringPrologCallbackType = func(**RequestContext, *types.ResponseFace) (NonBlockingEpilogCallbackType, error)
+)
+
 // Static assert that RequestContext implements the SDK Event Recorder Getter
 // interface.
-var _ protection_context.EventRecorderGetter = (*RequestContext)(nil)
+var _ protectioncontext.EventRecorderGetter = (*RequestContext)(nil)
 
-func (c *RequestContext) EventRecorder() protection_context.EventRecorder {
-	return c
-}
+func (c *RequestContext) EventRecorder() protectioncontext.EventRecorder { return c }
 
 type requestReader struct {
 	types.RequestReader
@@ -56,7 +69,7 @@ func (c *RequestContext) AddAttackEvent(attack *event.AttackEvent) {
 	c.events.AddAttackEvent(attack)
 }
 
-func (c *RequestContext) TrackEvent(event string) protection_context.CustomEvent {
+func (c *RequestContext) TrackEvent(event string) protectioncontext.CustomEvent {
 	return c.events.AddCustomEvent(event)
 }
 
@@ -74,10 +87,10 @@ func (c *RequestContext) IdentifyUser(id map[string]string) error {
 }
 
 // Static assert that the SDK interface is implemented.
-var _ protection_context.EventRecorder = &RequestContext{}
+var _ protectioncontext.EventRecorder = &RequestContext{}
 
 func FromContext(ctx context.Context) *RequestContext {
-	c, _ := protection_context.FromContext(ctx).(*RequestContext)
+	c, _ := protectioncontext.FromContext(ctx).(*RequestContext)
 	return c
 }
 
@@ -89,7 +102,7 @@ func FromGLS() *RequestContext {
 	return ctx.(*RequestContext)
 }
 
-func NewRequestContext(agent protection_context.AgentFace, w types.ResponseWriter, r types.RequestReader, cancelHandlerContextFunc context.CancelFunc) *RequestContext {
+func NewRequestContext(agent protectioncontext.AgentFace, w types.ResponseWriter, r types.RequestReader, cancelHandlerContextFunc context.CancelFunc) *RequestContext {
 	if r.ClientIP() == nil {
 		cfg := agent.Config()
 		r = requestReader{
@@ -97,18 +110,15 @@ func NewRequestContext(agent protection_context.AgentFace, w types.ResponseWrite
 			RequestReader: r,
 		}
 	}
-	if agent.IsIPWhitelisted(r.ClientIP()) {
+	if agent.IsIPAllowed(r.ClientIP()) {
 		return nil
 	}
 	ctx := &RequestContext{
-		RequestContext:           protection_context.NewRequestContext(agent),
+		RequestContext:           protectioncontext.NewRequestContext(agent),
 		ResponseWriter:           w,
 		RequestReader:            r,
 		cancelHandlerContextFunc: cancelHandlerContextFunc,
 	}
-	// Set the current goroutine local storage to this request storage to be able
-	// to retrieve it from lower-level functions.
-	sqgls.Set(ctx)
 	return ctx
 }
 
@@ -116,7 +126,15 @@ func NewRequestContext(agent protection_context.AgentFace, w types.ResponseWrite
 // and the request should be stopped immediately by closing the RequestContext
 // and returning.
 func (c *RequestContext) Before() (err error) {
+	// Set the current goroutine local storage to this request storage to be able
+	// to retrieve it from lower-level functions.
+	sqgls.Set(c)
+
 	c.addSecurityHeaders()
+
+	if err := c.isIPBlocked(); err != nil {
+		return err
+	}
 	if err := c.ipSecurityResponse(); err != nil {
 		return err
 	}
@@ -125,6 +143,9 @@ func (c *RequestContext) Before() (err error) {
 	}
 	return nil
 }
+
+//go:noinline
+func (c *RequestContext) isIPBlocked() error { /* dynamically instrumented */ return nil }
 
 //go:noinline
 func (c *RequestContext) waf() error { /* dynamically instrumented */ return nil }
@@ -191,6 +212,11 @@ func (c *closedRequestContext) Response() types.ResponseFace {
 }
 
 func (c *RequestContext) Close(response types.ResponseFace) error {
+	// Make sure to clear the goroutine local storage to avoid keeping it if some
+	// memory pools are used under the hood.
+	// TODO: enforce this by design of the gls instrumentation
+	defer sqgls.Set(nil)
+
 	// Do not assume values are safe to keep after the request is done, as they
 	// might be put back in a shared pool.
 	c.monitorObservedResponse(response)

--- a/internal/protection/http/types/types.go
+++ b/internal/protection/http/types/types.go
@@ -55,6 +55,4 @@ type ClosedRequestContextFace interface {
 
 type WriteAfterCloseError struct{}
 
-func (WriteAfterCloseError) Error() string {
-	return "response write after close"
-}
+func (WriteAfterCloseError) Error() string { return "response write after close" }

--- a/internal/record/record.go
+++ b/internal/record/record.go
@@ -9,7 +9,7 @@ package record
 //	FindActionByUserID(userID map[string]string) (action actor.Action, exists bool)
 //	AddHTTPRequestRecord(rr *RequestRecord)
 //	addUserEvent(event UserEventFace)
-//	IsIPWhitelisted(ip net.IP) (whitelisted bool, matchedCIDR string, err error)
+//	IsIPAllowed(ip net.IP) (whitelisted bool, matchedCIDR string, err error)
 //	addWhitelistEvent(matchedWhitelistEntry string)
 //}
 //

--- a/internal/rule/callback/add-security-headers_test.go
+++ b/internal/rule/callback/add-security-headers_test.go
@@ -6,7 +6,7 @@ package callback_test
 
 //
 //func TestNewAddSecurityHeadersCallbacks(t *testing.T) {
-//	RunCallbackTest(t, TestConfig{
+//	RunNativeCallbackTest(t, TestConfig{
 //		CallbacksCtor: callback.NewAddSecurityHeadersCallback,
 //		ExpectProlog:  true,
 //		PrologType:    reflect.TypeOf(callback.AddSecurityHeadersPrologCallbackType(nil)),

--- a/internal/rule/callback/callback_test.go
+++ b/internal/rule/callback/callback_test.go
@@ -5,93 +5,41 @@
 package callback_test
 
 import (
-	"testing"
-
 	"github.com/pkg/errors"
-	"github.com/sqreen/go-agent/internal/backend/api"
 	"github.com/sqreen/go-agent/internal/event"
-	"github.com/sqreen/go-agent/internal/rule/callback"
-	"github.com/sqreen/go-agent/internal/sqlib/sqhook"
 	"github.com/stretchr/testify/mock"
-	"github.com/stretchr/testify/require"
 )
 
-type TestConfig struct {
-	CallbacksCtor              callback.NativeCallbackConstructorFunc
-	ExpectEpilog, ExpectProlog bool
-	InvalidTestCases           []interface{}
-	ValidTestCases             []ValidTestCase
+type NativeCallbackConfigMockup struct {
+	mock.Mock
 }
 
-type ValidTestCase struct {
-	Rule                       *RuleContextMockup
-	TestCallback               func(t *testing.T, rule *RuleContextMockup, prolog sqhook.PrologCallback)
-	ExpectAbortedCallbackChain bool
-	Config                     callback.NativeCallbackConfig
+func (m *NativeCallbackConfigMockup) Data() interface{} {
+	return m.Called().Get(0)
 }
 
-type callbackConfig struct {
-	data interface{}
+func (m *NativeCallbackConfigMockup) ExpectData() *mock.Call {
+	return m.On("Data")
 }
 
-func (c callbackConfig) BlockingMode() bool {
-	return false
+func (m *NativeCallbackConfigMockup) BlockingMode() bool {
+	return m.Called().Bool(0)
 }
 
-func (c callbackConfig) Data() interface{} {
-	return c.data
-}
-
-func (c callbackConfig) Strategy() *api.ReflectedCallbackConfig {
-	return nil
-}
-
-func RunCallbackTest(t *testing.T, config TestConfig) {
-	for _, data := range config.InvalidTestCases {
-		data := data
-		t.Run("with incorrect data", func(t *testing.T) {
-			cbCfg := callbackConfig{data}
-			prolog, err := config.CallbacksCtor(&RuleContextMockup{}, cbCfg)
-			require.Error(t, err)
-			require.Nil(t, prolog)
-		})
-	}
-
-	for _, tc := range config.ValidTestCases {
-		tc := tc
-		t.Run("with correct data", func(t *testing.T) {
-			// Instantiate the callback with the given correct rule data
-			prolog, err := config.CallbacksCtor(tc.Rule, tc.Config)
-			require.NoError(t, err)
-			checkCallbacksValues(t, config, prolog)
-			tc.TestCallback(t, tc.Rule, prolog)
-		})
-	}
-}
-
-func checkCallbacksValues(t *testing.T, config TestConfig, prolog sqhook.PrologCallback) {
-	if config.ExpectProlog || config.ExpectEpilog {
-		require.NotNil(t, prolog)
-	}
+func (m *NativeCallbackConfigMockup) ExpectBlockingMode() *mock.Call {
+	return m.On("BlockingMode")
 }
 
 type RuleContextMockup struct {
 	mock.Mock
 }
 
-func (m *RuleContextMockup) BlockingMode() bool {
-	return m.Called().Bool(0)
-}
-
-func (m *RuleContextMockup) ExpectBlockingMode() *mock.Call {
-	return m.On("BlockingMode")
-}
-
-func (mockup *RuleContextMockup) Error(err error) {
-}
-
 func (r *RuleContextMockup) PushMetricsValue(key interface{}, value int64) error {
 	return r.Called(key, value).Error(0)
+}
+
+func (r *RuleContextMockup) ExpectPushMetricsValue(key interface{}, value int64) *mock.Call {
+	return r.On("PushMetricsValue", key, value)
 }
 
 func (r *RuleContextMockup) NewAttackEvent(blocked bool, info interface{}, st errors.StackTrace) *event.AttackEvent {

--- a/internal/rule/callback/factory.go
+++ b/internal/rule/callback/factory.go
@@ -31,6 +31,8 @@ func NewNativeCallback(name string, ctx RuleFace, cfg NativeCallbackConfig) (pro
 		callbackCtor = NewIPSecurityResponseCallback
 	case "UserSecurityResponse":
 		callbackCtor = NewUserSecurityResponseCallback
+	case "IPBlockList", "IPDenyList":
+		callbackCtor = NewIPDenyListCallback
 	}
 	return callbackCtor(ctx, cfg)
 }

--- a/internal/rule/callback/ip-denylist.go
+++ b/internal/rule/callback/ip-denylist.go
@@ -1,0 +1,99 @@
+// Copyright (c) 2016 - 2019 Sqreen. All Rights Reserved.
+// Please refer to our terms for more information:
+// https://www.sqreen.io/terms.html
+
+//sqreen:ignore
+
+package callback
+
+import (
+	"fmt"
+	"net"
+
+	"github.com/sqreen/go-agent/internal/actor"
+	httpprotection "github.com/sqreen/go-agent/internal/protection/http"
+	"github.com/sqreen/go-agent/internal/sqlib/sqassert"
+	"github.com/sqreen/go-agent/internal/sqlib/sqerrors"
+	"github.com/sqreen/go-agent/internal/sqlib/sqhook"
+	sdktypes "github.com/sqreen/go-agent/sdk/types"
+)
+
+func NewIPDenyListCallback(rule RuleFace, cfg NativeCallbackConfig) (sqhook.PrologCallback, error) {
+	sqassert.NotNil(rule)
+	sqassert.NotNil(cfg)
+
+	data, ok := cfg.Data().([]interface{})
+	if !ok {
+		return nil, sqerrors.Errorf("unexpected callback data type: got `%T` instead of `%T`", cfg.Data(), data)
+	}
+
+	if l := len(data); l == 0 {
+		return nil, sqerrors.New("empty denylist`")
+	} else if l > 1 {
+		return nil, sqerrors.Errorf("unexpected number of data entries`")
+	}
+
+	d1 := data[0]
+	cidrs, ok := d1.([]string)
+	if !ok {
+		return nil, sqerrors.Errorf("unexpected callback data type: got `%T` instead of `%T`", d1, cidrs)
+	}
+
+	if len(cidrs) == 0 {
+		return nil, sqerrors.New("empty denylist`")
+	}
+
+	denylist, err := actor.NewCIDRIPListStore(cidrs)
+	if err != nil {
+		return nil, sqerrors.Wrapf(err, "unexpected error while creating the IP denylist")
+	}
+	return newIPDenyListPrologCallback(rule, denylist), nil
+}
+
+type IPDenyListPrologCallbackType = httpprotection.BlockingPrologCallbackType
+type IPDenyListEpilogCallbackType = httpprotection.BlockingEpilogCallbackType
+
+type IPDenyListError struct {
+	DeniedIP      net.IP
+	DenyListEntry string
+}
+
+func (e IPDenyListError) Error() string {
+	return fmt.Sprintf("ip address `%s` matched the denylist entry `%s` and was blocked", e.DeniedIP.String(), e.DenyListEntry)
+}
+
+func newIPDenyListPrologCallback(rule RuleFace, denylist *actor.CIDRIPListStore) IPDenyListPrologCallbackType {
+	return func(p **httpprotection.RequestContext) (IPDenyListEpilogCallbackType, error) {
+		ctx := *p
+		ip := ctx.RequestReader.ClientIP()
+		exists, matched, err := denylist.Find(ip)
+
+		if err != nil {
+			ctx.Logger().Error(sqerrors.Wrapf(err, "unexpected error while searching IP address `%#+v` in the IP denylist", ip))
+			return nil, nil
+		}
+
+		if !exists {
+			return nil, nil
+		}
+
+		ctx.WriteDefaultBlockingResponse()
+
+		if err := rule.PushMetricsValue(matched, 1); err != nil {
+			ctx.Logger().Error(sqerrors.Wrapf(err, "could not update the metrics"))
+		}
+
+		return func(e *error) {
+			sqassert.NotNil(e)
+			err := sdktypes.SqreenError{
+				Err: IPDenyListError{
+					DeniedIP:      ip,
+					DenyListEntry: matched,
+				},
+			}
+			// Display the error message explaining why the request is denied.
+			ctx.Logger().Debug(err.Error())
+			*e = err
+		}, nil
+	}
+}

--- a/internal/rule/callback/ip-denylist_test.go
+++ b/internal/rule/callback/ip-denylist_test.go
@@ -1,0 +1,261 @@
+// Copyright (c) 2016 - 2020 Sqreen. All Rights Reserved.
+// Please refer to our terms for more information:
+// https://www.sqreen.io/terms.html
+
+package callback_test
+
+import (
+	"errors"
+	"net"
+	"net/http"
+	"net/url"
+	"os"
+	"testing"
+
+	"github.com/sqreen/go-agent/internal/actor"
+	"github.com/sqreen/go-agent/internal/plog"
+	protectioncontext "github.com/sqreen/go-agent/internal/protection/context"
+	httpprotection "github.com/sqreen/go-agent/internal/protection/http"
+	"github.com/sqreen/go-agent/internal/rule/callback"
+	sdktypes "github.com/sqreen/go-agent/sdk/types"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+type AgentMock struct {
+	mock.Mock
+}
+
+func (a *AgentMock) FindActionByIP(ip net.IP) (action actor.Action, exists bool, err error) {
+	ret := a.Called(ip)
+	action, _ = ret.Get(0).(actor.Action)
+	exists = ret.Bool(1)
+	err = ret.Error(2)
+	return
+}
+
+func (a *AgentMock) FindActionByUserID(userID map[string]string) (action actor.Action, exists bool) {
+	ret := a.Called(userID)
+	action, _ = ret.Get(0).(actor.Action)
+	exists = ret.Bool(1)
+	return
+}
+
+func (a *AgentMock) Logger() (logger *plog.Logger) {
+	logger, _ = a.Called().Get(0).(*plog.Logger)
+	return
+}
+
+func (a *AgentMock) Config() (cfg protectioncontext.ConfigReader) {
+	cfg, _ = a.Called().Get(0).(protectioncontext.ConfigReader)
+	return
+}
+
+func (a *AgentMock) SendClosedRequestContext(face protectioncontext.ClosedRequestContextFace) error {
+	return a.Called(face).Error(0)
+}
+
+func (a *AgentMock) IsIPAllowed(ip net.IP) bool {
+	return a.Called(ip).Bool(0)
+}
+
+func (a *AgentMock) ExpectLogger() *mock.Call {
+	return a.On("Logger")
+}
+
+type RequestReaderMock struct {
+	mock.Mock
+}
+
+func (r *RequestReaderMock) Header(header string) (value *string) {
+	value, _ = r.Called(header).Get(0).(*string)
+	return
+}
+
+func (r *RequestReaderMock) Headers() (headers http.Header) {
+	headers, _ = r.Called().Get(0).(http.Header)
+	return
+}
+
+func (r *RequestReaderMock) Method() string {
+	return r.Called().String(0)
+}
+
+func (r *RequestReaderMock) URL() (u *url.URL) {
+	u, _ = r.Called().Get(0).(*url.URL)
+	return
+}
+
+func (r *RequestReaderMock) RequestURI() string {
+	return r.Called().String(0)
+}
+
+func (r *RequestReaderMock) Host() string {
+	return r.Called().String(0)
+}
+
+func (r *RequestReaderMock) RemoteAddr() string {
+	return r.Called().String(0)
+}
+
+func (r *RequestReaderMock) IsTLS() bool {
+	return r.Called().Bool(0)
+}
+
+func (r *RequestReaderMock) UserAgent() string {
+	return r.Called().String(0)
+}
+
+func (r *RequestReaderMock) Referer() string {
+	return r.Called().String(0)
+}
+
+func (r *RequestReaderMock) Form() (v url.Values) {
+	v, _ = r.Called().Get(0).(url.Values)
+	return
+}
+
+func (r *RequestReaderMock) PostForm() (v url.Values) {
+	v, _ = r.Called().Get(0).(url.Values)
+	return
+}
+
+func (r *RequestReaderMock) ClientIP() (ip net.IP) {
+	ip, _ = r.Called().Get(0).(net.IP)
+	return
+}
+
+func (r *RequestReaderMock) ExpectClientIP() *mock.Call {
+	return r.On("ClientIP")
+}
+
+func (r *RequestReaderMock) FrameworkParams() (v url.Values) {
+	v, _ = r.Called().Get(0).(url.Values)
+	return
+}
+
+type ResponseWriterMock struct {
+	mock.Mock
+}
+
+func (r *ResponseWriterMock) Header() (h http.Header) {
+	h, _ = r.Called().Get(0).(http.Header)
+	return
+}
+
+func (r *ResponseWriterMock) Write(bytes []byte) (int, error) {
+	ret := r.Called(bytes)
+	return ret.Int(0), ret.Error(0)
+}
+
+func (r *ResponseWriterMock) WriteHeader(statusCode int) {
+	r.Called(statusCode)
+}
+
+func (r *ResponseWriterMock) WriteString(s string) (n int, err error) {
+	ret := r.Called(s)
+	return ret.Int(0), ret.Error(1)
+}
+
+var logger = plog.NewLogger(plog.Debug, os.Stderr, 0)
+
+func TestIPDenyListCallback(t *testing.T) {
+	t.Run("Constructor", func(t *testing.T) {
+		t.Run("Configuration errors", func(t *testing.T) {
+			for _, tc := range []interface{}{
+				nil,
+				33,                             // wrong type
+				([]interface{})(nil),           // empty list
+				[]interface{}{},                // empty list
+				[]interface{}{([]string)(nil)}, // empty list
+				[]interface{}{[]string{}},      // empty list
+			} {
+				tc := tc
+				t.Run("", func(t *testing.T) {
+					r := &RuleContextMockup{}
+					defer r.AssertExpectations(t)
+
+					cfg := &NativeCallbackConfigMockup{}
+					cfg.ExpectData().Return(tc)
+					defer cfg.AssertExpectations(t)
+
+					_, err := callback.NewIPDenyListCallback(r, cfg)
+					require.Error(t, err)
+				})
+			}
+		})
+	})
+
+	t.Run("Callback", func(t *testing.T) {
+		r := &RuleContextMockup{}
+
+		cfg := &NativeCallbackConfigMockup{}
+		// Note that exhaustive tests of the underlying IP list is done in the
+		// corresponding package, and that we are only testing the callback API here
+		// with a few examples.
+		data := []interface{}{
+			[]string{
+				"1.2.3.4",
+				"10.0.0.0/8",
+			},
+		}
+		cfg.ExpectData().Return(data).Once()
+		defer cfg.AssertExpectations(t)
+
+		cb, err := callback.NewIPDenyListCallback(r, cfg)
+		require.NoError(t, err)
+		require.NotNil(t, cb)
+
+		prolog, ok := cb.(callback.IPDenyListPrologCallbackType)
+		require.True(t, ok)
+
+		ctx, agent, requestReader, _ := newMockups()
+		agent.ExpectLogger().Return(logger)
+
+		// Not blocked
+		requestReader.ExpectClientIP().Return(net.ParseIP("11.22.33.44")).Once()
+		epilog, err := prolog(&ctx)
+		require.Nil(t, epilog)
+		require.NoError(t, err)
+		requestReader.AssertExpectations(t)
+		// Make sure we didn't call PushMetricsValue
+		r.AssertExpectations(t)
+
+		// Blocked
+		ipStr := "1.2.3.4"
+		ip := net.ParseIP(ipStr)
+		requestReader.ExpectClientIP().Return(ip).Once()
+		r.ExpectPushMetricsValue(ipStr, 1).Return(nil).Once()
+		epilog, err = prolog(&ctx)
+		require.NotNil(t, epilog)
+		require.NoError(t, err)
+		requestReader.AssertExpectations(t)
+		r.AssertExpectations(t)
+
+		var e error
+		epilog(&e)
+		require.NoError(t, err)
+		require.True(t, errors.As(e, &sdktypes.SqreenError{}))
+		var actualErr callback.IPDenyListError
+		require.True(t, errors.As(e, &actualErr))
+		require.Equal(t, ipStr, actualErr.DenyListEntry)
+		require.Equal(t, ip, actualErr.DeniedIP)
+	})
+}
+
+func newMockups() (*httpprotection.RequestContext, *AgentMock, *RequestReaderMock, *ResponseWriterMock) {
+	// TODO: lower-level callback expecting the interface it needs, so that
+	//   tests are easier and thus faster to write
+	agent := &AgentMock{}
+	requestReader := &RequestReaderMock{}
+	responseWriter := &ResponseWriterMock{}
+
+	ctx := &httpprotection.RequestContext{
+		RequestContext: &protectioncontext.RequestContext{
+			AgentFace: agent,
+		},
+		RequestReader:  requestReader,
+		ResponseWriter: responseWriter,
+	}
+	return ctx, agent, requestReader, responseWriter
+}

--- a/internal/rule/callback/monitor-http-status-code_test.go
+++ b/internal/rule/callback/monitor-http-status-code_test.go
@@ -5,7 +5,7 @@
 package callback_test
 
 //func TestNewMonitorHTTPStatusCodeCallbacks(t *testing.T) {
-//	RunCallbackTest(t, TestConfig{
+//	RunNativeCallbackTest(t, TestConfig{
 //		CallbacksCtor: callback.NewMonitorHTTPStatusCodeCallback,
 //		ExpectProlog:  true,
 //		PrologType:    reflect.TypeOf(callback.MonitorHTTPStatusCodePrologCallbackType(nil)),

--- a/internal/rule/callback/testdata/testrules/main.go
+++ b/internal/rule/callback/testdata/testrules/main.go
@@ -1,5 +1,0 @@
-// Copyright (c) 2016 - 2020 Sqreen. All Rights Reserved.
-// Please refer to our terms for more information:
-// https://www.sqreen.io/terms.html
-
-package main

--- a/internal/rule/callback/waf_test.go
+++ b/internal/rule/callback/waf_test.go
@@ -10,7 +10,7 @@ package callback_test
 //		t.SkipNow()
 //	}
 //
-//	RunCallbackTest(t, TestConfig{
+//	RunNativeCallbackTest(t, TestConfig{
 //		CallbacksCtor: callback.NewWAFCallback,
 //		ExpectProlog:  true,
 //		InvalidTestCases: []interface{}{

--- a/internal/rule/callback/write-custom-error-page.go
+++ b/internal/rule/callback/write-custom-error-page.go
@@ -34,8 +34,8 @@ func NewWriteCustomErrorPageCallback(_ RuleFace, cfg NativeCallbackConfig) (sqho
 func newWriteCustomErrorPagePrologCallback(statusCode int) httpprotection.NonBlockingPrologCallbackType {
 	return func(m **httpprotection.RequestContext) (httpprotection.NonBlockingEpilogCallbackType, error) {
 		ctx := *m
-		// Note that the header must be written first because body writting will
-		// otherwise write the default OK status
+		// Note that the header must be written first since writing the body first
+		// leads to the default OK status.
 		ctx.ResponseWriter.WriteHeader(statusCode)
 		ctx.ResponseWriter.WriteString(blockedBySqreenPage)
 		return nil, nil

--- a/internal/rule/callback/write-custom-error-page_test.go
+++ b/internal/rule/callback/write-custom-error-page_test.go
@@ -5,7 +5,7 @@
 package callback_test
 
 //func TestNewWriteCustomErrorPageCallbacks(t *testing.T) {
-//	RunCallbackTest(t, TestConfig{
+//	RunNativeCallbackTest(t, TestConfig{
 //		CallbacksCtor: callback.NewWriteCustomErrorPageCallback,
 //		ExpectProlog:  true,
 //		PrologType:    reflect.TypeOf(callback.WriteCustomErrorPagePrologCallbackType(nil)),

--- a/internal/rule/callback/write-http-redirection_test.go
+++ b/internal/rule/callback/write-http-redirection_test.go
@@ -5,7 +5,7 @@
 package callback_test
 
 //func TestNewWriteHTTPRedirectionCallbacks(t *testing.T) {
-//	RunCallbackTest(t, TestConfig{
+//	RunNativeCallbackTest(t, TestConfig{
 //		CallbacksCtor: callback.NewWriteHTTPRedirectionCallbacks,
 //		ExpectProlog:  true,
 //		PrologType:    reflect.TypeOf(callback.WriteHTTPRedirectionPrologCallbackType(nil)),

--- a/sdk/middleware/_testlib/mockups/agent.go
+++ b/sdk/middleware/_testlib/mockups/agent.go
@@ -62,12 +62,12 @@ func (a *AgentMockup) ExpectSendClosedRequestContext(ctx interface{}) *mock.Call
 	return a.On("SendClosedRequestContext", ctx)
 }
 
-func (a *AgentMockup) IsIPWhitelisted(ip net.IP) bool {
+func (a *AgentMockup) IsIPAllowed(ip net.IP) bool {
 	return a.Called(ip).Bool(0)
 }
 
-func (a *AgentMockup) ExpectIsIPWhitelisted(ip interface{}) *mock.Call {
-	return a.On("IsIPWhitelisted", ip)
+func (a *AgentMockup) ExpectIsIPAllowed(ip interface{}) *mock.Call {
+	return a.On("IsIPAllowed", ip)
 }
 
 type AgentConfigMockup struct {

--- a/sdk/middleware/sqecho/echo_test.go
+++ b/sdk/middleware/sqecho/echo_test.go
@@ -107,7 +107,7 @@ func TestMiddleware(t *testing.T) {
 		handlerResponseStatus := 533
 		agent := &mockups.AgentMockup{}
 		agent.ExpectConfig().Return(&mockups.AgentConfigMockup{})
-		agent.ExpectIsIPWhitelisted(mock.Anything).Return(false)
+		agent.ExpectIsIPAllowed(mock.Anything).Return(false)
 		agent.ExpectSendClosedRequestContext(mock.Anything).Return(nil)
 		defer agent.AssertExpectations(t) // inaccurate but worth it
 
@@ -372,7 +372,7 @@ func TestMiddleware(t *testing.T) {
 
 		agent := &mockups.AgentMockup{}
 		agent.ExpectConfig().Return(&mockups.AgentConfigMockup{}).Once()
-		agent.ExpectIsIPWhitelisted(mock.Anything).Return(false).Once()
+		agent.ExpectIsIPAllowed(mock.Anything).Return(false).Once()
 		var responseStatusCode int
 		agent.ExpectSendClosedRequestContext(mock.MatchedBy(func(recorded types.ClosedRequestContextFace) bool {
 			resp := recorded.Response()
@@ -402,7 +402,6 @@ func TestMiddleware(t *testing.T) {
 		require.Equal(t, expectedStatusCode, responseStatusCode)
 		require.Equal(t, expectedStatusCode, rec.Code)
 	})
-
 
 }
 

--- a/sdk/middleware/sqgin/gin_test.go
+++ b/sdk/middleware/sqgin/gin_test.go
@@ -98,7 +98,7 @@ func TestMiddleware(t *testing.T) {
 		handlerResponseStatus := 533
 		agent := &mockups.AgentMockup{}
 		agent.ExpectConfig().Return(&mockups.AgentConfigMockup{})
-		agent.ExpectIsIPWhitelisted(mock.Anything).Return(false)
+		agent.ExpectIsIPAllowed(mock.Anything).Return(false)
 		agent.ExpectSendClosedRequestContext(mock.Anything).Return(nil)
 		defer agent.AssertExpectations(t) // inaccurate but worth it
 
@@ -319,7 +319,7 @@ func TestMiddleware(t *testing.T) {
 
 		agent := &mockups.AgentMockup{}
 		agent.ExpectConfig().Return(&mockups.AgentConfigMockup{}).Once()
-		agent.ExpectIsIPWhitelisted(mock.Anything).Return(false).Once()
+		agent.ExpectIsIPAllowed(mock.Anything).Return(false).Once()
 		var responseStatusCode int
 		agent.ExpectSendClosedRequestContext(mock.MatchedBy(func(recorded types.ClosedRequestContextFace) bool {
 			resp := recorded.Response()

--- a/sdk/middleware/sqhttp/http_test.go
+++ b/sdk/middleware/sqhttp/http_test.go
@@ -77,7 +77,7 @@ func TestMiddleware(t *testing.T) {
 		handlerResponseStatus := 533
 		agent := &mockups.AgentMockup{}
 		agent.ExpectConfig().Return(&mockups.AgentConfigMockup{})
-		agent.ExpectIsIPWhitelisted(mock.Anything).Return(false)
+		agent.ExpectIsIPAllowed(mock.Anything).Return(false)
 		agent.ExpectSendClosedRequestContext(mock.Anything).Return(nil)
 		defer agent.AssertExpectations(t) // inaccurate but worth it
 
@@ -183,7 +183,7 @@ func TestMiddleware(t *testing.T) {
 
 		agent := &mockups.AgentMockup{}
 		agent.ExpectConfig().Return(&mockups.AgentConfigMockup{}).Once()
-		agent.ExpectIsIPWhitelisted(mock.Anything).Return(false).Once()
+		agent.ExpectIsIPAllowed(mock.Anything).Return(false).Once()
 		var responseStatusCode int
 		agent.ExpectSendClosedRequestContext(mock.MatchedBy(func(recorded types.ClosedRequestContextFace) bool {
 			resp := recorded.Response()

--- a/sdk/types/types.go
+++ b/sdk/types/types.go
@@ -1,0 +1,22 @@
+// Copyright (c) 2016 - 2020 Sqreen. All Rights Reserved.
+// Please refer to our terms for more information:
+// https://www.sqreen.io/terms.html
+
+package types
+
+import "fmt"
+
+// SqreenError is the wrapper error type returned by every Sqreen protection.
+// It allows to implement specific error management when Sqreen has blocked a
+// function call by returning a non-nil error. For example, if SQL-injection
+// is detected and blocked by Sqreen, it is possible to avoid retrying the SQL
+// query when the error is a `SqreenError`. It is possible to test if an error
+// is a SqreenError by using `errors.As`.
+// This type also implements the `Unwrap()` so that more details can be
+// obtained by using `errors.As()`.
+type SqreenError struct {
+	Err error
+}
+
+func (e SqreenError) Error() string { return fmt.Sprintf("sqreen: %s", e.Err) }
+func (e SqreenError) Unwrap() error { return e.Err }

--- a/sdk/types/types_test.go
+++ b/sdk/types/types_test.go
@@ -1,0 +1,68 @@
+// Copyright (c) 2016 - 2020 Sqreen. All Rights Reserved.
+// Please refer to our terms for more information:
+// https://www.sqreen.io/terms.html
+
+package types_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/sqreen/go-agent/sdk/types"
+	"github.com/stretchr/testify/require"
+)
+
+type myErrorType struct{ e error }
+
+func (e myErrorType) Error() string { return e.e.Error() }
+func (e myErrorType) Unwrap() error { return e.e }
+
+func TestTypes(t *testing.T) {
+	t.Run("errors", func(t *testing.T) {
+		t.Run("properly implement the unwrap method", func(t *testing.T) {
+			// Create a custom error type wrapping another one.
+			// This error will be wrapped into the SqreenError type so that we can
+			// test the Unwrap() method through the helper functions of package
+			// `errors`.
+			myLegacyErr := errors.New("my error")
+			myErrWrapper := myErrorType{myLegacyErr}
+
+			t.Run("through struct value", func(t *testing.T) {
+				// Wrap myErrWrapper into SqreenError
+				err := types.SqreenError{Err: myErrWrapper}
+
+				// Unwrap down to SqreenError
+				var sqerr types.SqreenError
+				require.True(t, errors.As(err, &sqerr))
+
+				// Unwrap down to myErrorType
+				var myerr myErrorType
+				require.True(t, errors.As(err, &myerr))
+
+				// Unwrap down to myLegacyErr
+				require.True(t, errors.Is(err, myLegacyErr))
+			})
+
+			t.Run("through pointer value", func(t *testing.T) {
+				// Wrap myErrWrapper into a SqreenError pointer
+				err := &types.SqreenError{Err: myErrWrapper}
+
+				// Unwrap down to SqreenError with the wrong type
+				var sqerrKO types.SqreenError
+				require.False(t, errors.As(err, &sqerrKO))
+
+				// Unwrap down to SqreenError with the correct type
+				var sqerr *types.SqreenError
+				require.True(t, errors.As(err, &sqerr))
+
+				// Unwrap down to myErrorType
+				var myerr myErrorType
+				require.True(t, errors.As(err, &myerr))
+
+				// Unwrap down to myLegacyErr
+				require.True(t, errors.Is(err, myLegacyErr))
+			})
+
+		})
+	})
+}


### PR DESCRIPTION
Add a native callback to check if an IP address is in the IP denylist.
Integrate it into a new HTTP protection method `isIPBlocked` which
returns a non-nil error when the IP is blocked and the request was
handled. 

This small patch went big in the end to remove every usage of whitelist
and blacklist in the code (when possible).