### PR TITLE
Call Count Monitoring of RASP and In-App WAF callbacks

### DIFF
--- a/internal/agent.go
+++ b/internal/agent.go
@@ -193,7 +193,13 @@ type AgentType struct {
 }
 
 type staticMetrics struct {
-	sdkUserLoginSuccess, sdkUserLoginFailure, sdkUserSignup, allowedIP, allowedPath, errors *metrics.Store
+	sdkUserLoginSuccess,
+	sdkUserLoginFailure,
+	sdkUserSignup,
+	allowedIP,
+	allowedPath,
+	errors,
+	callCounts *metrics.Store
 }
 
 // Error channel buffer length.

--- a/internal/backend/api/api.go
+++ b/internal/backend/api/api.go
@@ -186,17 +186,18 @@ type BatchRequest_Event struct {
 }
 
 type Rule struct {
-	Name       string             `json:"name"`
-	Hookpoint  Hookpoint          `json:"hookpoint"`
-	Data       RuleData           `json:"data"`
-	Metrics    []MetricDefinition `json:"metrics"`
-	Signature  RuleSignature      `json:"signature"`
-	Conditions RuleConditions     `json:"conditions"`
-	Callbacks  RuleCallbacks      `json:"callbacks"`
-	Test       bool               `json:"test"`
-	Block      bool               `json:"block"`
-	AttackType string             `json:"attack_type"`
-	Priority   int                `json:"priority"`
+	Name              string             `json:"name"`
+	Hookpoint         Hookpoint          `json:"hookpoint"`
+	Data              RuleData           `json:"data"`
+	Metrics           []MetricDefinition `json:"metrics"`
+	Signature         RuleSignature      `json:"signature"`
+	Conditions        RuleConditions     `json:"conditions"`
+	Callbacks         RuleCallbacks      `json:"callbacks"`
+	Test              bool               `json:"test"`
+	Block             bool               `json:"block"`
+	AttackType        string             `json:"attack_type"`
+	Priority          int                `json:"priority"`
+	CallCountInterval int                `json:"call_count_interval"`
 }
 
 type RuleConditions struct{}

--- a/internal/rule/callback/callback_test.go
+++ b/internal/rule/callback/callback_test.go
@@ -34,6 +34,10 @@ type RuleContextMockup struct {
 	mock.Mock
 }
 
+func (r *RuleContextMockup) MonitorPre() {
+	r.Called()
+}
+
 func (r *RuleContextMockup) PushMetricsValue(key interface{}, value int64) error {
 	return r.Called(key, value).Error(0)
 }

--- a/internal/rule/callback/javascript.go
+++ b/internal/rule/callback/javascript.go
@@ -48,6 +48,7 @@ func NewJSExecCallback(rule RuleFace, cfg JSReflectedCallbackConfig) (sqhook.Ref
 			//}
 
 			if vm.hasPre() {
+				rule.MonitorPre()
 				result, err := vm.callPre(baCtx)
 				if err != nil {
 					// TODO: api adding more information to the error such as the

--- a/internal/rule/callback/shellshock.go
+++ b/internal/rule/callback/shellshock.go
@@ -68,6 +68,8 @@ func newShellshockPrologCallback(rule RuleFace, blockingMode bool, regexps []*re
 			return nil, nil
 		}
 
+		rule.MonitorPre()
+
 		env := (*attr).Env
 		if env == nil {
 			env = os.Environ()

--- a/internal/rule/callback/types.go
+++ b/internal/rule/callback/types.go
@@ -24,6 +24,7 @@ type RuleFace interface {
 	PushMetricsValue(key interface{}, value int64) error
 	// TODO: variadic options api
 	NewAttackEvent(blocked bool, info interface{}, st errors.StackTrace) *event.AttackEvent
+	MonitorPre()
 }
 
 // Config is the interface of the rule configuration.

--- a/internal/rule/callback/waf.go
+++ b/internal/rule/callback/waf.go
@@ -161,6 +161,7 @@ func makeWAFPrologCallback(rule RuleFace, blockingMode bool, wafRule waftypes.Ru
 	return func(p **httpprotection.RequestContext) (httpprotection.BlockingEpilogCallbackType, error) {
 		ctx := *p
 
+		rule.MonitorPre()
 		blocked, err := runWAF(ctx, bindingAccessors, wafRule, blockingMode, timeout, rule)
 		if err != nil {
 			WAFErrorLogOnce.Do(func() {
@@ -261,6 +262,7 @@ func makeFunctionWAFPrologCallback(rule RuleFace, blockingMode bool, wafRule waf
 			}
 
 			if l := len(pre); l > 0 {
+				rule.MonitorPre()
 				blocked, err := runFunctionWAF(ctx, bindingAccessors, wafRule, blockingMode, timeout, rule, pre, strategy, params, nil)
 				if err != nil {
 					return sqerrors.Wrap(err, "function waf error: pre")

--- a/internal/rule/rule.go
+++ b/internal/rule/rule.go
@@ -83,7 +83,7 @@ func (e *Engine) SetRules(packID string, rules []api.Rule) {
 	var ruleDescriptors hookDescriptorMap
 	if len(rules) > 0 {
 		e.logger.Debugf("security rules: loading rules from pack `%s`", packID)
-		ruleDescriptors = newHookDescriptors(e, rules)
+		ruleDescriptors = newHookDescriptors(e, packID, rules)
 	}
 	e.setRules(packID, ruleDescriptors)
 }
@@ -136,7 +136,7 @@ func (e *Engine) setRules(packID string, descriptors hookDescriptorMap) {
 // newHookDescriptors walks the list of received rules and creates the map of
 // hook descriptors indexed by their hook pointer. A hook descriptor contains
 // all it takes to enable and disable rules at run time.
-func newHookDescriptors(e *Engine, rules []api.Rule) hookDescriptorMap {
+func newHookDescriptors(e *Engine, rulepackID string, rules []api.Rule) hookDescriptorMap {
 	logger := e.logger
 
 	// Create and configure the list of callbacks according to the given rules
@@ -163,7 +163,7 @@ func newHookDescriptors(e *Engine, rules []api.Rule) hookDescriptorMap {
 			logger.Debugf("security rules: rule `%s`: successfully found hook `%v`", r.Name, hook)
 		}
 
-		callbackContext, err := NewCallbackContext(&r, e.metricsEngine, e.errorMetricsStore)
+		callbackContext, err := NewCallbackContext(&r, rulepackID, e.metricsEngine, e.errorMetricsStore)
 		if err != nil {
 			logger.Error(sqerrors.Wrapf(err, "security rules: rule `%s`: callback configuration", r.Name))
 			continue


### PR DESCRIPTION
Implement the activity monitoring displayed on the dashboard, showing the number
of times a security rule has been called. This feature is enabled when the rule's
`call_count_interval` is not 0.

For now only deployed only on the In-App WAF and RASP callbacks.