### PR TITLE
Security Responses: fix the name of security response action events

### DIFF
--- a/internal/actor/action.go
+++ b/internal/actor/action.go
@@ -31,11 +31,6 @@ type RedirectAction interface {
 	RedirectionURL() string
 }
 
-type UserRedirectAction interface {
-	RedirectAction
-	UserID() map[string]string
-}
-
 // Timed is an interface implemented by actions having an expiration time.
 type Timed interface {
 	Expired() bool

--- a/internal/actor/http.go
+++ b/internal/actor/http.go
@@ -1,5 +1,0 @@
-// Copyright (c) 2016 - 2019 Sqreen. All Rights Reserved.
-// Please refer to our terms for more information:
-// https://www.sqreen.io/terms.html
-
-package actor

--- a/internal/backend/api/signal/signal.go
+++ b/internal/backend/api/signal/signal.go
@@ -137,7 +137,9 @@ func newAttackPayload(test, block bool, infos interface{}) *api.SignalPayload {
 
 func fromLegacyTrackEvent(track *legacy_api.RequestRecord_Observed_SDKEvent_Args_Track, t time.Time) *api.Point {
 	var name strings.Builder
-	name.WriteString("sq.sdk.")
+	if !strings.HasPrefix(track.Event, "sq.") {
+		name.WriteString("sq.sdk.")
+	}
 	name.WriteString(track.Event)
 	return api.NewPoint(name.String(), "sqreen:sdk:track", t, nil, nil, nil, nil, nil, newTrackEventPayload(track.Options.Properties, track.Options.UserIdentifiers))
 }

--- a/internal/plog/plog_test.go
+++ b/internal/plog/plog_test.go
@@ -10,7 +10,9 @@ import (
 	"github.com/pkg/errors"
 	"github.com/sqreen/go-agent/internal/plog"
 	"github.com/sqreen/go-agent/internal/sqlib/sqerrors"
+	"github.com/sqreen/go-agent/internal/sqlib/sqsafe"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/xerrors"
 )
 
 func TestLogger(t *testing.T) {
@@ -71,90 +73,119 @@ func TestLogger(t *testing.T) {
 }
 
 func TestWithBackoff(t *testing.T) {
-	for _, level := range []plog.LogLevel{
-		plog.Disabled,
-		plog.Debug,
-		plog.Info,
-		plog.Error,
-	} {
-		level := level // new scope
-		t.Run(level.String(), func(t *testing.T) {
-			for _, errChanLen := range []int{0, 1, 2, 3, 1024} {
-				errChanLen := errChanLen // new scope
-				t.Run(fmt.Sprintf("with chan buffer length %d", errChanLen), func(t *testing.T) {
-					g := gomega.NewGomegaWithT(t)
-					output := gbytes.NewBuffer()
+	t.Run("common usage", func(t *testing.T) {
+		for _, level := range []plog.LogLevel{
+			plog.Disabled,
+			plog.Debug,
+			plog.Info,
+			plog.Error,
+		} {
+			level := level // new scope
+			t.Run(level.String(), func(t *testing.T) {
+				for _, errChanLen := range []int{0, 1, 2, 3, 1024} {
+					errChanLen := errChanLen // new scope
+					t.Run(fmt.Sprintf("with chan buffer length %d", errChanLen), func(t *testing.T) {
+						g := gomega.NewGomegaWithT(t)
+						output := gbytes.NewBuffer()
 
-					var errChan chan error
-					if errChanLen > 0 {
-						errChan = make(chan error, errChanLen)
-					}
-					logger := plog.WithBackoff(plog.NewLogger(level, output, errChan))
+						var errChan chan error
+						if errChanLen > 0 {
+							errChan = make(chan error, errChanLen)
+						}
+						logger := plog.WithBackoff(plog.NewLogger(level, output, errChan))
 
-					// Perform log calls
-					logger.Debug("debug 1", " debug 2", " debug 3")
-					logger.Info("info 1 ", "info 2 ", "info 3")
-					err := errors.New("error message 0")
-					logger.Error(err)
-					logger.Error(err)
-					logger.Error(err)
-					logger.Error(err)
-					logger.Error(err)
-					err1 := sqerrors.WithKey(errors.New("error message 1"), 1)
-					logger.Error(err1)
-					logger.Error(err1)
-					err2 := sqerrors.WithKey(errors.New("error message 2"), 2)
-					logger.Error(err2)
-					logger.Error(err2)
-					logger.Error(err2)
-					logger.Error(err2)
-					logger.Error(err2)
+						// Perform log calls
+						logger.Debug("debug 1", " debug 2", " debug 3")
+						logger.Info("info 1 ", "info 2 ", "info 3")
+						err := errors.New("error message 0")
+						logger.Error(err)
+						logger.Error(err)
+						logger.Error(err)
+						logger.Error(err)
+						logger.Error(err)
+						err1 := sqerrors.WithKey(errors.New("error message 1"), 1)
+						logger.Error(err1)
+						logger.Error(err1)
+						err2 := sqerrors.WithKey(errors.New("error message 2"), 2)
+						logger.Error(err2)
+						logger.Error(err2)
+						logger.Error(err2)
+						logger.Error(err2)
+						logger.Error(err2)
 
-					var (
-						re      = "sqreen/%s - [0-9]{4}(-[0-9]{2}){2}T([0-9]{2}:){2}[0-9]{2}.?[0-9]{0,6} - %s"
-						debugRe = fmt.Sprintf(re, plog.Debug, "debug 1 debug 2 debug 3")
-						errorRe = fmt.Sprintf(re, plog.Error, "error message")
-						infoRe  = fmt.Sprintf(re, plog.Info, "info 1 info 2 info 3")
-					)
-					switch level {
-					case plog.Disabled:
-						g.Expect(output).ShouldNot(gbytes.Say(debugRe))
-						g.Expect(output).ShouldNot(gbytes.Say(infoRe))
-						g.Expect(output).ShouldNot(gbytes.Say(errorRe))
-					case plog.Debug:
-						g.Expect(output).Should(gbytes.Say(debugRe))
-						fallthrough
-					case plog.Info:
-						g.Expect(output).Should(gbytes.Say(infoRe))
-						fallthrough
-					case plog.Error:
-						errMsg0 := errorRe + " 0"
-						g.Expect(output).Should(gbytes.Say(errMsg0))
-						g.Expect(output).Should(gbytes.Say(errMsg0))
-						g.Expect(output).Should(gbytes.Say(errMsg0))
+						var (
+							re      = "sqreen/%s - [0-9]{4}(-[0-9]{2}){2}T([0-9]{2}:){2}[0-9]{2}.?[0-9]{0,6} - %s"
+							debugRe = fmt.Sprintf(re, plog.Debug, "debug 1 debug 2 debug 3")
+							errorRe = fmt.Sprintf(re, plog.Error, "error message")
+							infoRe  = fmt.Sprintf(re, plog.Info, "info 1 info 2 info 3")
+						)
+						switch level {
+						case plog.Disabled:
+							g.Expect(output).ShouldNot(gbytes.Say(debugRe))
+							g.Expect(output).ShouldNot(gbytes.Say(infoRe))
+							g.Expect(output).ShouldNot(gbytes.Say(errorRe))
+						case plog.Debug:
+							g.Expect(output).Should(gbytes.Say(debugRe))
+							fallthrough
+						case plog.Info:
+							g.Expect(output).Should(gbytes.Say(infoRe))
+							fallthrough
+						case plog.Error:
+							errMsg0 := errorRe + " 0"
+							g.Expect(output).Should(gbytes.Say(errMsg0))
+							g.Expect(output).Should(gbytes.Say(errMsg0))
+							g.Expect(output).Should(gbytes.Say(errMsg0))
 
-						errMsg1 := errorRe + " 1"
-						g.Expect(output).Should(gbytes.Say(errMsg1))
+							errMsg1 := errorRe + " 1"
+							g.Expect(output).Should(gbytes.Say(errMsg1))
 
-						errMsg2 := errorRe + " 2"
-						g.Expect(output).Should(gbytes.Say(errMsg2))
-						g.Expect(output).Should(gbytes.Say(errMsg2))
-						g.Expect(output).Should(gbytes.Say(errMsg2))
-					}
+							errMsg2 := errorRe + " 2"
+							g.Expect(output).Should(gbytes.Say(errMsg2))
+							g.Expect(output).Should(gbytes.Say(errMsg2))
+							g.Expect(output).Should(gbytes.Say(errMsg2))
+						}
 
-					// The error should have been sent into the channel
-					// The number of sent events has been backoff'd but also limited by
-					// the channel buffer size
-					expectedErrors := []error{
-						err, err, err, err1, err2, err2, err2,
-					}
-					for i := 0; i < len(expectedErrors) && i < errChanLen; i++ {
-						g.Eventually(errChan).Should(gomega.Receive(gomega.Equal(expectedErrors[i])))
-					}
-				})
-			}
-		})
-	}
+						// The error should have been sent into the channel
+						// The number of sent events has been backoff'd but also limited by
+						// the channel buffer size
+						expectedErrors := []error{
+							err, err, err, err1, err2, err2, err2,
+						}
+						for i := 0; i < len(expectedErrors) && i < errChanLen; i++ {
+							g.Eventually(errChan).Should(gomega.Receive(gomega.Equal(expectedErrors[i])))
+						}
+					})
+				}
+			})
+		}
+	})
+
+	t.Run("with bad key type leading to a panic while looking up the map", func(t *testing.T) {
+		output := gbytes.NewBuffer()
+		errChan := make(chan error, 1)
+		var logger plog.DebugLevelLogger = plog.NewLogger(plog.Debug, output, errChan)
+		logger = plog.WithBackoff(logger)
+
+		anError := errors.New("my error")
+
+		// A slice is not hashable and will lead to a panic
+		type badErrKey []int
+		logger.Error(sqerrors.WithKey(anError, badErrKey{}))
+
+		// The panic was caught and logged along the original error as an error
+		// collection
+		logged := <-errChan
+		var collection sqerrors.ErrorCollection
+		require.True(t, xerrors.As(logged, &collection))
+		require.Len(t, collection, 2)
+
+		// One of them is the panic error
+		var panicErr *sqsafe.PanicError
+		require.True(t, xerrors.As(collection[0], &panicErr) || xerrors.As(collection[1], &panicErr))
+
+		// One of them is the original error
+		require.True(t, xerrors.Is(collection[0], anError) || xerrors.Is(collection[1], anError))
+	})
 }
 
 func TestTimeFormat(t *testing.T) {

--- a/internal/protection/context/_testlib/mockup.go
+++ b/internal/protection/context/_testlib/mockup.go
@@ -1,0 +1,78 @@
+// Copyright (c) 2016 - 2020 Sqreen. All Rights Reserved.
+// Please refer to our terms for more information:
+// https://www.sqreen.io/terms.html
+
+package _testlib
+
+import (
+	"time"
+
+	protection_context "github.com/sqreen/go-agent/internal/protection/context"
+	"github.com/stretchr/testify/mock"
+)
+
+type EventRecorderMockup struct {
+	mock.Mock
+}
+
+var (
+	_ protection_context.EventRecorder = (*EventRecorderMockup)(nil)
+	_ protection_context.CustomEvent   = (*EventRecorderMockup)(nil)
+)
+
+func (e *EventRecorderMockup) TrackEvent(event string) protection_context.CustomEvent {
+	r, _ := e.Called(event).Get(0).(protection_context.CustomEvent)
+	return r
+}
+
+func (e *EventRecorderMockup) ExpectTrackEvent(event string) *mock.Call {
+	return e.On("TrackEvent", event)
+}
+
+func (e *EventRecorderMockup) TrackUserSignup(id map[string]string) {
+	e.Called(id)
+}
+
+func (e *EventRecorderMockup) ExpectTrackUserSignup(id map[string]string) *mock.Call {
+	return e.On("TrackUserSignup", id)
+}
+
+func (e *EventRecorderMockup) TrackUserAuth(id map[string]string, success bool) {
+	e.Called(id, success)
+}
+
+func (e *EventRecorderMockup) ExpectTrackUserAuth(id map[string]string, success bool) *mock.Call {
+	return e.On("TrackUserAuth", id, success)
+}
+
+func (e *EventRecorderMockup) IdentifyUser(id map[string]string) error {
+	return e.Called(id).Error(0)
+}
+
+func (e *EventRecorderMockup) ExpectIdentifyUser(id map[string]string) *mock.Call {
+	return e.On("IdentifyUser", id)
+}
+
+func (e *EventRecorderMockup) WithTimestamp(t time.Time) {
+	e.Called(t)
+}
+
+func (e *EventRecorderMockup) ExpectWithTimestamp(t time.Time) *mock.Call {
+	return e.On("WithTimestamp", t)
+}
+
+func (e *EventRecorderMockup) WithProperties(props protection_context.EventProperties) {
+	e.Called(props)
+}
+
+func (e *EventRecorderMockup) ExpectWithProperties(props protection_context.EventProperties) *mock.Call {
+	return e.On("WithProperties", props)
+}
+
+func (e *EventRecorderMockup) WithUserIdentifiers(id map[string]string) {
+	e.Called(id)
+}
+
+func (e *EventRecorderMockup) ExpectWithUserIdentifiers(id map[string]string) *mock.Call {
+	return e.On("WithUserIdentifiers", id)
+}

--- a/internal/protection/http/_testlib/mockups/mockups.go
+++ b/internal/protection/http/_testlib/mockups/mockups.go
@@ -22,6 +22,10 @@ func (r *ResponseWriterMockup) Header() http.Header {
 	return h
 }
 
+func (r *ResponseWriterMockup) ExpectHeader() *mock.Call {
+	return r.On("Header")
+}
+
 func (r *ResponseWriterMockup) Write(bytes []byte) (int, error) {
 	ret := r.Called(bytes)
 	return ret.Int(0), ret.Error(1)
@@ -29,6 +33,10 @@ func (r *ResponseWriterMockup) Write(bytes []byte) (int, error) {
 
 func (r *ResponseWriterMockup) WriteHeader(statusCode int) {
 	r.Called(statusCode)
+}
+
+func (r *ResponseWriterMockup) ExpectWriteHeader(statusCode int) *mock.Call {
+	return r.On("WriteHeader", statusCode)
 }
 
 func (r *ResponseWriterMockup) WriteString(s string) (n int, err error) {

--- a/internal/protection/http/http.go
+++ b/internal/protection/http/http.go
@@ -66,6 +66,21 @@ func NewProtectionContext(ctx types.RootProtectionContext, w types.ResponseWrite
 	return p
 }
 
+func NewTestProtectionContext(ctx types.RootProtectionContext, clientIP net.IP, w types.ResponseWriter, r types.RequestReader) *ProtectionContext {
+	rr := &requestReader{
+		RequestReader: r,
+		clientIP:      clientIP,
+		requestParams: make(types.RequestParamMap),
+	}
+
+	return &ProtectionContext{
+		RootProtectionContext: ctx,
+		ResponseWriter:        w,
+		RequestReader:         rr,
+		requestReader:         rr,
+	}
+}
+
 // Helper types for callbacks who must be designed for this protection so that
 // they are the source of truth and so that the compiler catches type issues
 // when compiling (versus when the callback is attached).
@@ -95,11 +110,11 @@ func (p *ProtectionContext) TrackEvent(event string) protection_context.CustomEv
 }
 
 func (p *ProtectionContext) TrackUserSignup(id map[string]string) {
-	p.events.AddUserSignup(id, p.RequestReader.ClientIP())
+	p.events.AddUserSignup(id, p.ClientIP())
 }
 
 func (p *ProtectionContext) TrackUserAuth(id map[string]string, success bool) {
-	p.events.AddUserAuth(id, p.RequestReader.ClientIP(), success)
+	p.events.AddUserAuth(id, p.ClientIP(), success)
 }
 
 func (p *ProtectionContext) IdentifyUser(id map[string]string) error {

--- a/internal/rule/callback/security-responses_test.go
+++ b/internal/rule/callback/security-responses_test.go
@@ -1,0 +1,380 @@
+// Copyright (c) 2016 - 2020 Sqreen. All Rights Reserved.
+// Please refer to our terms for more information:
+// https://www.sqreen.io/terms.html
+
+package callback_test
+
+import (
+	"errors"
+	"net"
+	"net/http"
+	"testing"
+
+	http_protection "github.com/sqreen/go-agent/internal/protection/http"
+	http_protection_mockups "github.com/sqreen/go-agent/internal/protection/http/_testlib/mockups"
+	"github.com/sqreen/go-agent/internal/rule/callback"
+	"github.com/sqreen/go-agent/internal/rule/callback/_testlib/mockups"
+	middleware_mockups "github.com/sqreen/go-agent/sdk/middleware/_testlib/mockups"
+	"github.com/sqreen/go-agent/sdk/types"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/xerrors"
+)
+
+type (
+	ActionMockup struct {
+		mock.Mock
+	}
+
+	RedirectionActionMockup struct {
+		ActionMockup
+	}
+)
+
+func (a *ActionMockup) ActionID() string {
+	return a.Called().String(0)
+}
+
+func (a *ActionMockup) ExpectActionID() *mock.Call {
+	return a.On("ActionID")
+}
+
+func (a *RedirectionActionMockup) RedirectionURL() string {
+	return a.Called().String(0)
+}
+
+func (a *RedirectionActionMockup) ExpectRedirectionURL() *mock.Call {
+	return a.On("RedirectionURL")
+}
+
+func TestIPSecurityResponseCallback(t *testing.T) {
+	t.Run("not blocked", func(t *testing.T) {
+		r := &mockups.NativeRuleContextMockup{}
+		defer r.AssertExpectations(t)
+
+		rootCtx := &middleware_mockups.RootHTTPProtectionContextMockup{}
+		defer rootCtx.AssertExpectations(t)
+
+		responseWriterMockup := &http_protection_mockups.ResponseWriterMockup{}
+		defer responseWriterMockup.AssertExpectations(t)
+
+		requestReaderMockup := &http_protection_mockups.RequestReaderMockup{}
+		defer requestReaderMockup.AssertExpectations(t)
+
+		ip := net.ParseIP("1.2.3.4")
+		p := http_protection.NewTestProtectionContext(rootCtx, ip, responseWriterMockup, requestReaderMockup)
+
+		v, err := callback.NewIPSecurityResponseCallback(r, nil /* unused */)
+		require.NoError(t, err)
+
+		rootCtx.ExpectFindActionByIP(ip).Return(nil, false, nil)
+
+		r.ExpectPre(mock.MatchedBy(func(cb func(callback.CallbackContext) error) bool {
+			c := &mockups.CallbackContextMockup{}
+			require.NoError(t, cb(c))
+			return true
+		}))
+
+		prolog := v.(http_protection.BlockingPrologCallbackType)
+		epilog, err := prolog(&p)
+		require.NoError(t, err)
+		require.Nil(t, epilog)
+	})
+
+	t.Run("blocked", func(t *testing.T) {
+		t.Run("with default blocking behaviour", func(t *testing.T) {
+			r := &mockups.NativeRuleContextMockup{}
+			defer r.AssertExpectations(t)
+
+			rootCtx := &middleware_mockups.RootHTTPProtectionContextMockup{}
+			defer rootCtx.AssertExpectations(t)
+
+			responseWriterMockup := &http_protection_mockups.ResponseWriterMockup{}
+			defer responseWriterMockup.AssertExpectations(t)
+
+			requestReaderMockup := &http_protection_mockups.RequestReaderMockup{}
+			defer requestReaderMockup.AssertExpectations(t)
+
+			ip := net.ParseIP("1.2.3.4")
+			p := http_protection.NewTestProtectionContext(rootCtx, ip, responseWriterMockup, requestReaderMockup)
+
+			v, err := callback.NewIPSecurityResponseCallback(r, nil /* unused */)
+			require.NoError(t, err)
+
+			actionMockup := &ActionMockup{}
+			defer actionMockup.AssertExpectations(t)
+
+			rootCtx.ExpectFindActionByIP(ip).Return(actionMockup, true, nil)
+			rootCtx.ExpectCancelContext()
+
+			r.ExpectPre(mock.MatchedBy(func(cb func(callback.CallbackContext) error) bool {
+				c := &mockups.CallbackContextMockup{}
+				require.NoError(t, cb(c))
+				return true
+			}))
+
+			prolog := v.(http_protection.BlockingPrologCallbackType)
+			epilog, err := prolog(&p)
+			require.NoError(t, err)
+			require.NotNil(t, epilog)
+
+			epilog(&err)
+			require.Error(t, err)
+			require.True(t, xerrors.As(err, &types.SqreenError{}))
+		})
+
+		t.Run("with redirection action", func(t *testing.T) {
+			r := &mockups.NativeRuleContextMockup{}
+			defer r.AssertExpectations(t)
+
+			rootCtx := &middleware_mockups.RootHTTPProtectionContextMockup{}
+			defer rootCtx.AssertExpectations(t)
+
+			responseWriterMockup := &http_protection_mockups.ResponseWriterMockup{}
+			defer responseWriterMockup.AssertExpectations(t)
+
+			requestReaderMockup := &http_protection_mockups.RequestReaderMockup{}
+			defer requestReaderMockup.AssertExpectations(t)
+
+			ip := net.ParseIP("1.2.3.4")
+			p := http_protection.NewTestProtectionContext(rootCtx, ip, responseWriterMockup, requestReaderMockup)
+
+			v, err := callback.NewIPSecurityResponseCallback(r, nil /* unused */)
+			require.NoError(t, err)
+
+			actionMockup := &RedirectionActionMockup{}
+			defer actionMockup.AssertExpectations(t)
+			expectedLocation := "https://sqreen.com/"
+			actionMockup.ExpectRedirectionURL().Return(expectedLocation)
+
+			headers := http.Header{}
+			responseWriterMockup.ExpectHeader().Return(headers)
+			responseWriterMockup.ExpectWriteHeader(http.StatusSeeOther)
+
+			rootCtx.ExpectFindActionByIP(ip).Return(actionMockup, true, nil)
+			rootCtx.ExpectCancelContext()
+
+			r.ExpectPre(mock.MatchedBy(func(cb func(callback.CallbackContext) error) bool {
+				c := &mockups.CallbackContextMockup{}
+				require.NoError(t, cb(c))
+				return true
+			}))
+
+			prolog := v.(http_protection.BlockingPrologCallbackType)
+			epilog, err := prolog(&p)
+			require.NoError(t, err)
+			require.NotNil(t, epilog)
+
+			require.Equal(t, expectedLocation, headers.Get("Location"))
+
+			epilog(&err)
+			require.Error(t, err)
+			require.True(t, xerrors.As(err, &types.SqreenError{}))
+		})
+	})
+
+	t.Run("ip lookup error", func(t *testing.T) {
+		r := &mockups.NativeRuleContextMockup{}
+		defer r.AssertExpectations(t)
+
+		rootCtx := &middleware_mockups.RootHTTPProtectionContextMockup{}
+		defer rootCtx.AssertExpectations(t)
+
+		responseWriterMockup := &http_protection_mockups.ResponseWriterMockup{}
+		defer responseWriterMockup.AssertExpectations(t)
+
+		requestReaderMockup := &http_protection_mockups.RequestReaderMockup{}
+		defer requestReaderMockup.AssertExpectations(t)
+
+		ip := net.ParseIP("1.2.3.4")
+		p := http_protection.NewTestProtectionContext(rootCtx, ip, responseWriterMockup, requestReaderMockup)
+
+		v, err := callback.NewIPSecurityResponseCallback(r, nil /* unused */)
+		require.NoError(t, err)
+
+		rootCtx.ExpectFindActionByIP(ip).Return(nil, false, errors.New("an error"))
+
+		r.ExpectPre(mock.MatchedBy(func(cb func(callback.CallbackContext) error) bool {
+			c := &mockups.CallbackContextMockup{}
+			err := cb(c)
+			require.Error(t, err)
+			return true
+		}))
+
+		prolog := v.(http_protection.BlockingPrologCallbackType)
+		epilog, err := prolog(&p)
+		require.NoError(t, err)
+		require.Nil(t, epilog)
+	})
+
+}
+
+func TestUserSecurityResponseCallback(t *testing.T) {
+	t.Run("not blocked", func(t *testing.T) {
+		r := &mockups.NativeRuleContextMockup{}
+		defer r.AssertExpectations(t)
+
+		rootCtx := &middleware_mockups.RootHTTPProtectionContextMockup{}
+		defer rootCtx.AssertExpectations(t)
+
+		responseWriterMockup := &http_protection_mockups.ResponseWriterMockup{}
+		defer responseWriterMockup.AssertExpectations(t)
+
+		requestReaderMockup := &http_protection_mockups.RequestReaderMockup{}
+		defer requestReaderMockup.AssertExpectations(t)
+
+		p := http_protection.NewTestProtectionContext(rootCtx, net.ParseIP("1.2.3.4"), responseWriterMockup, requestReaderMockup)
+
+		v, err := callback.NewUserSecurityResponseCallback(r, nil /* unused */)
+		require.NoError(t, err)
+
+		userID := map[string]string{
+			"uid": "unique user id",
+		}
+		rootCtx.ExpectFindActionByUserID(userID).Return(nil, false, nil)
+
+		r.ExpectPre(mock.MatchedBy(func(cb func(callback.CallbackContext) error) bool {
+			c := &mockups.CallbackContextMockup{}
+			require.NoError(t, cb(c))
+			return true
+		}))
+
+		prolog := v.(http_protection.IdentifyUserPrologCallbackType)
+		epilog, err := prolog(&p, &userID)
+		require.NoError(t, err)
+		require.Nil(t, epilog)
+	})
+
+	t.Run("blocked", func(t *testing.T) {
+		t.Run("with default blocking behaviour", func(t *testing.T) {
+			r := &mockups.NativeRuleContextMockup{}
+			defer r.AssertExpectations(t)
+
+			rootCtx := &middleware_mockups.RootHTTPProtectionContextMockup{}
+			defer rootCtx.AssertExpectations(t)
+
+			responseWriterMockup := &http_protection_mockups.ResponseWriterMockup{}
+			defer responseWriterMockup.AssertExpectations(t)
+
+			requestReaderMockup := &http_protection_mockups.RequestReaderMockup{}
+			defer requestReaderMockup.AssertExpectations(t)
+
+			ip := net.ParseIP("1.2.3.4")
+			p := http_protection.NewTestProtectionContext(rootCtx, ip, responseWriterMockup, requestReaderMockup)
+
+			v, err := callback.NewUserSecurityResponseCallback(r, nil /* unused */)
+			require.NoError(t, err)
+
+			actionMockup := &ActionMockup{}
+			defer actionMockup.AssertExpectations(t)
+
+			userID := map[string]string{
+				"uid": "unique user id",
+			}
+			rootCtx.ExpectFindActionByUserID(userID).Return(actionMockup, true)
+			rootCtx.ExpectCancelContext()
+
+			r.ExpectPre(mock.MatchedBy(func(cb func(callback.CallbackContext) error) bool {
+				c := &mockups.CallbackContextMockup{}
+				require.NoError(t, cb(c))
+				return true
+			}))
+
+			prolog := v.(http_protection.IdentifyUserPrologCallbackType)
+			epilog, err := prolog(&p, &userID)
+			require.NoError(t, err)
+			require.NotNil(t, epilog)
+
+			epilog(&err)
+			require.Error(t, err)
+			require.True(t, xerrors.As(err, &types.SqreenError{}))
+		})
+
+		t.Run("with redirection action", func(t *testing.T) {
+			r := &mockups.NativeRuleContextMockup{}
+			defer r.AssertExpectations(t)
+
+			rootCtx := &middleware_mockups.RootHTTPProtectionContextMockup{}
+			defer rootCtx.AssertExpectations(t)
+
+			responseWriterMockup := &http_protection_mockups.ResponseWriterMockup{}
+			defer responseWriterMockup.AssertExpectations(t)
+
+			requestReaderMockup := &http_protection_mockups.RequestReaderMockup{}
+			defer requestReaderMockup.AssertExpectations(t)
+
+			ip := net.ParseIP("1.2.3.4")
+			p := http_protection.NewTestProtectionContext(rootCtx, ip, responseWriterMockup, requestReaderMockup)
+
+			v, err := callback.NewUserSecurityResponseCallback(r, nil /* unused */)
+			require.NoError(t, err)
+
+			actionMockup := &RedirectionActionMockup{}
+			defer actionMockup.AssertExpectations(t)
+			expectedLocation := "https://sqreen.com/"
+			actionMockup.ExpectRedirectionURL().Return(expectedLocation)
+
+			headers := http.Header{}
+			responseWriterMockup.ExpectHeader().Return(headers)
+			responseWriterMockup.ExpectWriteHeader(http.StatusSeeOther)
+
+			userID := map[string]string{
+				"uid": "unique user id",
+			}
+			rootCtx.ExpectFindActionByUserID(userID).Return(actionMockup, true)
+			rootCtx.ExpectCancelContext()
+
+			r.ExpectPre(mock.MatchedBy(func(cb func(callback.CallbackContext) error) bool {
+				c := &mockups.CallbackContextMockup{}
+				require.NoError(t, cb(c))
+				return true
+			}))
+
+			prolog := v.(http_protection.IdentifyUserPrologCallbackType)
+			epilog, err := prolog(&p, &userID)
+			require.NoError(t, err)
+			require.NotNil(t, epilog)
+
+			require.Equal(t, expectedLocation, headers.Get("Location"))
+
+			epilog(&err)
+			require.Error(t, err)
+			require.True(t, xerrors.As(err, &types.SqreenError{}))
+		})
+	})
+
+	t.Run("ip lookup error", func(t *testing.T) {
+		r := &mockups.NativeRuleContextMockup{}
+		defer r.AssertExpectations(t)
+
+		rootCtx := &middleware_mockups.RootHTTPProtectionContextMockup{}
+		defer rootCtx.AssertExpectations(t)
+
+		responseWriterMockup := &http_protection_mockups.ResponseWriterMockup{}
+		defer responseWriterMockup.AssertExpectations(t)
+
+		requestReaderMockup := &http_protection_mockups.RequestReaderMockup{}
+		defer requestReaderMockup.AssertExpectations(t)
+
+		ip := net.ParseIP("1.2.3.4")
+		p := http_protection.NewTestProtectionContext(rootCtx, ip, responseWriterMockup, requestReaderMockup)
+
+		v, err := callback.NewIPSecurityResponseCallback(r, nil /* unused */)
+		require.NoError(t, err)
+
+		rootCtx.ExpectFindActionByIP(ip).Return(nil, false, errors.New("an error"))
+
+		r.ExpectPre(mock.MatchedBy(func(cb func(callback.CallbackContext) error) bool {
+			c := &mockups.CallbackContextMockup{}
+			err := cb(c)
+			require.Error(t, err)
+			return true
+		}))
+
+		prolog := v.(http_protection.BlockingPrologCallbackType)
+		epilog, err := prolog(&p)
+		require.NoError(t, err)
+		require.Nil(t, epilog)
+	})
+
+}

--- a/internal/rule/callback/shellshock_unit_test.go
+++ b/internal/rule/callback/shellshock_unit_test.go
@@ -4,9 +4,6 @@
 
 package callback
 
-// TODO: higher-level callback API that will allow to avoid the missing GLS
-//  during testing, while a callback framework should be completely mockable.
-
 //func TestShellshockCallbacks(t *testing.T) {
 //	regexps := []*regexp.Regexp{
 //		regexp.MustCompile(`oh my regexp`),

--- a/sdk/middleware/_testlib/mockups/http.go
+++ b/sdk/middleware/_testlib/mockups/http.go
@@ -44,6 +44,10 @@ func (a *RootHTTPProtectionContextMockup) FindActionByIP(ip net.IP) (action acto
 	return
 }
 
+func (a *RootHTTPProtectionContextMockup) ExpectFindActionByIP(ip net.IP) *mock.Call {
+	return a.On("FindActionByIP", ip)
+}
+
 func (a *RootHTTPProtectionContextMockup) FindActionByUserID(userID map[string]string) (action actor.Action, exists bool) {
 	rets := a.Called(userID)
 	if v := rets.Get(0); v != nil {
@@ -51,6 +55,10 @@ func (a *RootHTTPProtectionContextMockup) FindActionByUserID(userID map[string]s
 	}
 	exists = rets.Bool(1)
 	return
+}
+
+func (a *RootHTTPProtectionContextMockup) ExpectFindActionByUserID(userID map[string]string) *mock.Call {
+	return a.On("FindActionByUserID", userID)
 }
 
 func (a *RootHTTPProtectionContextMockup) Logger() *plog.Logger {


### PR DESCRIPTION
Enable the correct event display on the dashboard by fixing the track event name with
the one the backend actually expects.
Also, restoring the security response tests highlighted some inconsistent blocking behavior
between user/ip blocking/redirecting that are now fixed.