### PR TITLE
scubbing: fix the waf metadata scrubbing

### DIFF
--- a/internal/backend/api/json_test.go
+++ b/internal/backend/api/json_test.go
@@ -220,7 +220,7 @@ func TestCustomScrubber(t *testing.T) {
 						OperatorValue:   "trigger",
 						BindingAccessor: "#.request_params",
 						ResolvedValue:   expectedMask,
-						MatchStatus:     expectedMask,
+						MatchStatus:     "forbidden",
 					},
 				},
 			},

--- a/internal/sqlib/sqsanitize/sanitize.go
+++ b/internal/sqlib/sqsanitize/sanitize.go
@@ -236,6 +236,9 @@ func (s *Scrubber) scrubMap(v reflect.Value, info Info) (scrubbed bool) {
 		// When the current value is an interface value, we scrub its underlying
 		// value.
 		if hasInterfaceValueType {
+			if val.IsNil() {
+				continue
+			}
 			val = val.Elem()
 			valT = val.Type()
 		}
@@ -335,14 +338,6 @@ func (i Info) Add(value string) {
 		return
 	}
 	i[value] = struct{}{}
-}
-
-func (i Info) Contains(value string) bool {
-	if len(i) == 0 {
-		return false
-	}
-	_, exists := i[value]
-	return exists
 }
 
 func (i Info) Append(info Info) {

--- a/internal/sqlib/sqsanitize/sanitize_test.go
+++ b/internal/sqlib/sqsanitize/sanitize_test.go
@@ -935,6 +935,14 @@ func TestScrubber(t *testing.T) {
 						},
 						"e":      33,
 						"passwd": []interface{}{"everything", randString},
+						"g":      nil,
+						"h":      (*string)(nil),
+						"i":      []interface{}{nil},
+						"j":      []interface{}{(*string)(nil)},
+						"password": map[string]interface{}{
+							"a": nil,
+							"b": []interface{}{nil},
+						},
 					}
 				},
 				expected: expectedValues{
@@ -948,6 +956,14 @@ func TestScrubber(t *testing.T) {
 						},
 						"e":      33,
 						"passwd": []interface{}{expectedMask, randString},
+						"g":      nil,
+						"h":      (*string)(nil),
+						"i":      []interface{}{nil},
+						"j":      []interface{}{(*string)(nil)},
+						"password": map[string]interface{}{
+							"a": nil,
+							"b": []interface{}{nil},
+						},
 					},
 					withKeyRE: map[string]interface{}{
 						"apikey": expectedMask,
@@ -959,6 +975,14 @@ func TestScrubber(t *testing.T) {
 						},
 						"e":      33,
 						"passwd": []interface{}{expectedMask, expectedMask},
+						"g":      nil,
+						"h":      (*string)(nil),
+						"i":      []interface{}{nil},
+						"j":      []interface{}{(*string)(nil)},
+						"password": map[string]interface{}{
+							"a": nil,
+							"b": []interface{}{nil},
+						},
 					},
 					withBothRE: map[string]interface{}{
 						"apikey": expectedMask,
@@ -970,6 +994,14 @@ func TestScrubber(t *testing.T) {
 						},
 						"e":      33,
 						"passwd": []interface{}{expectedMask, expectedMask},
+						"g":      nil,
+						"h":      (*string)(nil),
+						"i":      []interface{}{nil},
+						"j":      []interface{}{(*string)(nil)},
+						"password": map[string]interface{}{
+							"a": nil,
+							"b": []interface{}{nil},
+						},
 					},
 					withBothDisabled: map[string]interface{}{
 						"apikey": randString,
@@ -981,6 +1013,14 @@ func TestScrubber(t *testing.T) {
 						},
 						"e":      33,
 						"passwd": []interface{}{"everything", randString},
+						"g":      nil,
+						"h":      (*string)(nil),
+						"i":      []interface{}{nil},
+						"j":      []interface{}{(*string)(nil)},
+						"password": map[string]interface{}{
+							"a": nil,
+							"b": []interface{}{nil},
+						},
 					},
 				},
 			},


### PR DESCRIPTION
Change the scrubbing function of the WAF metadata to sanitize substrings and not
only the full string value.