### PR TITLE
agent/rule/shellshock: fix splitting environment variables

### DIFF
--- a/internal/rule/callback/shellshock.go
+++ b/internal/rule/callback/shellshock.go
@@ -79,11 +79,15 @@ func newShellshockPrologCallback(rule RuleFace, blockingMode bool, regexps []*re
 		}
 
 		for _, env := range env {
-			v := strings.Split(env, `=`)
-			if len(v) != 2 {
+			v := strings.SplitN(env, `=`, 2)
+			if l := len(v); l <= 0 || l > 2 {
 				ctx.Logger().Error(sqerrors.Errorf("unexpected number of elements split by `=` in `%s`", env))
 				return nil, nil
+			} else if l == 1 {
+				// Skip empty values
+				continue
 			}
+
 			name, value := v[0], v[1]
 			for _, re := range regexps {
 				if re.MatchString(value) {


### PR DESCRIPTION
Fix the environment variable lookup when other variable assignments are in the value. 