### PR TITLE
Hot-path error management

### DIFF
--- a/internal/actor/actor_test.go
+++ b/internal/actor/actor_test.go
@@ -22,7 +22,7 @@ import (
 )
 
 var (
-	logger = plog.NewLogger(plog.Debug, os.Stderr, 0)
+	logger = plog.NewLogger(plog.Debug, os.Stderr, nil)
 	fuzzer = fuzz.New().NilChance(0)
 )
 

--- a/internal/backend/client_test.go
+++ b/internal/backend/client_test.go
@@ -18,7 +18,7 @@ import (
 )
 
 var (
-	logger = plog.NewLogger(plog.Debug, os.Stderr, 0)
+	logger = plog.NewLogger(plog.Debug, os.Stderr, nil)
 	fuzzer = fuzz.New().Funcs(FuzzStruct, FuzzCommandRequest, FuzzRuleDataValue, FuzzRuleSignature)
 )
 

--- a/internal/command_test.go
+++ b/internal/command_test.go
@@ -21,7 +21,7 @@ import (
 
 func TestCommandManager(t *testing.T) {
 	var agent agentMockup
-	logger := plog.NewLogger(plog.Debug, os.Stderr, 0)
+	logger := plog.NewLogger(plog.Debug, os.Stderr, nil)
 	mng := internal.NewCommandManager(&agent, logger)
 	require.NotNil(t, mng)
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -18,7 +18,7 @@ import (
 )
 
 func TestUserConfig(t *testing.T) {
-	logger := plog.NewLogger(plog.Debug, os.Stderr, 0)
+	logger := plog.NewLogger(plog.Debug, os.Stderr, nil)
 	cfg, unset := newTestConfig(t, logger)
 	defer unset()
 
@@ -91,7 +91,7 @@ func TestUserConfig(t *testing.T) {
 }
 
 func TestConfigValidation(t *testing.T) {
-	logger := plog.NewLogger(plog.Debug, os.Stderr, 0)
+	logger := plog.NewLogger(plog.Debug, os.Stderr, nil)
 
 	t.Run("no token", func(t *testing.T) {
 		cfg, err := New(logger)
@@ -142,7 +142,7 @@ func TestFileLocation(t *testing.T) {
 	binDirFile := newCfgFile(t, binDir, `token: `+binDirToken)
 	defer os.Remove(binDirFile)
 
-	logger := plog.NewLogger(plog.Debug, os.Stderr, 0)
+	logger := plog.NewLogger(plog.Debug, os.Stderr, nil)
 	cfg, err := New(logger)
 	require.NoError(t, err)
 
@@ -250,7 +250,7 @@ func TestStripRegexp(t *testing.T) {
 		cwdFile := newCfgFile(t, ".", `token: mytoken`)
 		defer os.Remove(cwdFile)
 
-		logger := plog.NewLogger(plog.Debug, os.Stderr, 0)
+		logger := plog.NewLogger(plog.Debug, os.Stderr, nil)
 		cfg, err := New(logger)
 
 		require.NoError(t, err)
@@ -300,7 +300,7 @@ func TestStripRegexp(t *testing.T) {
 `+configKeyStripSensitiveValueRegexp+`: ""`)
 		defer os.Remove(cwdFile)
 
-		logger := plog.NewLogger(plog.Debug, os.Stderr, 0)
+		logger := plog.NewLogger(plog.Debug, os.Stderr, nil)
 		cfg, err := New(logger)
 
 		require.NoError(t, err)
@@ -314,7 +314,7 @@ func TestDefaultConfiguration(t *testing.T) {
 	cwdFile := newCfgFile(t, ".", `token: mytoken`)
 	defer os.Remove(cwdFile)
 
-	logger := plog.NewLogger(plog.Debug, os.Stderr, 0)
+	logger := plog.NewLogger(plog.Debug, os.Stderr, nil)
 	cfg, err := New(logger)
 
 	require.NoError(t, err)

--- a/internal/plog/plog.go
+++ b/internal/plog/plog.go
@@ -244,6 +244,11 @@ func WithBackoff(logger DebugLevelLogger) DebugLevelLogger {
 		return actual
 	}
 
+	// Don't backoff when in debug level mode
+	if _, isDebugLevel := logger.(*debugLevelLogger); isDebugLevel {
+		return logger
+	}
+
 	return &backoffLogger{
 		DebugLevelLogger: logger,
 	}

--- a/internal/plog/plog.go
+++ b/internal/plog/plog.go
@@ -106,7 +106,7 @@ type (
 
 // NewLogger returns a Logger instance wrapping one logger instance per level.
 // They can thus be individually enabled or disabled.
-func NewLogger(level LogLevel, out io.Writer, errChan chan error) Logger {
+func NewLogger(level LogLevel, out io.Writer, errChan chan error) *Logger {
 	var levelLogger DebugLevelLogger
 	switch level {
 	case Debug:
@@ -125,7 +125,7 @@ func NewLogger(level LogLevel, out io.Writer, errChan chan error) Logger {
 		levelLogger = makeDisabledLogger(errChan)
 	}
 
-	return Logger{
+	return &Logger{
 		DebugLevelLogger: levelLogger,
 	}
 }

--- a/internal/plog/plog_test.go
+++ b/internal/plog/plog_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/onsi/gomega/gbytes"
 	"github.com/pkg/errors"
 	"github.com/sqreen/go-agent/internal/plog"
+	"github.com/sqreen/go-agent/internal/sqlib/sqerrors"
 	"github.com/stretchr/testify/require"
 )
 
@@ -21,12 +22,13 @@ func TestLogger(t *testing.T) {
 	} {
 		level := level // new scope
 		t.Run(level.String(), func(t *testing.T) {
-			for _, errChanLen := range []int{-1, 0, 1, 1024} {
+			for _, errChanLen := range []int{1, 1024} {
 				errChanLen := errChanLen // new scope
 				t.Run(fmt.Sprintf("with chan buffer length %d", errChanLen), func(t *testing.T) {
 					g := gomega.NewGomegaWithT(t)
 					output := gbytes.NewBuffer()
-					logger := plog.NewLogger(level, output, errChanLen)
+					errChan := make(chan error, errChanLen)
+					logger := plog.NewLogger(level, output, errChan)
 
 					// Perform log calls
 					logger.Debug("debug 1", " debug 2", " debug 3")
@@ -55,9 +57,90 @@ func TestLogger(t *testing.T) {
 						g.Expect(output).Should(gbytes.Say(errorRe))
 					}
 
-					if errChanLen > 0 {
-						// The error should have been sent into the channel
-						g.Eventually(logger.ErrChan()).Should(gomega.Receive(gomega.Equal(err)))
+					// The error should have been sent into the channel
+					g.Eventually(errChan).Should(gomega.Receive(gomega.Equal(err)))
+				})
+			}
+		})
+	}
+}
+
+func TestWithBackoff(t *testing.T) {
+	for _, level := range []plog.LogLevel{
+		plog.Disabled,
+		plog.Debug,
+		plog.Info,
+		plog.Error,
+	} {
+		level := level // new scope
+		t.Run(level.String(), func(t *testing.T) {
+			for _, errChanLen := range []int{1, 2, 3, 1024} {
+				errChanLen := errChanLen // new scope
+				t.Run(fmt.Sprintf("with chan buffer length %d", errChanLen), func(t *testing.T) {
+					g := gomega.NewGomegaWithT(t)
+					output := gbytes.NewBuffer()
+					errChan := make(chan error, errChanLen)
+					logger := plog.WithBackoff(plog.NewLogger(level, output, errChan))
+
+					// Perform log calls
+					logger.Debug("debug 1", " debug 2", " debug 3")
+					logger.Info("info 1 ", "info 2 ", "info 3")
+					err := errors.New("error message 0")
+					logger.Error(err)
+					logger.Error(err)
+					logger.Error(err)
+					logger.Error(err)
+					logger.Error(err)
+					err1 := sqerrors.WithKey(errors.New("error message 1"), 1)
+					logger.Error(err1)
+					logger.Error(err1)
+					err2 := sqerrors.WithKey(errors.New("error message 2"), 2)
+					logger.Error(err2)
+					logger.Error(err2)
+					logger.Error(err2)
+					logger.Error(err2)
+					logger.Error(err2)
+
+					var (
+						re      = "sqreen/%s - [0-9]{4}(-[0-9]{2}){2}T([0-9]{2}:){2}[0-9]{2}.?[0-9]{0,6} - %s"
+						debugRe = fmt.Sprintf(re, plog.Debug, "debug 1 debug 2 debug 3")
+						errorRe = fmt.Sprintf(re, plog.Error, "error message")
+						infoRe  = fmt.Sprintf(re, plog.Info, "info 1 info 2 info 3")
+					)
+					switch level {
+					case plog.Disabled:
+						g.Expect(output).ShouldNot(gbytes.Say(debugRe))
+						g.Expect(output).ShouldNot(gbytes.Say(infoRe))
+						g.Expect(output).ShouldNot(gbytes.Say(errorRe))
+					case plog.Debug:
+						g.Expect(output).Should(gbytes.Say(debugRe))
+						fallthrough
+					case plog.Info:
+						g.Expect(output).Should(gbytes.Say(infoRe))
+						fallthrough
+					case plog.Error:
+						errMsg0 := errorRe + " 0"
+						g.Expect(output).Should(gbytes.Say(errMsg0))
+						g.Expect(output).Should(gbytes.Say(errMsg0))
+						g.Expect(output).Should(gbytes.Say(errMsg0))
+
+						errMsg1 := errorRe + " 1"
+						g.Expect(output).Should(gbytes.Say(errMsg1))
+
+						errMsg2 := errorRe + " 2"
+						g.Expect(output).Should(gbytes.Say(errMsg2))
+						g.Expect(output).Should(gbytes.Say(errMsg2))
+						g.Expect(output).Should(gbytes.Say(errMsg2))
+					}
+
+					// The error should have been sent into the channel
+					// The number of sent events has been backoff'd but also limited by
+					// the channel buffer size
+					expectedErrors := []error{
+						err, err, err, err1, err2, err2, err2,
+					}
+					for i := 0; i < len(expectedErrors) && i < errChanLen; i++ {
+						g.Eventually(errChan).Should(gomega.Receive(gomega.Equal(expectedErrors[i])))
 					}
 				})
 			}

--- a/internal/rule/callback/_testlib/mockups/mockups.go
+++ b/internal/rule/callback/_testlib/mockups/mockups.go
@@ -38,7 +38,7 @@ type NativeRuleContextMockup struct {
 	mock.Mock
 }
 
-func (r *NativeRuleContextMockup) Pre(cb func(c callback.CallbackContext)) {
+func (r *NativeRuleContextMockup) Pre(cb func(c callback.CallbackContext) error) {
 	r.Called(cb)
 }
 
@@ -46,7 +46,7 @@ func (r *NativeRuleContextMockup) ExpectPre(cb interface{}) *mock.Call {
 	return r.On("Pre", cb)
 }
 
-func (r *NativeRuleContextMockup) Post(cb func(c callback.CallbackContext)) {
+func (r *NativeRuleContextMockup) Post(cb func(c callback.CallbackContext) error) {
 	r.Called(cb)
 }
 

--- a/internal/rule/callback/context.go
+++ b/internal/rule/callback/context.go
@@ -18,7 +18,7 @@ type (
 		Pre(pre CallbackFunc)
 		Post(post CallbackFunc)
 	}
-	CallbackFunc = func(c CallbackContext)
+	CallbackFunc = func(c CallbackContext) error
 )
 
 type CallbackContext interface {

--- a/internal/rule/callback/ip-denylist_test.go
+++ b/internal/rule/callback/ip-denylist_test.go
@@ -65,7 +65,7 @@ func TestIPDenyListCallback(t *testing.T) {
 		require.True(t, ok)
 
 		// Not blocked
-		r.On("Pre", mock.MatchedBy(func(cb func(c callback.CallbackContext)) bool {
+		r.ExpectPre(mock.MatchedBy(func(cb func(c callback.CallbackContext) error) bool {
 			c := &mockups.CallbackContextMockup{}
 			defer c.AssertExpectations(t)
 
@@ -75,7 +75,7 @@ func TestIPDenyListCallback(t *testing.T) {
 			c.ExpectProtectionContext().Return(p)
 			p.ExpectClientIP().Return(net.ParseIP("11.22.33.44")).Once()
 
-			cb(c)
+			require.NoError(t, cb(c))
 			return true
 		})).Once()
 

--- a/internal/rule/callback/monitor-http-status-code.go
+++ b/internal/rule/callback/monitor-http-status-code.go
@@ -22,7 +22,7 @@ func NewMonitorHTTPStatusCodeCallback(r RuleContext, _ NativeCallbackConfig) (sq
 
 func newMonitorHTTPStatusCodePrologCallback(r RuleContext) http_protection.ResponseMonitoringPrologCallbackType {
 	return func(_ **http_protection.ProtectionContext, resp *types.ResponseFace) (http_protection.NonBlockingEpilogCallbackType, error) {
-		r.Pre(func(c CallbackContext) {
+		r.Pre(func(c CallbackContext) error {
 			sqassert.NotNil(resp)
 			status := (*resp).Status()
 			_ = c.AddMetricsValue(status, 1)
@@ -32,6 +32,7 @@ func newMonitorHTTPStatusCodePrologCallback(r RuleContext) http_protection.Respo
 				blocked := c.HandleAttack(false, event.WithAttackInfo(struct{}{}), event.WithTest(true))
 				sqassert.False(blocked)
 			}
+			return nil
 		})
 		return nil, nil
 	}

--- a/internal/rule/callback/monitor-http-status-code_test.go
+++ b/internal/rule/callback/monitor-http-status-code_test.go
@@ -42,11 +42,11 @@ func TestMonitorHTTPStatusCodeCallback(t *testing.T) {
 		require.NoError(t, err)
 		require.Nil(t, epilog)
 
-		r.AssertCalled(t, "Pre", mock.MatchedBy(func(cb func(callback.CallbackContext)) bool {
+		r.AssertCalled(t, "Pre", mock.MatchedBy(func(cb func(callback.CallbackContext) error) bool {
 			c := &mockups.CallbackContextMockup{}
 			defer c.AssertExpectations(t)
 			c.ExpectAddMetricsValue(expectedStatusCode, 1).Return(nil).Once()
-			cb(c)
+			require.NoError(t, cb(c))
 			return true
 		}))
 	})
@@ -73,7 +73,7 @@ func TestMonitorHTTPStatusCodeCallback(t *testing.T) {
 		require.NoError(t, err)
 		require.Nil(t, epilog)
 
-		r.AssertCalled(t, "Pre", mock.MatchedBy(func(cb func(callback.CallbackContext)) bool {
+		r.AssertCalled(t, "Pre", mock.MatchedBy(func(cb func(callback.CallbackContext) error) bool {
 			c := &mockups.CallbackContextMockup{}
 			defer c.AssertExpectations(t)
 			c.ExpectAddMetricsValue(expectedStatusCode, 1).Return(nil).Once()
@@ -84,7 +84,7 @@ func TestMonitorHTTPStatusCodeCallback(t *testing.T) {
 				}
 				return assert.Equal(t, &event.AttackEvent{Test: true, Info: struct{}{}}, attack)
 			})).Return(false).Once()
-			cb(c)
+			require.NoError(t, cb(c))
 			return true
 		}))
 	})

--- a/internal/rule/callback/waf.go
+++ b/internal/rule/callback/waf.go
@@ -118,7 +118,8 @@ func runWAF(c CallbackContext, bindingAccessors map[string]bindingaccessor.Bindi
 		value, err := ba(baCtx)
 		if err != nil {
 			// Log the error and continue
-			c.Logger().Error(sqerrors.WithKey(sqerrors.Wrapf(err, "binding accessor execution error `%s`", expr), expr))
+			type errKey string
+			c.Logger().Error(sqerrors.WithKey(sqerrors.Wrapf(err, "binding accessor execution error `%s`", expr), errKey(expr)))
 			continue
 		}
 		if value == nil {
@@ -311,7 +312,9 @@ func makeFunctionWAFPrologCallback(r RuleContext, wafRule waf_types.Rule, bindin
 func runFunctionWAF(c CallbackContext, bindingAccessors map[string]bindingaccessor.BindingAccessorFunc, wafRule waf_types.Rule, timeout time.Duration, extraParamAccessors functionWAFBindingAccessorMap, strategy *api.ReflectedCallbackConfig, params []reflect.Value, results []reflect.Value) (blocked bool, err error) {
 	baCtx, err := NewReflectedCallbackBindingAccessorContext(strategy.BindingAccessor.Capabilities, c.ProtectionContext(), params, results, nil)
 	if err != nil {
+		type errKey struct{}
 		err = sqerrors.Wrap(err, "unexpected error while creating the binding accessor context")
+		err = sqerrors.WithKey(err, errKey{})
 		return false, err
 	}
 

--- a/internal/rule/callback/write-blocking-html-page.go
+++ b/internal/rule/callback/write-blocking-html-page.go
@@ -9,6 +9,7 @@ package callback
 import (
 	"github.com/sqreen/go-agent/internal/backend/api"
 	httpprotection "github.com/sqreen/go-agent/internal/protection/http"
+	"github.com/sqreen/go-agent/internal/sqlib/sqassert"
 	"github.com/sqreen/go-agent/internal/sqlib/sqerrors"
 	"github.com/sqreen/go-agent/internal/sqlib/sqhook"
 )
@@ -17,7 +18,7 @@ import (
 // callbacks modifying the arguments of `httphandler.WriteResponse` in order to
 // modify the http status code and error page that are provided by the rule's
 // data.
-func NewWriteBlockingHTMLPageCallback(_ RuleContext, cfg NativeCallbackConfig) (sqhook.PrologCallback, error) {
+func NewWriteBlockingHTMLPageCallback(r RuleContext, cfg NativeCallbackConfig) (sqhook.PrologCallback, error) {
 	var statusCode = 500 // default status code
 	if data := cfg.Data(); data != nil {
 		cfg, ok := data.(*api.CustomErrorPageRuleDataEntry)
@@ -26,19 +27,25 @@ func NewWriteBlockingHTMLPageCallback(_ RuleContext, cfg NativeCallbackConfig) (
 		}
 		statusCode = cfg.StatusCode
 	}
-	return newWriteBlockingHTMLPagePrologCallback(statusCode), nil
+	return newWriteBlockingHTMLPagePrologCallback(r, statusCode), nil
 }
 
 // The prolog callback modifies the function arguments in order to replace the
 // written status code and body.
-func newWriteBlockingHTMLPagePrologCallback(statusCode int) httpprotection.NonBlockingPrologCallbackType {
-	return func(m **httpprotection.ProtectionContext) (httpprotection.NonBlockingEpilogCallbackType, error) {
-		ctx := *m
-		// Note that the header must be written first since writing the body first
-		// leads to the default OK status.
-		ctx.ResponseWriter.WriteHeader(statusCode)
-		// TODO: log error once
-		_, _ = ctx.ResponseWriter.WriteString(blockedBySqreenPage)
+func newWriteBlockingHTMLPagePrologCallback(r RuleContext, statusCode int) httpprotection.NonBlockingPrologCallbackType {
+	return func(ctx **httpprotection.ProtectionContext) (httpprotection.NonBlockingEpilogCallbackType, error) {
+		r.Pre(func(c CallbackContext) error {
+			sqassert.NotNil(ctx)
+			ctx := *ctx
+			// Note that the header must be written first since writing the body first
+			// leads to the default OK status.
+			ctx.ResponseWriter.WriteHeader(statusCode)
+			// Write the blocking page. We ignore any return error as this is a best
+			// effort response attempt: we don't want to penalize the server any
+			// further with this request - so no logging, no counting, no retry.
+			_, _ = ctx.ResponseWriter.WriteString(blockedBySqreenPage)
+			return nil
+		})
 		return nil, nil
 	}
 }

--- a/internal/rule/callback/write-http-redirection.go
+++ b/internal/rule/callback/write-http-redirection.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/sqreen/go-agent/internal/backend/api"
 	httpprotection "github.com/sqreen/go-agent/internal/protection/http"
+	"github.com/sqreen/go-agent/internal/sqlib/sqassert"
 	"github.com/sqreen/go-agent/internal/sqlib/sqerrors"
 	"github.com/sqreen/go-agent/internal/sqlib/sqhook"
 )
@@ -19,7 +20,7 @@ import (
 // NewWriteHTTPRedirectionCallbacks returns the native callback applying the
 // the rule-configured HTTP redirection to the HTTP protection response writer
 // using the URL provided by the rule's data.
-func NewWriteHTTPRedirectionCallbacks(_ RuleContext, cfg NativeCallbackConfig) (sqhook.PrologCallback, error) {
+func NewWriteHTTPRedirectionCallbacks(r RuleContext, cfg NativeCallbackConfig) (sqhook.PrologCallback, error) {
 	var redirectionURL string
 	if cfg := cfg.Data(); cfg != nil {
 		cfg, ok := cfg.(*api.RedirectionRuleDataEntry)
@@ -35,16 +36,20 @@ func NewWriteHTTPRedirectionCallbacks(_ RuleContext, cfg NativeCallbackConfig) (
 		return nil, sqerrors.Wrap(err, "validation error of the redirection url")
 	}
 
-	return newWriteHTTPRedirectionPrologCallback(redirectionURL), nil
+	return newWriteHTTPRedirectionPrologCallback(r, redirectionURL), nil
 }
 
 // The prolog callback modifies the function arguments in order to perform an
 // HTTP redirection.
-func newWriteHTTPRedirectionPrologCallback(url string) httpprotection.NonBlockingPrologCallbackType {
-	return func(m **httpprotection.ProtectionContext) (httpprotection.NonBlockingEpilogCallbackType, error) {
-		ctx := *m
-		ctx.ResponseWriter.Header().Set("Location", url)
-		ctx.ResponseWriter.WriteHeader(http.StatusSeeOther)
+func newWriteHTTPRedirectionPrologCallback(r RuleContext, url string) httpprotection.NonBlockingPrologCallbackType {
+	return func(ctx **httpprotection.ProtectionContext) (httpprotection.NonBlockingEpilogCallbackType, error) {
+		r.Pre(func(c CallbackContext) error {
+			sqassert.NotNil(ctx)
+			ctx := *ctx
+			ctx.ResponseWriter.Header().Set("Location", url)
+			ctx.ResponseWriter.WriteHeader(http.StatusSeeOther)
+			return nil
+		})
 		return nil, nil
 	}
 }

--- a/internal/rule/rule.go
+++ b/internal/rule/rule.go
@@ -32,7 +32,7 @@ import (
 )
 
 type Engine struct {
-	logger Logger
+	logger plog.DebugLevelLogger
 	// Map rules to their corresponding symbol in order to be able to modify them
 	// at run time by atomically replacing a running rule.
 	// TODO: write a test to check two HookFaces are correctly comparable
@@ -47,14 +47,8 @@ type Engine struct {
 	perfHistogramPeriod                  time.Duration
 }
 
-// Logger interface required by this package.
-type Logger interface {
-	plog.DebugLogger
-	plog.ErrorLogger
-}
-
 // NewEngine returns a new rule engine.
-func NewEngine(logger Logger, instrumentationEngine InstrumentationFace, metricsEngine *metrics.Engine, publicKey *ecdsa.PublicKey, perfHistogramUnit, perfHistogramBase float64, perfHistogramPeriod time.Duration) *Engine {
+func NewEngine(logger plog.DebugLevelLogger, instrumentationEngine InstrumentationFace, metricsEngine *metrics.Engine, publicKey *ecdsa.PublicKey, perfHistogramUnit, perfHistogramBase float64, perfHistogramPeriod time.Duration) *Engine {
 	if instrumentationEngine == nil {
 		instrumentationEngine = defaultInstrumentationEngine
 	}

--- a/internal/rule/rule_test.go
+++ b/internal/rule/rule_test.go
@@ -81,7 +81,7 @@ func TestEngineUsage(t *testing.T) {
 	require.NoError(t, err)
 	publicKey := &privateKey.PublicKey
 
-	logger := plog.NewLogger(plog.Debug, os.Stderr, 0)
+	logger := plog.NewLogger(plog.Debug, os.Stderr, nil)
 	metrics := metrics.NewEngine()
 
 	t.Run("empty state", func(t *testing.T) {

--- a/internal/sqlib/sqassert/sqsync/map.go
+++ b/internal/sqlib/sqassert/sqsync/map.go
@@ -1,0 +1,26 @@
+// Copyright (c) 2016 - 2020 Sqreen. All Rights Reserved.
+// Please refer to our terms for more information:
+// https://www.sqreen.io/terms.html
+
+package sqsync
+
+import (
+	"sync"
+	"sync/atomic"
+)
+
+type UInt64Map struct {
+	sync.Map
+}
+
+func (m *UInt64Map) Add(key interface{}, delta uint64) {
+	atomic.AddUint64(m.Get(key), delta)
+}
+
+func (m *UInt64Map) Get(key interface{}) *uint64 {
+	v, loaded := m.Load(key)
+	if !loaded {
+		v, _ = m.LoadOrStore(key, new(uint64))
+	}
+	return v.(*uint64)
+}

--- a/internal/sqlib/sqerrors/errors.go
+++ b/internal/sqlib/sqerrors/errors.go
@@ -33,25 +33,25 @@ type withTimestamp struct {
 // WithTimestamp annotates the given error `err` with a timestamp. The returned
 // error value implements interface Timestamper.
 func WithTimestamp(err error) error {
-	return &withTimestamp{
+	return withTimestamp{
 		error:     err,
 		timestamp: time.Now(),
 	}
 }
 
-func (e *withTimestamp) Timestamp() time.Time {
+func (e withTimestamp) Timestamp() time.Time {
 	return e.timestamp
 }
 
-func (e *withTimestamp) Unwrap() error {
+func (e withTimestamp) Unwrap() error {
 	return e.error
 }
 
-func (e *withTimestamp) Cause() error {
+func (e withTimestamp) Cause() error {
 	return e.Unwrap()
 }
 
-func (e *withTimestamp) Format(f fmt.State, c rune) {
+func (e withTimestamp) Format(f fmt.State, c rune) {
 	if formatter, ok := e.error.(fmt.Formatter); ok {
 		formatter.Format(f, c)
 	} else {
@@ -72,21 +72,53 @@ type withInfo struct {
 // extra context to the error. The returned error value implements interface
 // Info.
 func WithInfo(err error, info interface{}) error {
-	return &withInfo{
+	return withInfo{
 		error: err,
 		info:  info,
 	}
 }
 
-func (e *withInfo) Info() interface{} {
+func (e withInfo) Info() interface{} {
 	return e.info
 }
 
-func (e *withInfo) Unwrap() error {
+func (e withInfo) Unwrap() error {
 	return e.error
 }
 
-func (e *withInfo) Cause() error {
+func (e withInfo) Cause() error {
+	return e.Unwrap()
+}
+
+type KeyType interface{}
+
+type Keyer interface {
+	Key() KeyType
+}
+
+type withKey struct {
+	error
+	key KeyType
+}
+
+// WithKey associates the given key with the error. This key can be used for
+// error indexing in advanced error management cases such as error sampling.
+func WithKey(err error, key KeyType) error {
+	return withKey{
+		error: err,
+		key:   key,
+	}
+}
+
+func (e withKey) Key() KeyType {
+	return e.key
+}
+
+func (e withKey) Unwrap() error {
+	return e.error
+}
+
+func (e withKey) Cause() error {
 	return e.Unwrap()
 }
 
@@ -114,7 +146,7 @@ func Wrapf(err error, format string, args ...interface{}) error {
 	return Wrap(err, fmt.Sprintf(format, args...))
 }
 
-// StackTrace returns the earliest/deepest StackTrace attached to any of
+// StackTrace returns the deepest StackTrace attached to any of
 // the errors in the chain of Causes. If the error does not implement
 // Cause, the original error will be returned. If the error is nil,
 // nil will be returned without further investigation.
@@ -138,28 +170,23 @@ loop:
 	return topStackInfo
 }
 
-// Info returns the earliest/deepest information attached to any of the errors
+// Info returns the earliest information attached to any of the errors
 // in the chain of Causes. If the error does not implement Cause, the original
 // error will be returned. If the error is nil, nil will be returned without
 // further investigation.
 func Info(err error) interface{} {
-	var info interface{}
-loop:
 	for {
-		infoErr, ok := err.(Informer)
-		if ok {
-			info = infoErr.Info()
-		}
 		switch actual := err.(type) {
+		case Informer:
+			return actual.Info()
 		case Causer:
 			err = actual.Cause()
 		case xerrors.Wrapper:
 			err = actual.Unwrap()
 		default:
-			break loop
+			return nil
 		}
 	}
-	return info
 }
 
 // Timestamp returns the error timestamp created with the function
@@ -167,10 +194,34 @@ loop:
 // default time's zero value is returned and `ok` is false.
 // false and the
 func Timestamp(err error) (t time.Time, ok bool) {
-	if t, ok := err.(Timestamper); ok {
-		return t.Timestamp(), true
+	for {
+		switch actual := err.(type) {
+		case Timestamper:
+			return actual.Timestamp(), true
+		case Causer:
+			err = actual.Cause()
+		case xerrors.Wrapper:
+			err = actual.Unwrap()
+		default:
+			return time.Time{}, false
+		}
 	}
-	return time.Time{}, false
+}
+
+// Key returns the earliest key attached to the error if any.
+func Key(err error) (KeyType, bool) {
+	for {
+		switch actual := err.(type) {
+		case Keyer:
+			return actual.Key(), true
+		case Causer:
+			err = actual.Cause()
+		case xerrors.Wrapper:
+			err = actual.Unwrap()
+		default:
+			return nil, false
+		}
+	}
 }
 
 type ErrorCollection []error

--- a/internal/sqlib/sqerrors/errors_test.go
+++ b/internal/sqlib/sqerrors/errors_test.go
@@ -27,11 +27,10 @@ func TestWithInfo(t *testing.T) {
 
 	t.Run("multiple info", func(t *testing.T) {
 		err := errors.New("an error")
-		info := map[string]string{
+		err = sqerrors.WithInfo(err, map[string]string{
 			"k1": "v1",
 			"k2": "v2",
-		}
-		err = sqerrors.WithInfo(err, info)
+		})
 		err = sqerrors.Wrap(err, "an error occurred")
 		err = sqerrors.WithInfo(err, map[string]string{"key": "value"})
 		err = sqerrors.Wrap(err, "an error occurred")
@@ -41,10 +40,25 @@ func TestWithInfo(t *testing.T) {
 		err = sqerrors.Wrap(err, "an error occurred")
 		err = sqerrors.WithInfo(err, 33)
 
-		// Check that we get the deepest level
+		// Check that we get the earliest level
 		got := sqerrors.Info(err)
-		require.Equal(t, info, got)
+		require.Equal(t, 33, got)
 	})
+}
+
+func TestWithKey(t *testing.T) {
+	// Checking the Go assumption that the type is correctly taken into account
+	type t1 struct{}
+	type t2 struct{}
+	require.NotEqual(t, t1{}, t2{})
+
+	err := errors.New("an error")
+	key := t1{}
+	err = sqerrors.WithKey(err, key)
+	err = sqerrors.Wrap(err, "an error occurred")
+	got, ok := sqerrors.Key(err)
+	require.True(t, ok)
+	require.Equal(t, key, got)
 }
 
 func TestErrorCollection(t *testing.T) {

--- a/internal/sqlib/sqerrors/errors_test.go
+++ b/internal/sqlib/sqerrors/errors_test.go
@@ -48,8 +48,10 @@ func TestWithInfo(t *testing.T) {
 
 func TestWithKey(t *testing.T) {
 	// Checking the Go assumption that the type is correctly taken into account
-	type t1 struct{}
-	type t2 struct{}
+	type (
+		t1 struct{}
+		t2 struct{}
+	)
 	require.NotEqual(t, t1{}, t2{})
 
 	err := errors.New("an error")
@@ -59,6 +61,24 @@ func TestWithKey(t *testing.T) {
 	got, ok := sqerrors.Key(err)
 	require.True(t, ok)
 	require.Equal(t, key, got)
+
+	// Test two defined types identical but in distinct code blocks indeed two
+	// distinct types
+	err1 := sqerrors.New("my error")
+	{
+		type t3 struct{}
+		err1 = sqerrors.WithKey(err1, t3{})
+	}
+	err2 := sqerrors.New("my error")
+	{
+		type t3 struct{}
+		err2 = sqerrors.WithKey(err2, t3{})
+	}
+	k1, exists := sqerrors.Key(err1)
+	require.True(t, exists)
+	k2, exists := sqerrors.Key(err2)
+	require.True(t, exists)
+	require.NotEqual(t, k1, k2)
 }
 
 func TestErrorCollection(t *testing.T) {


### PR DESCRIPTION
Critical execution errors happening in the request hot path are now logged according to exponential backoff counters of their occurrences. This avoids slowing down request handlers but also spamming the internal agent queue. Such error will now go through the agent error logging facility every time the backoff counter is a power of two (1, 2, 4, 8, etc.). This is disabled when in debug log level.