### PR TITLE
RASP: add shellshock protection

### DIFF
--- a/internal/backend/api/signal/signal.go
+++ b/internal/backend/api/signal/signal.go
@@ -276,7 +276,7 @@ func convertLegacyMetrics(metric *legacy_api.MetricResponse, agentVersion string
 
 	values, ok := metric.Observation.Value.(map[string]int64)
 	if !ok {
-		return nil, sqerrors.Errorf("unexpected type of metric values `%T` instead of `map[string]intr64`", metric.Observation.Value)
+		return nil, sqerrors.Errorf("unexpected type of metric values `%T` instead of `%T`", metric.Observation.Value, values)
 	}
 
 	return api.NewSumMetric(name.String(), source, metric.Start, metric.Finish, metric.Finish.Sub(metric.Start), values), nil

--- a/internal/rule/callback/shellshock.go
+++ b/internal/rule/callback/shellshock.go
@@ -1,0 +1,111 @@
+// Copyright (c) 2016 - 2019 Sqreen. All Rights Reserved.
+// Please refer to our terms for more information:
+// https://www.sqreen.io/terms.html
+
+//sqreen:ignore
+
+package callback
+
+import (
+	"os"
+	"regexp"
+	"strings"
+
+	"github.com/pkg/errors"
+	httpprotection "github.com/sqreen/go-agent/internal/protection/http"
+	"github.com/sqreen/go-agent/internal/sqlib/sqassert"
+	"github.com/sqreen/go-agent/internal/sqlib/sqerrors"
+	"github.com/sqreen/go-agent/internal/sqlib/sqhook"
+	"github.com/sqreen/go-agent/sdk/types"
+)
+
+func NewShellshockCallback(rule RuleFace, cfg NativeCallbackConfig) (sqhook.PrologCallback, error) {
+	sqassert.NotNil(rule)
+	sqassert.NotNil(cfg)
+
+	data, ok := cfg.Data().([]interface{})
+	if !ok {
+		return nil, sqerrors.Errorf("unexpected callback data type: got `%T` instead of `%T`", cfg.Data(), data)
+	}
+
+	if l := len(data); l == 0 {
+		return nil, sqerrors.New("empty list of regular expressions`")
+	} else if l > 1 {
+		return nil, sqerrors.Errorf("unexpected number of data entries`")
+	}
+
+	values, ok := data[0].([]string)
+	if !ok {
+		return nil, sqerrors.Errorf("unexpected callback data values type: got `%T` instead of `%T`", data[0], values)
+	}
+	regexps := make([]*regexp.Regexp, len(values))
+	for i := range values {
+		expr := values[i]
+		re, err := regexp.Compile(expr)
+		if err != nil {
+			return nil, sqerrors.Wrapf(err, "could not compile the regular expression `%s`", expr)
+		}
+
+		regexps[i] = re
+	}
+
+	return newShellshockPrologCallback(rule, cfg.BlockingMode(), regexps), nil
+}
+
+type ShellshockPrologCallbackType = func(name *string, argv *[]string, attr **os.ProcAttr) (ShellshockEpilogCallbackType, error)
+type ShellshockEpilogCallbackType = func(**os.Process, *error)
+
+type ShellshockAttackInfo struct {
+	Found         string `json:"found"`
+	VariableName  string `json:"variable_name"`
+	VariableValue string `json:"variable_value"`
+}
+
+func newShellshockPrologCallback(rule RuleFace, blockingMode bool, regexps []*regexp.Regexp) ShellshockPrologCallbackType {
+	return func(_ *string, _ *[]string, attr **os.ProcAttr) (ShellshockEpilogCallbackType, error) {
+		ctx := httpprotection.FromGLS()
+		if ctx == nil {
+			return nil, nil
+		}
+
+		env := (*attr).Env
+		if env == nil {
+			env = os.Environ()
+		}
+		if len(env) == 0 {
+			return nil, nil
+		}
+
+		for _, env := range env {
+			v := strings.Split(env, `=`)
+			if len(v) != 2 {
+				ctx.Logger().Error(sqerrors.Errorf("unexpected number of elements split by `=` in `%s`", env))
+				return nil, nil
+			}
+			name, value := v[0], v[1]
+			for _, re := range regexps {
+				if re.MatchString(value) {
+					info := ShellshockAttackInfo{
+						Found:         re.String(),
+						VariableName:  name,
+						VariableValue: value,
+					}
+					err := errors.WithStack(types.SqreenError{})
+					ctx.AddAttackEvent(rule.NewAttackEvent(blockingMode, info, sqerrors.StackTrace(err)))
+
+					if !blockingMode {
+						return nil, nil
+					}
+
+					defer ctx.CancelHandlerContext()
+					ctx.WriteDefaultBlockingResponse()
+					return func(_ **os.Process, callErr *error) {
+						*callErr = err
+					}, sqhook.AbortError
+				}
+			}
+		}
+
+		return nil, nil
+	}
+}

--- a/internal/rule/callback/shellshock_unit_test.go
+++ b/internal/rule/callback/shellshock_unit_test.go
@@ -1,0 +1,54 @@
+// Copyright (c) 2016 - 2020 Sqreen. All Rights Reserved.
+// Please refer to our terms for more information:
+// https://www.sqreen.io/terms.html
+
+package callback
+
+// TODO: higher-level callback API that will allow to avoid the missing GLS
+//  during testing, while a callback framework should be completely mockable.
+
+//func TestShellshockCallbacks(t *testing.T) {
+//	regexps := []*regexp.Regexp{
+//		regexp.MustCompile(`oh my regexp`),
+//	}
+//	ctx := &RuleMockup{}
+//
+//	prolog := newShellshockPrologCallback(ctx, true, regexps)
+//
+//	ctx.ExpectNewAttackEvent(true, ShellshockAttackInfo{
+//		Found:         `oh my regexp`,
+//		VariableName:  "name",
+//		VariableValue: "does it match oh my regexp?",
+//	})
+//	attr := &os.ProcAttr{
+//		Env: []string{"name=does it match oh my regexp?"},
+//	}
+//	epilog, err := prolog(nil, nil, &attr)
+//	require.Error(t, err)
+//	require.Equal(t, sqhook.AbortError, err)
+//	require.NotNil(t, epilog)
+//
+//	epilog(nil, &err)
+//	require.Error(t, err)
+//	require.True(t, xerrors.As(err, &types.SqreenError{}))
+//}
+//
+//type RuleMockup struct {
+//	mock.Mock
+//}
+//
+//func (r *RuleMockup) PushMetricsValue(key interface{}, value int64) error {
+//	return r.Called(key, value).Error(0)
+//}
+//
+//func (r *RuleMockup) ExpectPushMetricsValue(key interface{}, value int64) *mock.Call {
+//	return r.On("PushMetricsValue", key, value)
+//}
+//
+//func (r *RuleMockup) NewAttackEvent(blocked bool, info interface{}, st errors.StackTrace) *event.AttackEvent {
+//	return r.Called(blocked, info, st).Get(0).(*event.AttackEvent)
+//}
+//
+//func (r *RuleMockup) ExpectNewAttackEvent(blocked bool, info interface{}) *mock.Call {
+//	return r.On("NewAttackEvent", blocked, info)
+//}

--- a/internal/rule/factory.go
+++ b/internal/rule/factory.go
@@ -35,6 +35,8 @@ func NewNativeCallback(name string, ctx callback.RuleFace, cfg callback.NativeCa
 		callbackCtor = callback.NewUserSecurityResponseCallback
 	case "IPBlockList", "IPDenyList":
 		callbackCtor = callback.NewIPDenyListCallback
+	case "Shellshock":
+		callbackCtor = callback.NewShellshockCallback
 	}
 	return callbackCtor(ctx, cfg)
 }


### PR DESCRIPTION
The shellshock protection is attached to `os.StartProcess()` and checks the environment variables against a list of regular expressions. When matching, the call is aborted and the request blocked.