### PR TITLE
Callback: binding accessor result caching

### DIFF
--- a/internal/rule/callback/bindingaccessor_test.go
+++ b/internal/rule/callback/bindingaccessor_test.go
@@ -8,10 +8,11 @@ import (
 	"context"
 	"database/sql"
 	"database/sql/driver"
+	"errors"
 	"reflect"
 	"testing"
 
-	bindingaccessor "github.com/sqreen/go-agent/internal/binding-accessor"
+	"github.com/sqreen/go-agent/internal/binding-accessor"
 	"github.com/sqreen/go-agent/internal/protection/http/types"
 	"github.com/sqreen/go-agent/internal/rule/callback"
 	"github.com/stretchr/testify/require"
@@ -175,10 +176,61 @@ func TestBindingAccessor(t *testing.T) {
 				},
 			},
 		},
+
+		{
+			Name:         "Result Caching",
+			Capabilities: []string{"cache", "rule"},
+			NewContextArgs: NewContextArgs{
+				Values: &MyCachedValueType{WithCaching: true},
+			},
+			TestCases: []TestCase{
+				// F's call side effect is not visible with caching and not be called
+				// more than once
+				{
+					Expr:          "#.Rule.Data.Values.F",
+					ExpectedValue: 1,
+				},
+
+				{
+					Expr:          "#.Rule.Data.Values.F",
+					ExpectedValue: 1,
+				},
+
+				{
+					Expr:          "#.Rule.Data.Values.F",
+					ExpectedValue: 1,
+				},
+			},
+		},
+
+		{
+			Name:         "No Result Caching",
+			Capabilities: []string{"rule"},
+			NewContextArgs: NewContextArgs{
+				Values: &MyCachedValueType{},
+			},
+			TestCases: []TestCase{
+				// F's call side effect is visible without caching
+				{
+					Expr:          "#.Rule.Data.Values.F",
+					ExpectedValue: 1,
+				},
+
+				{
+					Expr:          "#.Rule.Data.Values.F",
+					ExpectedValue: 2,
+				},
+
+				{
+					Expr:          "#.Rule.Data.Values.F",
+					ExpectedValue: 3,
+				},
+			},
+		},
 	} {
 		tc := tc
 		t.Run(tc.Name, func(t *testing.T) {
-			ctx, err := callback.NewCallbackBindingAccessorContext(tc.Capabilities, tc.NewContextArgs.Args, tc.NewContextArgs.Res, tc.NewContextArgs.Req, tc.NewContextArgs.Values)
+			ctx, err := callback.NewReflectedCallbackBindingAccessorContext(tc.Capabilities, tc.NewContextArgs.Args, tc.NewContextArgs.Res, tc.NewContextArgs.Req, tc.NewContextArgs.Values)
 			require.NoError(t, err)
 
 			for _, tc := range tc.TestCases {
@@ -198,6 +250,59 @@ func TestBindingAccessor(t *testing.T) {
 			}
 		})
 	}
+
+	t.Run("Caching", func(t *testing.T) {
+		type MyCachedContext struct {
+			F func() (int, error)
+			callback.BindingAccessorResultCache
+		}
+
+		t.Run("without execution error", func(t *testing.T) {
+			ctx := MyCachedContext{
+				F: func() (int, error) {
+					return 33, nil
+				},
+				BindingAccessorResultCache: callback.MakeBindingAccessorResultCache(),
+			}
+
+			p, err := bindingaccessor.Compile("#.F()")
+			require.NoError(t, err)
+
+			v, err := p(ctx)
+			require.NoError(t, err)
+			require.Equal(t, 33, v)
+
+			ctx.F = func() (int, error) {
+				panic("should not be called")
+			}
+			v, err = p(ctx)
+			require.NoError(t, err)
+			require.Equal(t, 33, v)
+		})
+
+		t.Run("with execution error", func(t *testing.T) {
+			ctx := MyCachedContext{
+				F: func() (int, error) {
+					return 0, errors.New("some execution error")
+				},
+				BindingAccessorResultCache: callback.MakeBindingAccessorResultCache(),
+			}
+
+			p, err := bindingaccessor.Compile("#.F()")
+			require.NoError(t, err)
+
+			v, err := p(ctx)
+			require.Error(t, err)
+			require.Equal(t, nil, v)
+
+			ctx.F = func() (int, error) {
+				panic("should not be called")
+			}
+			v, err = p(ctx)
+			require.Error(t, err)
+			require.Equal(t, nil, v)
+		})
+	})
 }
 
 type fakeSQLDriver struct{}
@@ -205,3 +310,19 @@ type fakeSQLDriver struct{}
 func (f fakeSQLDriver) Open(string) (driver.Conn, error)             { return nil, nil }
 func (f fakeSQLDriver) Connect(context.Context) (driver.Conn, error) { return nil, nil }
 func (f fakeSQLDriver) Driver() driver.Driver                        { return f }
+
+type MyCachedValueType struct {
+	i           int
+	WithCaching bool
+}
+
+// F increments the value of the field i so that we can observe the caching.
+// If the boolean field WithCaching is true, it panics at the second call which
+// should not happen.
+func (c *MyCachedValueType) F() (int, error) {
+	if c.WithCaching && c.i >= 1 {
+		panic("should not be called more than once when caching is enabled")
+	}
+	c.i += 1
+	return c.i, nil
+}

--- a/internal/rule/callback/javascript.go
+++ b/internal/rule/callback/javascript.go
@@ -39,7 +39,7 @@ func NewJSExecCallback(rule RuleFace, cfg ReflectedCallbackConfig) (sqhook.Refle
 			defer pool.put(vm)
 
 			// Make benefit from the fact this is a protection callback to also get the request reader
-			baCtx, err := NewCallbackBindingAccessorContext(strategy.BindingAccessor.Capabilities, params, nil, ctx.RequestReader, cfg.Data())
+			baCtx, err := NewReflectedCallbackBindingAccessorContext(strategy.BindingAccessor.Capabilities, params, nil, ctx.RequestReader, cfg.Data())
 			if err != nil {
 				return err
 			}

--- a/internal/rule/callback/waf.go
+++ b/internal/rule/callback/waf.go
@@ -73,7 +73,7 @@ func newWAFPrologCallback(rule RuleFace, blockingMode bool, wafRule waf_types.Ru
 		wafRule: wafRule,
 		prolog: func(p **httpprotection.RequestContext) (httpprotection.BlockingEpilogCallbackType, error) {
 			ctx := *p
-			baCtx := NewRequestCallbackBindingAccessorContext(ctx.RequestReader)
+			baCtx := MakeWAFCallbackBindingAccessorContext(ctx.RequestReader)
 			args := make(waf_types.DataSet, len(bindingAccessors))
 			for expr, ba := range bindingAccessors {
 				value, err := ba(baCtx)


### PR DESCRIPTION
Assuming the binding accessor context is created per call-site, request, and
security rule, we can add some simple caching of binding accessor results and
reuse them when the binding accessor expression is the same. This cache isn't
shared at all and doesn't need any invalidation nor thread-safety mechanism.

It is useful to use when a rule uses several times the same binding accessor
expressions, such as the In-App WAF.

Integrate it to:

- The JS callback through a new capability `cache` to make it optional, and
  disabled by default.

- The In-App WAF which likely uses lots of binding accessors.