### PR TITLE
RASP: enhanced sql package support

### DIFF
--- a/internal/backend/api/api.go
+++ b/internal/backend/api/api.go
@@ -223,7 +223,10 @@ const (
 	CustomErrorPageType = "custom_error_page"
 	RedirectionType     = "redirection"
 	WAFType             = "waf"
+	CustomType          = "custom"
 )
+
+type CustomRuleDataEntry map[string]interface{}
 
 type CustomErrorPageRuleDataEntry struct {
 	StatusCode int `json:"status_code"`

--- a/internal/backend/api/json.go
+++ b/internal/backend/api/json.go
@@ -158,6 +158,8 @@ func (v *RuleDataEntry) UnmarshalJSON(data []byte) error {
 		value = &RedirectionRuleDataEntry{}
 	case WAFType:
 		value = &WAFRuleDataEntry{}
+	case CustomType:
+		value = &CustomRuleDataEntry{}
 	default:
 		return sqerrors.Errorf("unexpected type of rule data value `%s`", t)
 	}

--- a/internal/binding-accessor/binding-accessor.go
+++ b/internal/binding-accessor/binding-accessor.go
@@ -241,7 +241,7 @@ func compileIdentifier(buf string) (valueFunc, string, error) {
 	var valueFn valueFunc
 	switch identifier {
 	default:
-		// Try match string value
+		// Try parse a string value
 		if l := len(identifier); l >= 2 && identifier[0] == '\'' && identifier[l-1] == '\'' {
 			str := identifier[1 : l-1]
 			valueFn = func(ctx Context, depth int) (interface{}, error) {
@@ -254,9 +254,7 @@ func compileIdentifier(buf string) (valueFunc, string, error) {
 		valueFn = func(ctx Context, depth int) (interface{}, error) {
 			return ctx, nil
 		}
-	case "nil":
-		fallthrough
-	case "null":
+	case "nil", "null":
 		valueFn = func(ctx Context, depth int) (interface{}, error) {
 			return nil, nil
 		}

--- a/internal/binding-accessor/exec.go
+++ b/internal/binding-accessor/exec.go
@@ -15,6 +15,7 @@ import (
 
 func execIndexAccess(v interface{}, index interface{}) (interface{}, error) {
 	lvalue := reflect.ValueOf(v)
+doExecIndexAccess:
 	switch lvalue.Kind() {
 	case reflect.Func:
 		// In order to be backward compatible with some binding accessor
@@ -32,6 +33,9 @@ func execIndexAccess(v interface{}, index interface{}) (interface{}, error) {
 		return value.Interface(), nil
 	case reflect.Slice:
 		return lvalue.Index(index.(int)).Interface(), nil
+	case reflect.Ptr, reflect.Interface:
+		lvalue = lvalue.Elem()
+		goto doExecIndexAccess
 	default:
 		return nil, sqerrors.Errorf("cannot index value `%[1]v` of type `%[1]T` with index `%[2]v` of type `%[2]T`", v, index)
 	}
@@ -41,9 +45,7 @@ func execFieldAccess(value interface{}, field string) (interface{}, error) {
 	v := reflect.ValueOf(value)
 	for {
 		switch v.Kind() {
-		case reflect.Interface:
-			fallthrough
-		case reflect.Ptr:
+		case reflect.Interface, reflect.Ptr:
 			if m := v.MethodByName(field); m.IsValid() {
 				// Call the the method which is expected to take no argument and to return a
 				// single value. This line can panic on purpose as this is the primary way
@@ -86,12 +88,20 @@ func execFieldAccess(value interface{}, field string) (interface{}, error) {
 }
 
 func execCall(fn interface{}, args ...interface{}) (interface{}, error) {
-	// TODO: func type validation
+	fnValue := reflect.ValueOf(fn)
+	fnType := fnValue.Type()
+
 	argValues := make([]reflect.Value, len(args))
 	for i, a := range args {
-		argValues[i] = reflect.ValueOf(a)
+		if a != nil {
+			argValues[i] = reflect.ValueOf(a)
+		} else {
+			// Don't use nil to avoid panics when calling the function with reflect.
+			// Use instead the expected zero value for that argument type.
+			argValues[i] = reflect.Zero(fnType.In(i))
+		}
 	}
-	results := reflect.ValueOf(fn).Call(argValues)
+	results := fnValue.Call(argValues)
 
 	if r1 := results[1]; !r1.IsNil() {
 		return nil, r1.Interface().(error)
@@ -253,9 +263,7 @@ func flatKeys(v reflect.Value, depth int, elements *int) []interface{} {
 			}
 		}
 
-	case reflect.Ptr:
-		fallthrough
-	case reflect.Interface:
+	case reflect.Ptr, reflect.Interface:
 		// traverse the interface and don't count this iteration in the depth count
 		return flatKeys(v.Elem(), depth+1, elements)
 

--- a/internal/rule/callback/bindingaccessor_test.go
+++ b/internal/rule/callback/bindingaccessor_test.go
@@ -5,40 +5,203 @@
 package callback_test
 
 import (
+	"context"
+	"database/sql"
+	"database/sql/driver"
+	"reflect"
 	"testing"
 
+	bindingaccessor "github.com/sqreen/go-agent/internal/binding-accessor"
+	"github.com/sqreen/go-agent/internal/protection/http/types"
 	"github.com/sqreen/go-agent/internal/rule/callback"
 	"github.com/stretchr/testify/require"
 )
 
-func TestBindingAccessorLibrary(t *testing.T) {
-	lib := callback.NewLibraryBindingAccessorContext()
+func TestBindingAccessor(t *testing.T) {
+	type NewContextArgs struct {
+		Args, Res []reflect.Value
+		Req       types.RequestReader
+		Values    interface{}
+	}
 
-	t.Run("Array Library", func(t *testing.T) {
-		t.Run("Prepend", func(t *testing.T) {
-			t.Run("", func(t *testing.T) {
-				got, err := lib.Array.Prepend([]string{"b", "c", "d"}, "a")
-				require.NoError(t, err)
-				require.Equal(t, []string{"a", "b", "c", "d"}, got)
-			})
+	db := sql.OpenDB(fakeSQLDriver{})
 
-			t.Run("", func(t *testing.T) {
-				got, err := lib.Array.Prepend([]int{}, 1)
-				require.NoError(t, err)
-				require.Equal(t, []int{1}, got)
-			})
+	type TestCase struct {
+		Expr          string
+		ExpectedValue interface{}
+		ExpectedError bool
+	}
 
-			t.Run("type mismatch", func(t *testing.T) {
-				require.Panics(t, func() {
-					lib.Array.Prepend([]int{}, "a")
+	for _, tc := range []struct {
+		Name           string
+		Capabilities   []string
+		NewContextArgs NewContextArgs
+		TestCases      []TestCase
+	}{
+		{
+			Name:         "SQL",
+			Capabilities: []string{"sql", "rule", "func"},
+			NewContextArgs: NewContextArgs{
+				Args: []reflect.Value{
+					reflect.ValueOf(&db),
+				},
+				Values: map[string]interface{}{
+					"dialects": map[string]interface{}{
+						"mysql":  []interface{}{"mypkg", reflect.TypeOf(fakeSQLDriver{}).PkgPath()},
+						"mysql2": []interface{}{"mypkg2"},
+					},
+
+					"dialects2": map[string]interface{}{
+						"mysql":  []interface{}{"mypkg"},
+						"mysql2": []interface{}{"mypkg2"},
+					},
+
+					"dialects_wrong_type": map[string][]string{
+						"mysql":  {"mypkg"},
+						"mysql2": {"mypkg2"},
+					},
+				},
+			},
+			TestCases: []TestCase{
+				{
+					Expr:          "#.SQL.Dialect(#.Func.Args[0], #.Rule.Data.Values['dialects'])",
+					ExpectedValue: "mysql",
+				},
+
+				{
+					Expr:          "#.SQL.Dialect(#.Func.Args[0], #.Rule.Data.Values['dialects2'])",
+					ExpectedValue: nil,
+					ExpectedError: true,
+				},
+
+				{
+					Expr:          "#.SQL.Dialect(#.Func.Args[0], #.Rule.Data.Values['oops'])",
+					ExpectedValue: nil,
+					ExpectedError: true,
+				},
+
+				{
+					Expr:          "#.SQL.Dialect(#.Func.Args[0], #.Rule.Data.Oops)",
+					ExpectedValue: nil,
+					ExpectedError: true,
+				},
+
+				{
+					Expr:          "#.SQL.Dialect(#.Func.Args[0], nil)",
+					ExpectedValue: nil,
+					ExpectedError: true,
+				},
+
+				{
+					Expr:          "#.SQL.Dialect(#.Func.Args[0], #.Rule.Data.Values['dialects_wrong_type'])",
+					ExpectedValue: nil,
+					ExpectedError: true,
+				},
+
+				{
+					Expr:          "#.SQL.Dialect(#.Func.Args[1], #.Rule.Data.Values['dialects'])",
+					ExpectedValue: nil,
+					ExpectedError: true,
+				},
+			},
+		},
+
+		{
+			Name:         "Array Library",
+			Capabilities: []string{"lib", "rule"},
+			NewContextArgs: NewContextArgs{
+				Values: struct {
+					StringSlice, EmptyStringSlice []string
+					StringValue                   string
+
+					IntSlice, EmptyIntSlice []int
+					IntValue                int
+					EmptyInterfaceSlice     []interface{}
+				}{
+					StringSlice:      []string{"b", "c", "d"},
+					EmptyStringSlice: []string{},
+					StringValue:      "a",
+
+					IntSlice:      []int{2, 3, 4},
+					EmptyIntSlice: []int{},
+					IntValue:      1,
+
+					EmptyInterfaceSlice: []interface{}{},
+				},
+			},
+			TestCases: []TestCase{
+				{
+					Expr:          "#.Lib.Array.Prepend(#.Rule.Data.Values.StringSlice, #.Rule.Data.Values.StringValue)",
+					ExpectedValue: []string{"a", "b", "c", "d"},
+				},
+				{
+					Expr:          "#.Lib.Array.Prepend(#.Rule.Data.Values.StringSlice, 'a')",
+					ExpectedValue: []string{"a", "b", "c", "d"},
+				},
+				{
+					Expr:          "#.Lib.Array.Prepend(#.Rule.Data.Values.EmptyStringSlice, 'a')",
+					ExpectedValue: []string{"a"},
+				},
+				{
+					Expr:          "#.Lib.Array.Prepend(nil, 'a')",
+					ExpectedValue: []string{"a"},
+				},
+				{
+					Expr:          "#.Lib.Array.Prepend(#.Rule.Data.Values.StringSlice, #.Rule.Data.Values.IntValue)",
+					ExpectedError: true,
+				},
+
+				{
+					Expr:          "#.Lib.Array.Prepend(#.Rule.Data.Values.IntSlice, #.Rule.Data.Values.IntValue)",
+					ExpectedValue: []int{1, 2, 3, 4},
+				},
+				{
+					Expr:          "#.Lib.Array.Prepend(#.Rule.Data.Values.EmptyIntSlice, #.Rule.Data.Values.IntValue)",
+					ExpectedValue: []int{1},
+				},
+				{
+					Expr:          "#.Lib.Array.Prepend(nil, #.Rule.Data.Values.IntValue)",
+					ExpectedValue: []int{1},
+				},
+
+				{
+					Expr:          "#.Lib.Array.Prepend(nil, #.Rule.Data.Values.IntSlice)",
+					ExpectedValue: [][]int{{2, 3, 4}},
+				},
+
+				{
+					Expr:          "#.Lib.Array.Prepend(#.Rule.Data.Values.EmptyInterfaceSlice, #.Rule.Data.Values.IntValue)",
+					ExpectedValue: []interface{}{1},
+				},
+			},
+		},
+	} {
+		tc := tc
+		t.Run(tc.Name, func(t *testing.T) {
+			ctx, err := callback.NewCallbackBindingAccessorContext(tc.Capabilities, tc.NewContextArgs.Args, tc.NewContextArgs.Res, tc.NewContextArgs.Req, tc.NewContextArgs.Values)
+			require.NoError(t, err)
+
+			for _, tc := range tc.TestCases {
+				tc := tc
+				t.Run("", func(t *testing.T) {
+					ba, err := bindingaccessor.Compile(tc.Expr)
+					require.NoError(t, err)
+
+					v, err := ba(ctx)
+					if tc.ExpectedError {
+						require.Error(t, err)
+					} else {
+						require.NoError(t, err)
+					}
+					require.Equal(t, tc.ExpectedValue, v)
 				})
-			})
-
-			t.Run("nil slice value", func(t *testing.T) {
-				got, err := lib.Array.Prepend(([]int)(nil), 1)
-				require.NoError(t, err)
-				require.Equal(t, []int{1}, got)
-			})
+			}
 		})
-	})
+	}
 }
+
+type fakeSQLDriver struct{}
+
+func (f fakeSQLDriver) Open(string) (driver.Conn, error)             { return nil, nil }
+func (f fakeSQLDriver) Connect(context.Context) (driver.Conn, error) { return nil, nil }
+func (f fakeSQLDriver) Driver() driver.Driver                        { return f }

--- a/internal/rule/callback/javascript.go
+++ b/internal/rule/callback/javascript.go
@@ -39,7 +39,7 @@ func NewJSExecCallback(rule RuleFace, cfg ReflectedCallbackConfig) (sqhook.Refle
 			defer pool.put(vm)
 
 			// Make benefit from the fact this is a protection callback to also get the request reader
-			baCtx, err := NewCallbackBindingAccessorContext(strategy.BindingAccessor.Capabilities, params, nil, ctx.RequestReader)
+			baCtx, err := NewCallbackBindingAccessorContext(strategy.BindingAccessor.Capabilities, params, nil, ctx.RequestReader, cfg.Data())
 			if err != nil {
 				return err
 			}

--- a/sdk/sqreen-instrumentation-tool/tool_test.go
+++ b/sdk/sqreen-instrumentation-tool/tool_test.go
@@ -51,6 +51,9 @@ func buildInstrumentationTool(t *testing.T) (path string) {
 func testInstrumentation(t *testing.T, toolPath string, testApp string) {
 	// Run it with full instrumentation and verbose mode
 	cmd := exec.Command(godriver, "run", "-a", "-toolexec", fmt.Sprintf("%s -v -full", toolPath), testApp)
+	gocache, err := ioutil.TempDir("", "go-cache")
+	require.NoError(t, err, "could not create a go-cache directory")
+	cmd.Env = append(os.Environ(), "GOCACHE="+gocache)
 	cmd.Stderr = os.Stderr
 	outputBuf, err := cmd.Output()
 	require.NoError(t, err)


### PR DESCRIPTION
Remove the hard-coded map of SQL dialects per package paths and make it
rule-defined. To do so, the `SQL.Dialect()` function was modified so that the
map can be provided as a second argument. The map is now defined in the SQLi
rule and made accessible to binding accessors through the new `rule`
capability. This new capability adds a new `Rule` field to the binding accessor
context, giving access to the rule data, where the map is defined in the SQLi
rule. The new binding accessor is therefore:
`#.SQL.Dialect(#.Func.Args[1], #.Rule.Data.Values['dialects'])`.