### PR TITLE
agent/protection/http: lazy access to post form values

### DIFF
--- a/internal/adapter.go
+++ b/internal/adapter.go
@@ -136,7 +136,7 @@ func (a *httpRequestAPIAdapter) GetParameters() api.RequestRecord_Request_Parame
 		rawBody = "<Redacted By Sqreen>"
 	}
 	return api.RequestRecord_Request_Parameters{
-		Query:   req.Form(),
+		Query:   req.QueryForm(),
 		Form:    req.PostForm(),
 		Params:  req.Params(),
 		RawBody: rawBody,

--- a/internal/protection/http/bindingaccessor.go
+++ b/internal/protection/http/bindingaccessor.go
@@ -59,14 +59,13 @@ func (r *RequestBindingAccessorContext) FromContext(v interface{}) (*RequestBind
 }
 
 func (r *RequestBindingAccessorContext) FilteredParams() RequestParamMap {
-	form := r.Form()
+	queryForm := r.QueryForm()
+	postForm := r.PostForm()
 	params := r.RequestReader.Params()
-	if len(form) == 0 {
-		return params
-	}
 
-	res := make(types.RequestParamMap, 1+len(params))
-	res.Add("Form", form)
+	res := make(types.RequestParamMap, 2+len(params))
+	res.Add("PostForm", postForm)
+	res.Add("QueryForm", queryForm)
 	for k, v := range params {
 		res.Add(k, v)
 	}

--- a/internal/protection/http/bindingaccessor.go
+++ b/internal/protection/http/bindingaccessor.go
@@ -64,8 +64,12 @@ func (r *RequestBindingAccessorContext) FilteredParams() RequestParamMap {
 	params := r.RequestReader.Params()
 
 	res := make(types.RequestParamMap, 2+len(params))
-	res.Add("PostForm", postForm)
-	res.Add("QueryForm", queryForm)
+	if len(postForm) > 0 {
+		res.Add("PostForm", postForm)
+	}
+	if len(queryForm) > 0 {
+		res.Add("QueryForm", queryForm)
+	}
 	for k, v := range params {
 		res.Add(k, v)
 	}

--- a/internal/protection/http/http_test.go
+++ b/internal/protection/http/http_test.go
@@ -99,7 +99,7 @@ func (r *RequestReaderMockup) Referer() string {
 	return r.Called().String(0)
 }
 
-func (r *RequestReaderMockup) Form() url.Values {
+func (r *RequestReaderMockup) QueryForm() url.Values {
 	v, _ := r.Called().Get(0).(url.Values)
 	return v
 }

--- a/internal/protection/http/request.go
+++ b/internal/protection/http/request.go
@@ -226,7 +226,7 @@ type handledRequest struct {
 	isTLS      bool
 	userAgent  string
 	referer    string
-	form       url.Values
+	queryForm  url.Values
 	postForm   url.Values
 	clientIP   net.IP
 	params     types.RequestParamMap
@@ -242,7 +242,7 @@ func (h *handledRequest) RemoteAddr() string            { return h.remoteAddr }
 func (h *handledRequest) IsTLS() bool                   { return h.isTLS }
 func (h *handledRequest) UserAgent() string             { return h.userAgent }
 func (h *handledRequest) Referer() string               { return h.referer }
-func (h *handledRequest) Form() url.Values              { return h.form }
+func (h *handledRequest) QueryForm() url.Values         { return h.queryForm }
 func (h *handledRequest) PostForm() url.Values          { return h.postForm }
 func (h *handledRequest) ClientIP() net.IP              { return h.clientIP }
 func (h *handledRequest) Params() types.RequestParamMap { return h.params }
@@ -270,7 +270,7 @@ func copyRequest(reader types.RequestReader) types.RequestReader {
 		isTLS:      reader.IsTLS(),
 		userAgent:  reader.UserAgent(),
 		referer:    reader.Referer(),
-		form:       reader.Form(),
+		queryForm:  reader.QueryForm(),
 		postForm:   reader.PostForm(),
 		clientIP:   reader.ClientIP(),
 		params:     reader.Params(),

--- a/internal/protection/http/types/types.go
+++ b/internal/protection/http/types/types.go
@@ -25,7 +25,7 @@ type RequestReader interface {
 	IsTLS() bool
 	UserAgent() string
 	Referer() string
-	Form() url.Values
+	QueryForm() url.Values
 	PostForm() url.Values
 	ClientIP() net.IP
 	// Params returns the request parameters parsed by the handler so far at the

--- a/internal/rule/callback/ip-denylist_test.go
+++ b/internal/rule/callback/ip-denylist_test.go
@@ -115,7 +115,7 @@ func (r *RequestReaderMock) Referer() string {
 	return r.Called().String(0)
 }
 
-func (r *RequestReaderMock) Form() (v url.Values) {
+func (r *RequestReaderMock) QueryForm() (v url.Values) {
 	v, _ = r.Called().Get(0).(url.Values)
 	return
 }

--- a/sdk/middleware/sqecho/echo.go
+++ b/sdk/middleware/sqecho/echo.go
@@ -123,6 +123,7 @@ func middlewareHandler(agent protectioncontext.AgentFace, next echo.HandlerFunc,
 type requestReaderImpl struct {
 	c              echo.Context
 	bodyReadBuffer bytes.Buffer
+	queryForm      url.Values
 }
 
 func (r *requestReaderImpl) Body() []byte {
@@ -175,8 +176,11 @@ func (r *requestReaderImpl) Params() types.RequestParamMap {
 	return m
 }
 
-func (r *requestReaderImpl) Form() url.Values {
-	return r.c.Request().Form
+func (r *requestReaderImpl) QueryForm() url.Values {
+	if r.queryForm == nil {
+		r.queryForm = r.c.Request().URL.Query()
+	}
+	return r.queryForm
 }
 
 func (r *requestReaderImpl) PostForm() url.Values {

--- a/sdk/middleware/sqecho/echo.go
+++ b/sdk/middleware/sqecho/echo.go
@@ -176,12 +176,10 @@ func (r *requestReaderImpl) Params() types.RequestParamMap {
 }
 
 func (r *requestReaderImpl) Form() url.Values {
-	_ = r.c.Request().ParseForm()
 	return r.c.Request().Form
 }
 
 func (r *requestReaderImpl) PostForm() url.Values {
-	_ = r.c.Request().ParseForm()
 	return r.c.Request().PostForm
 }
 

--- a/sdk/middleware/sqgin/gin.go
+++ b/sdk/middleware/sqgin/gin.go
@@ -106,7 +106,8 @@ func middlewareHandler(agent protection_context.AgentFace, c *gingonic.Context) 
 }
 
 type requestReaderImpl struct {
-	c *gingonic.Context
+	c         *gingonic.Context
+	queryForm url.Values
 }
 
 func (r *requestReaderImpl) Body() []byte {
@@ -161,13 +162,14 @@ func (r *requestReaderImpl) Params() types.RequestParamMap {
 	return m
 }
 
-func (r *requestReaderImpl) Form() url.Values {
-	_ = r.c.Request.ParseForm()
-	return r.c.Request.Form
+func (r *requestReaderImpl) QueryForm() url.Values {
+	if r.queryForm == nil {
+		r.queryForm = r.c.Request.URL.Query()
+	}
+	return r.queryForm
 }
 
 func (r *requestReaderImpl) PostForm() url.Values {
-	_ = r.c.Request.ParseForm()
 	return r.c.Request.PostForm
 }
 

--- a/sdk/middleware/sqhttp/http.go
+++ b/sdk/middleware/sqhttp/http.go
@@ -89,6 +89,7 @@ func middlewareHandler(agent protection_context.AgentFace, next http.Handler, w 
 
 type requestReaderImpl struct {
 	*http.Request
+	queryForm url.Values
 }
 
 func (r *requestReaderImpl) Body() []byte {
@@ -152,8 +153,11 @@ func (r *requestReaderImpl) IsTLS() bool {
 	return r.Request.TLS != nil
 }
 
-func (r *requestReaderImpl) Form() url.Values {
-	return r.Request.Form
+func (r *requestReaderImpl) QueryForm() url.Values {
+	if r.queryForm == nil {
+		r.queryForm = r.Request.URL.Query()
+	}
+	return r.queryForm
 }
 
 func (r *requestReaderImpl) PostForm() url.Values {

--- a/sdk/middleware/sqhttp/http.go
+++ b/sdk/middleware/sqhttp/http.go
@@ -153,12 +153,10 @@ func (r *requestReaderImpl) IsTLS() bool {
 }
 
 func (r *requestReaderImpl) Form() url.Values {
-	_ = r.Request.ParseForm()
 	return r.Request.Form
 }
 
 func (r *requestReaderImpl) PostForm() url.Values {
-	_ = r.Request.ParseForm()
 	return r.Request.PostForm
 }
 

--- a/sdk/middleware/sqhttp/http_test.go
+++ b/sdk/middleware/sqhttp/http_test.go
@@ -221,7 +221,7 @@ func TestRequestReaderImpl(t *testing.T) {
 		t.Run("empty", func(t *testing.T) {
 			req, err := http.NewRequest("GET", "/", nil)
 			require.NoError(t, err)
-			reqReader := requestReaderImpl{req}
+			reqReader := requestReaderImpl{Request: req}
 
 			frameworkParams := reqReader.Params()
 			require.Empty(t, frameworkParams)
@@ -230,7 +230,7 @@ func TestRequestReaderImpl(t *testing.T) {
 		t.Run("url segments", func(t *testing.T) {
 			req, err := http.NewRequest("GET", `/a/bb/cc/%2Ffoo//bar///zyz/"\"\\"\\\"/`, nil)
 			require.NoError(t, err)
-			reqReader := requestReaderImpl{req}
+			reqReader := requestReaderImpl{Request: req}
 
 			frameworkParams := reqReader.Params()
 			require.NotEmpty(t, frameworkParams)

--- a/sdk/sqreen-instrumentation-tool/instrumentation.go
+++ b/sdk/sqreen-instrumentation-tool/instrumentation.go
@@ -217,6 +217,7 @@ var (
 			//   can parse this string and compare the signature ASTs) - and log when
 			//   not found
 			"client.go",
+			"request.go",
 		},
 		"github.com/gin-gonic/gin": {
 			// Same comment as net/http


### PR DESCRIPTION
Remove the current call to `ParseForm()` in the middlewares in favor of a direct
access to the cached value in the `Request` structure. This value is not nil
when the request handler has called `ParseForm()` itself. Meaning that the
In-WAF and RASP protections will now only consider the POST form values of the
request when actually parsed by the request handler.

Note that the In-App WAF is now dynamically attached to `ParseForm()` which
returns a non-nil error of type `*SqreenError` when blocked by the In-App WAF
(cf. https://docs.sqreen.com/go/integration for more details).

This fixes the usage of the Go agent in a reverse proxy server where the agent
was consuming the body because of the call to `ParseForm()`, making later reads
to `Request.Body` return EOF. A server can now correctly copy the request body.
