### PR TITLE
sdk/middleware/sqgin: response's content length monitoring

### DIFF
--- a/sdk/middleware/sqecho/echo_test.go
+++ b/sdk/middleware/sqecho/echo_test.go
@@ -426,7 +426,7 @@ func TestMiddleware(t *testing.T) {
 	})
 
 	t.Run("response observation", func(t *testing.T) {
-		t.Run("direct http header write", func(t *testing.T) {
+		t.Run("handler response", func(t *testing.T) {
 			var (
 				responseStatusCode    int
 				responseContentType   string
@@ -465,43 +465,121 @@ func TestMiddleware(t *testing.T) {
 			require.Equal(t, expectedStatusCode, rec.Code)
 			require.Equal(t, expectedStatusCode, responseStatusCode)
 			require.Equal(t, expectedContentLength, responseContentLength)
+			require.Equal(t, int64(rec.Body.Len()), responseContentLength)
 			require.Equal(t, expectedContentType, responseContentType)
+			require.Equal(t, rec.Header().Get("Content-Type"), responseContentType)
+		})
+
+		t.Run("default response", func(t *testing.T) {
+			var (
+				responseStatusCode    int
+				responseContentType   string
+				responseContentLength int64
+			)
+			root := mockups.NewRootHTTPProtectionContextMockup(context.Background(), mock.Anything, mock.Anything)
+			root.ExpectClose(mock.MatchedBy(func(closed types.ClosedProtectionContextFace) bool {
+				resp := closed.Response()
+				responseStatusCode = resp.Status()
+				responseContentLength = resp.ContentLength()
+				responseContentType = resp.ContentType()
+				return true
+			}))
+			defer root.AssertExpectations(t)
+
+			h := func(c echo.Context) error {
+				// Do nothing, so that Echo's response fields have their default values
+				return nil
+			}
+
+			// Perform the request and record the output
+			rec := httptest.NewRecorder()
+			req, _ := http.NewRequest("GET", "/", nil)
+
+			m := middleware(root)
+			c := echo.New().NewContext(req, rec)
+
+			// Wrap and call the handler
+			err := m(h)(c)
+
+			// Check the result
+			require.NoError(t, err)
+			require.Equal(t, http.StatusOK, rec.Code)
+			require.Equal(t, http.StatusOK, responseStatusCode)
+			require.Equal(t, int64(rec.Body.Len()), responseContentLength)
+			require.Equal(t, rec.Header().Get("Content-Type"), responseContentType)
+		})
+
+		t.Run("not found endpoint", func(t *testing.T) {
+			var (
+				responseStatusCode    int
+				responseContentType   string
+				responseContentLength int64
+			)
+			root := mockups.NewRootHTTPProtectionContextMockup(context.Background(), mock.Anything, mock.Anything)
+			root.ExpectClose(mock.MatchedBy(func(closed types.ClosedProtectionContextFace) bool {
+				resp := closed.Response()
+				responseStatusCode = resp.Status()
+				responseContentLength = resp.ContentLength()
+				responseContentType = resp.ContentType()
+				return true
+			}))
+			defer root.AssertExpectations(t)
+
+			// Perform the request and record the output
+			rec := httptest.NewRecorder()
+			req, _ := http.NewRequest("GET", "/", nil)
+
+			e := echo.New()
+			m := middleware(root)
+			e.Use(m)
+			e.ServeHTTP(rec, req)
+
+			// Check the result
+			require.Equal(t, http.StatusNotFound, rec.Code)
+			require.Equal(t, http.StatusNotFound, responseStatusCode)
+
+			// Echo bypasses the middleware when handling an error
+			require.Equal(t, int64(0), responseContentLength)
+			//require.Equal(t, int64(rec.Body.Len()), responseContentLength)
+			require.Equal(t, "", responseContentType)
+			//require.Equal(t, rec.Header().Get("Content-Type"), responseContentType)
+		})
+
+		t.Run("echo handler error", func(t *testing.T) {
+			var (
+				responseStatusCode int
+			)
+			root := mockups.NewRootHTTPProtectionContextMockup(context.Background(), mock.Anything, mock.Anything)
+			root.ExpectClose(mock.MatchedBy(func(closed types.ClosedProtectionContextFace) bool {
+				resp := closed.Response()
+				responseStatusCode = resp.Status()
+				return true
+			}))
+			defer root.AssertExpectations(t)
+
+			expectedError := echo.ErrNotFound
+
+			h := func(c echo.Context) error {
+				return expectedError
+			}
+
+			// Perform the request and record the output
+			rec := httptest.NewRecorder()
+			req, _ := http.NewRequest("GET", "/", nil)
+
+			m := middleware(root)
+			c := echo.New().NewContext(req, rec)
+
+			// Wrap and call the handler
+			err := m(h)(c)
+
+			// Check the result
+			require.Error(t, err)
+			require.Equal(t, expectedError, err)
+			require.Equal(t, expectedError.Code, responseStatusCode)
 		})
 	})
 
-	t.Run("echo handler error", func(t *testing.T) {
-		var (
-			responseStatusCode int
-		)
-		root := mockups.NewRootHTTPProtectionContextMockup(context.Background(), mock.Anything, mock.Anything)
-		root.ExpectClose(mock.MatchedBy(func(closed types.ClosedProtectionContextFace) bool {
-			resp := closed.Response()
-			responseStatusCode = resp.Status()
-			return true
-		}))
-		defer root.AssertExpectations(t)
-
-		expectedError := echo.ErrNotFound
-
-		h := func(c echo.Context) error {
-			return expectedError
-		}
-
-		// Perform the request and record the output
-		rec := httptest.NewRecorder()
-		req, _ := http.NewRequest("GET", "/", nil)
-
-		m := middleware(root)
-		c := echo.New().NewContext(req, rec)
-
-		// Wrap and call the handler
-		err := m(h)(c)
-
-		// Check the result
-		require.Error(t, err)
-		require.Equal(t, expectedError, err)
-		require.Equal(t, expectedError.Code, responseStatusCode)
-	})
 }
 
 func middleware(p types.RootProtectionContext) echo.MiddlewareFunc {

--- a/sdk/middleware/sqgin/gin.go
+++ b/sdk/middleware/sqgin/gin.go
@@ -266,11 +266,10 @@ func newObservedResponse(r *responseWriterImpl) *observedResponse {
 	// less than 0 when not set by default with Gin.
 	cl := int64(r.c.Writer.Size())
 	if cl < 0 {
+		cl = 0
 		if contentLength := headers.Get("Content-Length"); contentLength != "" {
 			if l, err := strconv.ParseInt(contentLength, 10, 0); err == nil {
 				cl = l
-			} else {
-				cl = 0
 			}
 		}
 	}


### PR DESCRIPTION
Fix the response's content-length monitoring with the default response (ie. the handler does nothing).