### PR TITLE
Enable partial instrumentation of Echo

### DIFF
--- a/sdk/sqreen-instrumentation-tool/instrumentation.go
+++ b/sdk/sqreen-instrumentation-tool/instrumentation.go
@@ -202,6 +202,7 @@ var (
 		"os",
 		"net/http",
 		"github.com/gin-gonic/gin",
+		"github.com/labstack/echo",
 		"go.mongodb.org/mongo-driver/mongo",
 	}
 
@@ -226,6 +227,10 @@ var (
 		"go.mongodb.org/mongo-driver/mongo": {
 			// Limited for performance reasons to:
 			"mongo.go", // mongo.go contains the bson transformation function
+		},
+		"github.com/labstack/echo": {
+			// Same comment as net/http
+			"context.go", // context.go contains the body parsers
 		},
 	}
 )


### PR DESCRIPTION
Enable partial instrumentation of Echo in order to run the In-App WAF when the body is parsed into a Go object. This is achieved thanks to a security rule dynamically attaching the In-App WAF to Echo's `Bind()` method.