### PR TITLE
Fix a possible empty batch being sent

### DIFF
--- a/internal/backend/api/signal/signal.go
+++ b/internal/backend/api/signal/signal.go
@@ -60,12 +60,12 @@ func NewAgentInfra(agentVersion, osType, hostname, runtimeVersion string) *Agent
 func fromLegacyRequestRecord(record *legacy_api.RequestRecord, infra *AgentInfra) (*http_trace.Trace, error) {
 	port, err := strconv.ParseUint(record.Request.Port, 10, 64)
 	if err != nil {
-		return nil, sqerrors.Wrap(err, "could not parse the request port number as an int64 value")
+		return nil, sqerrors.Wrap(err, "could not parse the request port number as an uint64 value")
 	}
 
 	remotePort, err := strconv.ParseUint(record.Request.RemotePort, 10, 64)
 	if err != nil {
-		return nil, sqerrors.Wrap(err, "could not parse the request remote port number as an int64 value")
+		return nil, sqerrors.Wrap(err, "could not parse the request remote port number as an uint64 value")
 	}
 
 	headers := make([][]string, len(record.Request.Headers))
@@ -182,7 +182,7 @@ func FromLegacyBatch(b []legacy_api.BatchRequest_Event, infra *AgentInfra, logge
 		case legacy_api.RequestRecordEvent:
 			trace, err := fromLegacyRequestRecord(evt.RequestRecord, infra)
 			if err != nil {
-				logger.Error(sqerrors.Wrap(err, "could not create the HTTP trace"))
+				logger.Error(sqerrors.WithInfo(sqerrors.Wrap(err, "could not create the HTTP trace"), evt))
 				continue
 			}
 			signal = trace

--- a/internal/backend/client.go
+++ b/internal/backend/client.go
@@ -199,10 +199,7 @@ func (c *Client) Batch(ctx context.Context, req *api.BatchRequest) error {
 			return err
 		}
 		httpReq.Header.Set(config.BackendHTTPAPIHeaderSession, c.session)
-		if err := c.Do(httpReq, req); err != nil {
-			return err
-		}
-		return nil
+		return c.Do(httpReq, req)
 	}
 
 	batch := signal.FromLegacyBatch(req.Batch, c.infra, c.logger)


### PR DESCRIPTION
I think the staleness timer could be triggered during the initialization and lead to the empty batch being sent.
This patch changes the initial duration to 24 hours to make sure it cannot trigger during the loop initialization.