### PR TITLE
SDK: interface-only public API

### DIFF
--- a/internal/protection/context/_testlib/mockup.go
+++ b/internal/protection/context/_testlib/mockup.go
@@ -25,7 +25,7 @@ func (e *EventRecorderMockup) TrackEvent(event string) protection_context.Custom
 	return r
 }
 
-func (e *EventRecorderMockup) ExpectTrackEvent(event string) *mock.Call {
+func (e *EventRecorderMockup) ExpectTrackEvent(event interface{}) *mock.Call {
 	return e.On("TrackEvent", event)
 }
 
@@ -33,7 +33,7 @@ func (e *EventRecorderMockup) TrackUserSignup(id map[string]string) {
 	e.Called(id)
 }
 
-func (e *EventRecorderMockup) ExpectTrackUserSignup(id map[string]string) *mock.Call {
+func (e *EventRecorderMockup) ExpectTrackUserSignup(id interface{}) *mock.Call {
 	return e.On("TrackUserSignup", id)
 }
 
@@ -41,7 +41,7 @@ func (e *EventRecorderMockup) TrackUserAuth(id map[string]string, success bool) 
 	e.Called(id, success)
 }
 
-func (e *EventRecorderMockup) ExpectTrackUserAuth(id map[string]string, success bool) *mock.Call {
+func (e *EventRecorderMockup) ExpectTrackUserAuth(id, success interface{}) *mock.Call {
 	return e.On("TrackUserAuth", id, success)
 }
 
@@ -49,7 +49,7 @@ func (e *EventRecorderMockup) IdentifyUser(id map[string]string) error {
 	return e.Called(id).Error(0)
 }
 
-func (e *EventRecorderMockup) ExpectIdentifyUser(id map[string]string) *mock.Call {
+func (e *EventRecorderMockup) ExpectIdentifyUser(id interface{}) *mock.Call {
 	return e.On("IdentifyUser", id)
 }
 
@@ -57,7 +57,7 @@ func (e *EventRecorderMockup) WithTimestamp(t time.Time) {
 	e.Called(t)
 }
 
-func (e *EventRecorderMockup) ExpectWithTimestamp(t time.Time) *mock.Call {
+func (e *EventRecorderMockup) ExpectWithTimestamp(t interface{}) *mock.Call {
 	return e.On("WithTimestamp", t)
 }
 
@@ -65,7 +65,7 @@ func (e *EventRecorderMockup) WithProperties(props protection_context.EventPrope
 	e.Called(props)
 }
 
-func (e *EventRecorderMockup) ExpectWithProperties(props protection_context.EventProperties) *mock.Call {
+func (e *EventRecorderMockup) ExpectWithProperties(props interface{}) *mock.Call {
 	return e.On("WithProperties", props)
 }
 
@@ -73,6 +73,6 @@ func (e *EventRecorderMockup) WithUserIdentifiers(id map[string]string) {
 	e.Called(id)
 }
 
-func (e *EventRecorderMockup) ExpectWithUserIdentifiers(id map[string]string) *mock.Call {
+func (e *EventRecorderMockup) ExpectWithUserIdentifiers(id interface{}) *mock.Call {
 	return e.On("WithUserIdentifiers", id)
 }

--- a/sdk/sdk.go
+++ b/sdk/sdk.go
@@ -7,22 +7,53 @@
 package sdk
 
 import (
-	"context"
+	go_context "context"
 	"encoding/json"
 	"time"
 
 	protection_context "github.com/sqreen/go-agent/internal/protection/context"
 )
 
-// Deprecated: type name alias of Context.
-type HTTPRequestRecord = Context
+type (
+	// Context is Sqreen's request context associated to a HTTP request by the
+	// middleware function. Its methods allow request handlers to record security
+	// events and monitor the user activity.
+	Context interface {
+		// ForUser returns a new user request context for the given user `id`. Its
+		// methods allow to perform security events related to this user. A call to
+		// this method does not create a new event but only returns a user handle to
+		// perform user events.
+		//
+		// Note that it doesn't associate the user to the request unless `Identify()`
+		// is explicitly called.
+		//
+		// Usage example:
+		//
+		//	uid := sdk.EventUserIdentifiersMap{"uid": "my-uid"}
+		//	sqUser := sdk.FromContext(ctx).ForUser(uid)
+		//	sqUser.TrackAuthSuccess()
+		//	props := sdk.EventPropertyMap{"key": "value"}
+		//	sqUser.TrackEvent("my.user.event").WithProperties(props)
+		//
+		ForUser(userID EventUserIdentifiersMap) UserContext
 
-// Context is Sqreen's request context associated to a HTTP request by the
-// middleware function. Its methods allow request handlers to record security
-// events and monitor the user activity.
-type Context struct {
-	events protection_context.EventRecorder
-}
+		// TrackEvent allows to track a custom security events with the given event name.
+		// It creates a new event whose additional options can be set using the
+		// returned value's methods, such as `WithProperties()` or
+		// `WithTimestamp()`. A call to this method creates a new event.
+		//
+		//	uid := sdk.EventUserIdentifiersMap{"uid": "my-uid"}
+		//	props := sdk.EventPropertyMap{"key": "value"}
+		//	sqreen := sdk.FromContext(ctx)
+		//	sqreen.TrackEvent("my.event").WithUserIdentifiers(uid).WithProperties(props)
+		//
+		TrackEvent(name string) TrackEvent
+	}
+
+	context struct {
+		events protection_context.EventRecorder
+	}
+)
 
 // EventUserIdentifiersMap is the type used to represent user identifiers in
 // collected events. It is a key-value map that should uniquely identify a user.
@@ -55,7 +86,11 @@ type EventUserIdentifiersMap map[string]string
 //		// ...
 //	}
 //
-func FromContext(ctx context.Context) Context {
+func FromContext(ctx go_context.Context) Context {
+	if ctx == nil {
+		return context{events: disabledEventRecorder{}}
+	}
+
 	v := ctx.Value(protection_context.ContextKey)
 	if v == nil {
 		// Try with a string since frameworks such as Gin implement it with keys of
@@ -66,10 +101,10 @@ func FromContext(ctx context.Context) Context {
 	actual, ok := v.(protection_context.EventRecorder)
 
 	if !ok || actual == nil {
-		return Context{events: disabledEventRecorder{}}
+		return context{events: disabledEventRecorder{}}
 	}
 
-	return Context{events: actual}
+	return context{events: actual}
 }
 
 // TrackEvent allows to track a custom security events with the given event name.
@@ -82,8 +117,8 @@ func FromContext(ctx context.Context) Context {
 //	sqreen := sdk.FromContext(ctx)
 //	sqreen.TrackEvent("my.event").WithUserIdentifiers(uid).WithProperties(props)
 //
-func (ctx Context) TrackEvent(event string) *TrackEvent {
-	return &TrackEvent{event: ctx.events.TrackEvent(event)}
+func (ctx context) TrackEvent(event string) TrackEvent {
+	return trackEvent{event: ctx.events.TrackEvent(event)}
 }
 
 // EventPropertyMap is the type used to represent extra event properties.
@@ -98,21 +133,47 @@ type EventPropertyMap map[string]string
 
 func (m EventPropertyMap) MarshalJSON() ([]byte, error) { return json.Marshal(map[string]string(m)) }
 
-// TrackEvent is a custom security event. Its methods allow to further
-// define the event, such as a unique user identifier or extra properties.
-type TrackEvent struct {
-	event protection_context.CustomEvent
-}
+type (
+	// TrackEvent is a custom security event. Its methods allow to further
+	// define the event, such as a unique user identifier or extra properties.
+	TrackEvent interface {
+		// WithUserIdentifier associates the given user identifier map `id` to the
+		// event.
+		//
+		//	uid := sdk.EventUserIdentifierMap{"uid": "my-uid"}
+		//	sdk.FromContext(ctx).Identify(uid)
+		//
+		WithUserIdentifiers(userID EventUserIdentifiersMap) TrackEvent
 
-// Deprecated: HTTPRequestEvent is the former type name of TrackEvent.
-type HTTPRequestEvent = TrackEvent
+		// WithProperties adds custom properties to the event.
+		//
+		//	props := sdk.EventPropertyMap{
+		//		"key1": "value1",
+		//		"key2": "value2",
+		//	}
+		//	sdk.FromContext(ctx).TrackEvent("my.event").WithProperties(prop)
+		//
+		WithProperties(properties EventPropertyMap) TrackEvent
+
+		// WithTimestamp adds a custom timestamp to the event. By default, the timestamp
+		// is set to `time.Now()` value at the time of the call to the event creation.
+		//
+		//	sdk.FromContext(ctx).TrackEvent("my.event").WithTimestamp(yourTimestamp)
+		//
+		WithTimestamp(timestamp time.Time) TrackEvent
+	}
+
+	trackEvent struct {
+		event protection_context.CustomEvent
+	}
+)
 
 // WithTimestamp adds a custom timestamp to the event. By default, the timestamp
 // is set to `time.Now()` value at the time of the call to the event creation.
 //
 //	sdk.FromContext(ctx).TrackEvent("my.event").WithTimestamp(yourTimestamp)
 //
-func (e *TrackEvent) WithTimestamp(t time.Time) *TrackEvent {
+func (e trackEvent) WithTimestamp(t time.Time) TrackEvent {
 	e.event.WithTimestamp(t)
 	return e
 }
@@ -125,7 +186,7 @@ func (e *TrackEvent) WithTimestamp(t time.Time) *TrackEvent {
 //	}
 //	sdk.FromContext(ctx).TrackEvent("my.event").WithProperties(prop)
 //
-func (e *TrackEvent) WithProperties(p EventPropertyMap) *TrackEvent {
+func (e trackEvent) WithProperties(p EventPropertyMap) TrackEvent {
 	e.event.WithProperties(p)
 	return e
 }
@@ -136,21 +197,91 @@ func (e *TrackEvent) WithProperties(p EventPropertyMap) *TrackEvent {
 //	uid := sdk.EventUserIdentifierMap{"uid": "my-uid"}
 //	sdk.FromContext(ctx).Identify(uid)
 //
-func (e *TrackEvent) WithUserIdentifiers(id EventUserIdentifiersMap) *TrackEvent {
+func (e trackEvent) WithUserIdentifiers(id EventUserIdentifiersMap) TrackEvent {
 	e.event.WithUserIdentifiers(id)
 	return e
 }
 
-// UserContext is a SDK handle for a given user and current request.
-// Its methods allow request handlers to monitor user activity (login, signup,
-// or identification) or create custom user security events.
-type UserContext struct {
-	ctx Context
-	id  EventUserIdentifiersMap
-}
+type (
+	// UserContext is a SDK handle for a given user and current request.
+	// Its methods allow request handlers to monitor user activity (login, signup,
+	// or identification) or create custom user security events.
+	UserContext interface {
+		// TrackEvent is a convenience method to send a custom security event
+		// associated to the user. It is equivalent to using method
+		// `WithUserIdentifiers()` on the regular `TrackEvent()` method.
+		// So it is equivalent to
+		// `sdk.FromContext(ctx).TrackEvent("event").WithUserIdentifiers(uid)`.
+		// This alternative should be considered when performing multiple user events
+		// as it allows to write fewer lines.
+		//
+		// Usage example:
+		//
+		//	uid := sdk.EventUserIdentifiersMap{"uid": "my-uid"}
+		//	sqUser := sdk.FromContext(ctx).ForUser(uid)
+		//	sqUser.TrackSignup()
+		//	if match, _ := sqUser.MatchSecurityResponse(); match {
+		//		return
+		//	}
+		//	sqUser.TrackEvent("my.event.one")
+		//	sqUser.TrackEvent("my.event.two")
+		//	// ...
+		//
+		TrackEvent(name string) UserEvent
 
-// Deprecated: UserHTTPRequestRecord is the deprecated type name of UserContext.
-type UserHTTPRequestRecord = UserContext
+		// TrackSignup allows to track a user signup. A call to this method creates a
+		// new event.
+		//
+		//	uid := sdk.EventUserIdentifiersMap{"uid": "my-uid"}
+		//	sqUser := sdk.FromContext(ctx).ForUser(uid)
+		//	sqUser.TrackSignup()
+		//
+		TrackSignup() UserContext
+
+		// TrackAuth allows to track a user authentication. The boolean value
+		// `loginSuccess` must be true when the user successfully logged in, false
+		// otherwise. A call to this method creates a new event.
+		//
+		//	uid := sdk.EventUserIdentifiersMap{"uid": "my-uid"}
+		//	sqUser := sdk.FromContext(ctx).ForUser(uid)
+		//	sqUser.TrackAuthSuccess()
+		//
+		TrackAuth(success bool) UserContext
+
+		// TrackAuthSuccess is equivalent to `TrackAuth(true)`.
+		TrackAuthSuccess() UserContext
+
+		// TrackAuthFailure is equivalent to `TrackAuth(false)`.
+		TrackAuthFailure() UserContext
+
+		// Identify globally associates the given UserContext identifiers to the current
+		// request and returns a non-nil error if the user was blocked by Sqreen. Note
+		// that when an error is returned, the request was already answered with your
+		// blocking configuration and the request context was canceled in order to abort
+		// every ongoing operation. So the caller shouldn't continue handling the
+		// request any further.
+		//
+		// Every event following this one will be automatically associated to this
+		// user, unless forced using `WithUserIdentifiers()`.
+		//
+		// Usage example:
+		//
+		//	uid := sdk.EventUserIdentifiersMap{"uid": "my-uid"}
+		//	sqUser := sdk.FromContext(ctx).ForUser(uid)
+		//	if err := sqUser.Identify(); err != nil {
+		//		// Return now to stop further handling the request. Returning the error
+		//		// may help bubbling up the handler call stack.
+		//		return err
+		//	}
+		//
+		Identify() error
+	}
+
+	userContext struct {
+		ctx context
+		id  EventUserIdentifiersMap
+	}
+)
 
 // ForUser returns a new user request context for the given user `id`. Its
 // methods allow to perform security events related to this user. A call to
@@ -168,10 +299,8 @@ type UserHTTPRequestRecord = UserContext
 //	props := sdk.EventPropertyMap{"key": "value"}
 //	sqUser.TrackEvent("my.user.event").WithProperties(props)
 //
-func (ctx Context) ForUser(id EventUserIdentifiersMap) *UserContext {
-	// TODO: we can likely return a value instead by changing the method
-	//   receivers below to values instead of pointers.
-	return &UserContext{
+func (ctx context) ForUser(id EventUserIdentifiersMap) UserContext {
+	return userContext{
 		ctx: ctx,
 		id:  id,
 	}
@@ -185,18 +314,18 @@ func (ctx Context) ForUser(id EventUserIdentifiersMap) *UserContext {
 //	sqUser := sdk.FromContext(ctx).ForUser(uid)
 //	sqUser.TrackAuthSuccess()
 //
-func (u *UserContext) TrackAuth(loginSuccess bool) *UserContext {
+func (u userContext) TrackAuth(loginSuccess bool) UserContext {
 	u.ctx.events.TrackUserAuth(u.id, loginSuccess)
 	return u
 }
 
 // TrackAuthSuccess is equivalent to `TrackAuth(true)`.
-func (u *UserContext) TrackAuthSuccess() *UserContext {
+func (u userContext) TrackAuthSuccess() UserContext {
 	return u.TrackAuth(true)
 }
 
 // TrackAuthFailure is equivalent to `TrackAuth(false)`.
-func (u *UserContext) TrackAuthFailure() *UserContext {
+func (u userContext) TrackAuthFailure() UserContext {
 	return u.TrackAuth(false)
 }
 
@@ -207,7 +336,7 @@ func (u *UserContext) TrackAuthFailure() *UserContext {
 //	sqUser := sdk.FromContext(ctx).ForUser(uid)
 //	sqUser.TrackSignup()
 //
-func (u *UserContext) TrackSignup() *UserContext {
+func (u userContext) TrackSignup() UserContext {
 	u.ctx.events.TrackUserSignup(u.id)
 	return u
 }
@@ -232,27 +361,31 @@ func (u *UserContext) TrackSignup() *UserContext {
 //	sqUser.TrackEvent("my.event.two")
 //	// ...
 //
-func (u *UserContext) TrackEvent(event string) *UserEvent {
+func (u userContext) TrackEvent(event string) UserEvent {
 	uevent := u.ctx.TrackEvent(event).WithUserIdentifiers(u.id)
-	return (*UserEvent)(uevent)
+	return userEvent{event: uevent}
 }
 
-// UserEvent is a custom user event. Its methods allow request handlers to
-// add options further defining the event, such as a extra properties, etc.
-type UserEvent TrackEvent
+type (
+	// UserEvent is a custom user event. Its methods allow request handlers to
+	// add options further defining the event, such as a extra properties, etc.
+	UserEvent interface {
+		WithProperties(properties EventPropertyMap) UserEvent
+		WithTimestamp(timestamp time.Time) UserEvent
+	}
 
-// Deprecated: UserHTTPRequestEvent is the deprecated type name of UserEvent.
-type UserHTTPRequestEvent = UserEvent
-
-func (e *UserEvent) unwrap() *TrackEvent { return (*TrackEvent)(e) }
+	userEvent struct {
+		event TrackEvent
+	}
+)
 
 // WithTimestamp adds a custom timestamp to the event. By default, the timestamp
 // is set to `time.Now()` value at the time of the call to the event creation.
 //
 //	sdk.FromContext(ctx).TrackEvent("my.event").WithTimestamp(yourTimestamp)
 //
-func (e *UserEvent) WithTimestamp(t time.Time) *UserEvent {
-	e.unwrap().WithTimestamp(t)
+func (e userEvent) WithTimestamp(t time.Time) UserEvent {
+	e.event.WithTimestamp(t)
 	return e
 }
 
@@ -264,8 +397,8 @@ func (e *UserEvent) WithTimestamp(t time.Time) *UserEvent {
 //	}
 //	sdk.FromContext(ctx).TrackEvent("my.event").WithProperties(prop)
 //
-func (e *UserEvent) WithProperties(p EventPropertyMap) *UserEvent {
-	e.unwrap().WithProperties(p)
+func (e userEvent) WithProperties(p EventPropertyMap) UserEvent {
+	e.event.WithProperties(p)
 	return e
 }
 
@@ -289,9 +422,8 @@ func (e *UserEvent) WithProperties(p EventPropertyMap) *UserEvent {
 //		return err
 //	}
 //
-func (u *UserContext) Identify() error {
-	err := u.ctx.events.IdentifyUser(u.id)
-	return err
+func (u userContext) Identify() error {
+	return u.ctx.events.IdentifyUser(u.id)
 }
 
 // Returned when the context value is not found.

--- a/sdk/sdk_test.go
+++ b/sdk/sdk_test.go
@@ -4,333 +4,353 @@
 
 package sdk_test
 
-//
-//import (
-//	"context"
-//	"encoding/json"
-//	"net/http"
-//	"net/http/httptest"
-//	"testing"
-//	"time"
-//
-//	"github.com/sqreen/go-agent/types"
-//	"github.com/sqreen/go-agent/sdk"
-//	"github.com/sqreen/go-agent/tools/testlib"
-//	"github.com/sqreen/go-agent/tools/testlib/testmock"
-//	"github.com/stretchr/testify/mock"
-//	"github.com/stretchr/testify/require"
-//)
-//
-//func TestFromContext(t *testing.T) {
-//	record := &sdk.HTTPRequestRecord{}
-//
-//	t.Run("unset value", func(t *testing.T) {
-//		ctx := context.Background()
-//		got := sdk.FromContext(ctx)
-//		require.Nil(t, got)
-//	})
-//
-//	t.Run("from a pointer key", func(t *testing.T) {
-//		ctx := context.WithValue(context.Background(), sdk.HTTPRequestRecordContextKey, record)
-//		got := sdk.FromContext(ctx)
-//		require.NotNil(t, got)
-//	})
-//
-//	t.Run("from a string key", func(t *testing.T) {
-//		ctx := context.WithValue(context.Background(), sdk.HTTPRequestRecordContextKey.String, record)
-//		got := sdk.FromContext(ctx)
-//		require.NotNil(t, got)
-//	})
-//}
-//
-//func TestGracefulStop(t *testing.T) {
-//	agent := &testlib.AgentMockup{}
-//	sdk.SetAgent(agent)
-//	defer agent.AssertExpectations(t)
-//	agent.ExpectGracefulStop().Once()
-//	sdk.GracefulStop()
-//}
-//
-//func TestTrackEvent(t *testing.T) {
-//	agent := &testlib.AgentMockup{}
-//	defer agent.AssertExpectations(t)
-//	sdk.SetAgent(agent)
-//	record := &testmock.RequestRecordMockup{}
-//	defer record.AssertExpectations(t)
-//	agent.ExpectNewRequestRecord(mock.Anything).Return(record).Once()
-//
-//	req := newTestRequest()
-//	sqReq := sdk.NewHTTPRequest(req)
-//	require.NotNil(t, sqReq)
-//	req = sqReq.Request()
-//	require.NotNil(t, req)
-//
-//	sqreen := sdk.FromContext(req.Context())
-//	require.NotNil(t, sqreen)
-//
-//	defer sqReq.Close()
-//	record.ExpectClose()
-//
-//	eventID := testlib.RandPrintableUSASCIIString(2, 50)
-//	record.ExpectTrackEvent(eventID).Return(record).Once()
-//
-//	sqEvent := sqreen.TrackEvent(eventID)
-//	require.NotNil(t, sqEvent)
-//
-//	t.Run("with user identifiers", func(t *testing.T) {
-//		userID := sdk.EventUserIdentifiersMap{testlib.RandPrintableUSASCIIString(2, 50): testlib.RandPrintableUSASCIIString(2, 50)}
-//		record.ExpectWithUserIdentifiers(userID).Once()
-//		sqEvent = sqEvent.WithUserIdentifiers(userID)
-//		require.NotNil(t, sqEvent)
-//
-//		t.Run("chain with properties", func(t *testing.T) {
-//			props := sdk.EventPropertyMap{testlib.RandPrintableUSASCIIString(2, 50): testlib.RandPrintableUSASCIIString(2, 50)}
-//			record.ExpectWithProperties(props).Once()
-//			sqEvent = sqEvent.WithProperties(props)
-//			require.NotNil(t, sqEvent)
-//		})
-//
-//		t.Run("chain with timestamp", func(t *testing.T) {
-//			timestamp := time.Now()
-//			record.ExpectWithTimestamp(timestamp).Once()
-//			sqEvent = sqEvent.WithTimestamp(timestamp)
-//			require.NotNil(t, sqEvent)
-//		})
-//	})
-//
-//	t.Run("with properties", func(t *testing.T) {
-//		require := require.New(t)
-//		props := sdk.EventPropertyMap{testlib.RandPrintableUSASCIIString(2, 50): testlib.RandPrintableUSASCIIString(2, 50)}
-//		record.ExpectWithProperties(props).Once()
-//		sqEvent = sqEvent.WithProperties(props)
-//		require.NotNil(sqEvent)
-//
-//		t.Run("chain with user identifiers", func(t *testing.T) {
-//			userID := sdk.EventUserIdentifiersMap{testlib.RandPrintableUSASCIIString(2, 50): testlib.RandPrintableUSASCIIString(2, 50)}
-//			record.ExpectWithUserIdentifiers(userID).Once()
-//			sqEvent = sqEvent.WithUserIdentifiers(userID)
-//			require.NotNil(t, sqEvent)
-//		})
-//
-//		t.Run("chain with timestamp", func(t *testing.T) {
-//			timestamp := time.Now()
-//			record.ExpectWithTimestamp(timestamp).Once()
-//			sqEvent = sqEvent.WithTimestamp(timestamp)
-//			require.NotNil(t, sqEvent)
-//		})
-//	})
-//
-//	t.Run("with timestamp", func(t *testing.T) {
-//		require := require.New(t)
-//		timestamp := time.Now()
-//		record.ExpectWithTimestamp(timestamp).Once()
-//		sqEvent = sqEvent.WithTimestamp(timestamp)
-//		require.NotNil(sqEvent)
-//
-//		t.Run("chain with user identifiers", func(t *testing.T) {
-//			userID := sdk.EventUserIdentifiersMap{testlib.RandPrintableUSASCIIString(2, 50): testlib.RandPrintableUSASCIIString(2, 50)}
-//			record.ExpectWithUserIdentifiers(userID).Once()
-//			sqEvent = sqEvent.WithUserIdentifiers(userID)
-//			require.NotNil(sqEvent)
-//		})
-//
-//		t.Run("chain with properties", func(t *testing.T) {
-//			props := sdk.EventPropertyMap{testlib.RandPrintableUSASCIIString(2, 50): testlib.RandPrintableUSASCIIString(2, 50)}
-//			record.ExpectWithProperties(props).Once()
-//			sqEvent = sqEvent.WithProperties(props)
-//			require.NotNil(sqEvent)
-//		})
-//	})
-//}
-//
-//func TestForUser(t *testing.T) {
-//	agent := &testlib.AgentMockup{}
-//	defer agent.AssertExpectations(t)
-//	sdk.SetAgent(agent)
-//	record := &testmock.RequestRecordMockup{}
-//	defer record.AssertExpectations(t)
-//	req := newTestRequest()
-//	agent.ExpectNewRequestRecord(mock.Anything).Return(record).Once()
-//
-//	sqReq := sdk.NewHTTPRequest(req)
-//	require.NotNil(t, sqReq)
-//	req = sqReq.Request()
-//	require.NotNil(t, req)
-//
-//	sqreen := sdk.FromContext(req.Context())
-//	require.NotNil(t, sqreen)
-//
-//	defer sqReq.Close()
-//	record.ExpectClose()
-//
-//	userID := sdk.EventUserIdentifiersMap{testlib.RandPrintableUSASCIIString(2, 50): testlib.RandPrintableUSASCIIString(2, 50)}
-//
-//	sqUser := sqreen.ForUser(userID)
-//	require.NotNil(t, sqUser)
-//
-//	t.Run("TrackAuth", func(t *testing.T) {
-//		record.ExpectTrackAuth(userID, true).Once()
-//		sqUser = sqUser.TrackAuth(true)
-//		require.NotNil(t, sqUser)
-//
-//		record.ExpectTrackAuth(userID, true).Once()
-//		sqUser = sqUser.TrackAuthSuccess()
-//		require.NotNil(t, sqUser)
-//
-//		record.ExpectTrackAuth(userID, false).Once()
-//		sqUser = sqUser.TrackAuth(false)
-//		require.NotNil(t, sqUser)
-//
-//		record.ExpectTrackAuth(userID, false).Once()
-//		sqUser = sqUser.TrackAuthFailure()
-//		require.NotNil(t, sqUser)
-//	})
-//
-//	t.Run("TrackSignup", func(t *testing.T) {
-//		record.ExpectTrackSignup(userID).Once()
-//		sqUser = sqUser.TrackSignup()
-//		require.NotNil(t, sqUser)
-//	})
-//
-//	t.Run("Identify", func(t *testing.T) {
-//		record.ExpectIdentify(userID).Once()
-//		sqUser = sqUser.Identify()
-//		require.NotNil(t, sqUser)
-//	})
-//
-//	t.Run("MatchSecurityResponse", func(t *testing.T) {
-//		t.Run("without security response", func(t *testing.T) {
-//			record.ExpectUserSecurityResponse().Return(http.Handler(nil)).Once()
-//			match, err := sqUser.MatchSecurityResponse()
-//			require.NoError(t, err)
-//			require.False(t, match)
-//		})
-//
-//		t.Run("with security response", func(t *testing.T) {
-//			handler := http.HandlerFunc(func(http.ResponseWriter, *http.Request) {})
-//			record.ExpectUserSecurityResponse().Return(handler).Once()
-//			match, err := sqUser.MatchSecurityResponse()
-//			require.Error(t, err)
-//			require.NotEmpty(t, err.Error())
-//			require.True(t, match)
-//		})
-//	})
-//
-//	t.Run("TrackEvent", func(t *testing.T) {
-//		eventID := testlib.RandPrintableUSASCIIString(2, 50)
-//		record.ExpectTrackEvent(eventID).Once()
-//		record.ExpectWithUserIdentifiers(userID).Once()
-//		sqEvent := sqUser.TrackEvent(eventID)
-//		require.NotNil(t, sqEvent)
-//
-//		t.Run("with properties", func(t *testing.T) {
-//			props := sdk.EventPropertyMap{testlib.RandPrintableUSASCIIString(2, 50): testlib.RandPrintableUSASCIIString(2, 50)}
-//			record.ExpectWithProperties(props).Once()
-//			sqEvent = sqEvent.WithProperties(props)
-//			require.NotNil(t, sqEvent)
-//
-//			t.Run("chain with timestamp", func(t *testing.T) {
-//				timestamp := time.Now()
-//				record.ExpectWithTimestamp(timestamp).Once()
-//				sqEvent = sqEvent.WithTimestamp(timestamp)
-//				require.NotNil(t, sqEvent)
-//			})
-//		})
-//
-//		t.Run("with timestamp", func(t *testing.T) {
-//			timestamp := time.Now()
-//			record.ExpectWithTimestamp(timestamp).Once()
-//			sqEvent = sqEvent.WithTimestamp(timestamp)
-//			require.NotNil(t, sqEvent)
-//
-//			t.Run("chain with properties", func(t *testing.T) {
-//				props := sdk.EventPropertyMap{testlib.RandPrintableUSASCIIString(2, 50): testlib.RandPrintableUSASCIIString(2, 50)}
-//				record.ExpectWithProperties(props).Once()
-//				sqEvent = sqEvent.WithProperties(props)
-//				require.NotNil(t, sqEvent)
-//			})
-//		})
-//	})
-//}
-//
-//type whitelistedRecord struct{}
-//
-//func (r whitelistedRecord) NewCustomEvent(event string) types.CustomEvent { return r }
-//func (whitelistedRecord) NewUserSignup(id map[string]string)              {}
-//func (whitelistedRecord) NewUserAuth(id map[string]string, success bool)  {}
-//func (whitelistedRecord) Identify(id map[string]string)                   {}
-//func (whitelistedRecord) SecurityResponse() http.Handler                  { return nil }
-//func (whitelistedRecord) UserSecurityResponse() http.Handler              { return nil }
-//func (whitelistedRecord) Close()                                          {}
-//func (whitelistedRecord) WithTimestamp(t time.Time)                       {}
-//func (whitelistedRecord) WithProperties(props types.EventProperties)      {}
-//func (whitelistedRecord) WithUserIdentifiers(id map[string]string)        {}
-//
-//// Using the SDK shouldn't fail when disabled.
-//func TestDisabled(t *testing.T) {
-//	useTheSDK := func(t *testing.T, sqreen *sdk.HTTPRequestRecord) func() {
-//		return func() {
-//			event := sqreen.TrackEvent(testlib.RandPrintableUSASCIIString(0, 50))
-//			event = event.WithTimestamp(time.Now())
-//			userID := sdk.EventUserIdentifiersMap{testlib.RandPrintableUSASCIIString(2, 30): testlib.RandPrintableUSASCIIString(2, 30)}
-//			event = event.WithUserIdentifiers(userID)
-//			props := sdk.EventPropertyMap{testlib.RandPrintableUSASCIIString(2, 30): testlib.RandPrintableUSASCIIString(2, 30)}
-//			event = event.WithProperties(props)
-//			uid := sdk.EventUserIdentifiersMap{testlib.RandPrintableUSASCIIString(2, 30): testlib.RandPrintableUSASCIIString(2, 30)}
-//			sqUser := sqreen.ForUser(uid)
-//			sqUser = sqUser.TrackSignup()
-//			sqUser = sqUser.TrackAuth(true)
-//			sqUser = sqUser.TrackAuthSuccess()
-//			sqUser = sqUser.TrackAuthFailure()
-//			sqUser = sqUser.Identify()
-//			match, err := sqUser.MatchSecurityResponse()
-//			require.False(t, match)
-//			require.NoError(t, err)
-//			sqUserEvent := sqUser.TrackEvent(testlib.RandPrintableUSASCIIString(0, 50))
-//			sqUserEvent = sqUserEvent.WithProperties(props)
-//			sqUserEvent = sqUserEvent.WithTimestamp(time.Now())
-//			sqreen.Close()
-//		}
-//	}
-//
-//	t.Run("with a disabled agent", func(t *testing.T) {
-//		sdk.SetAgent(nil)
-//		// When getting the SDK context out of a bare Go context, ie. without sqreen's
-//		// middleware modifications.
-//		sqreen := sdk.FromContext(context.Background())
-//		require.NotPanics(t, useTheSDK(t, sqreen))
-//
-//		// When not even following the proper SDK usage (middlewares, etc.).
-//		require.NotPanics(t, useTheSDK(t, nil))
-//
-//		// When getting the SDK context out of the request wrapper.
-//		req := sdk.NewHTTPRequest(newTestRequest())
-//		record := req.Record()
-//		require.NotPanics(t, useTheSDK(t, record))
-//
-//		// Other methods
-//		req.SecurityResponse()
-//		req.UserSecurityResponse()
-//		req.Close()
-//		sdk.GracefulStop()
-//	})
-//}
-//
-//func TestEventPropertyMap(t *testing.T) {
-//	key := testlib.RandPrintableUSASCIIString(1, 100)
-//	value := testlib.RandPrintableUSASCIIString(1, 100)
-//	props := sdk.EventPropertyMap{
-//		key: value,
-//	}
-//	buf, err := props.MarshalJSON()
-//	require.NoError(t, err)
-//	expected, err := json.Marshal(map[string]string{key: value})
-//	require.NoError(t, err)
-//	require.Equal(t, string(expected), string(buf))
-//}
-//
-//func newTestRequest() *http.Request {
-//	req := httptest.NewRequest("GET", "https://sqreen.com", nil)
-//	return req
-//}
-//
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+
+	protection_context "github.com/sqreen/go-agent/internal/protection/context"
+	"github.com/sqreen/go-agent/internal/protection/context/_testlib"
+	"github.com/sqreen/go-agent/sdk"
+	"github.com/sqreen/go-agent/tools/testlib"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFromContext(t *testing.T) {
+	t.Run("unset value", func(t *testing.T) {
+		sq := sdk.FromContext(context.Background())
+		dummySDKTest(t, sq)
+	})
+
+	t.Run("nil context", func(t *testing.T) {
+		sq := sdk.FromContext(nil)
+		dummySDKTest(t, sq)
+	})
+
+	t.Run("from a pointer key", func(t *testing.T) {
+		recorder := &_testlib.EventRecorderMockup{}
+		recorder.ExpectTrackEvent(mock.Anything).Return(recorder)
+		recorder.ExpectIdentifyUser(mock.Anything).Return(nil)
+		recorder.ExpectTrackUserAuth(mock.Anything, mock.AnythingOfType("bool")).Return(recorder)
+		recorder.ExpectTrackUserSignup(mock.Anything).Return(recorder)
+		recorder.ExpectWithUserIdentifiers(mock.Anything).Return(recorder)
+		recorder.ExpectWithTimestamp(mock.Anything).Return(recorder)
+		recorder.ExpectWithProperties(mock.Anything).Return(recorder)
+
+		ctx := context.WithValue(context.Background(), protection_context.ContextKey, recorder)
+		sq := sdk.FromContext(ctx)
+		dummySDKTest(t, sq)
+	})
+
+	t.Run("from a string key", func(t *testing.T) {
+		recorder := &_testlib.EventRecorderMockup{}
+		recorder.ExpectTrackEvent(mock.Anything).Return(recorder)
+		recorder.ExpectIdentifyUser(mock.Anything).Return(nil)
+		recorder.ExpectTrackUserAuth(mock.Anything, mock.AnythingOfType("bool")).Return(recorder)
+		recorder.ExpectTrackUserSignup(mock.Anything).Return(recorder)
+		recorder.ExpectWithUserIdentifiers(mock.Anything).Return(recorder)
+		recorder.ExpectWithTimestamp(mock.Anything).Return(recorder)
+		recorder.ExpectWithProperties(mock.Anything).Return(recorder)
+
+		ctx := context.WithValue(context.Background(), protection_context.ContextKey.String, recorder)
+		sq := sdk.FromContext(ctx)
+		dummySDKTest(t, sq)
+	})
+
+	t.Run("wrong type", func(t *testing.T) {
+		ctx := context.WithValue(context.Background(), protection_context.ContextKey, 33)
+		sq := sdk.FromContext(ctx)
+		dummySDKTest(t, sq)
+	})
+}
+
+func TestTrackEvent(t *testing.T) {
+	t.Run("without options", func(t *testing.T) {
+		ctx, recorder := newMockups()
+		defer recorder.AssertExpectations(t)
+
+		trackEventRecorder := &_testlib.EventRecorderMockup{}
+		defer recorder.AssertExpectations(t)
+
+		eventID := testlib.RandUTF8String(1, 50)
+		recorder.ExpectTrackEvent(eventID).Return(trackEventRecorder).Once()
+
+		sdk.FromContext(ctx).TrackEvent(eventID)
+	})
+
+	t.Run("with user identifiers", func(t *testing.T) {
+		ctx, recorder := newMockups()
+		defer recorder.AssertExpectations(t)
+
+		trackEventRecorder := &_testlib.EventRecorderMockup{}
+		defer trackEventRecorder.AssertExpectations(t)
+
+		eventID := testlib.RandUTF8String(1, 50)
+		recorder.ExpectTrackEvent(eventID).Return(trackEventRecorder).Once()
+
+		userID := sdk.EventUserIdentifiersMap{testlib.RandUTF8String(1, 50): testlib.RandUTF8String(1, 50)}
+		trackEventRecorder.ExpectWithUserIdentifiers(map[string]string(userID)).Once()
+
+		sdk.FromContext(ctx).TrackEvent(eventID).WithUserIdentifiers(userID)
+	})
+
+	t.Run("with properties", func(t *testing.T) {
+		ctx, recorder := newMockups()
+		defer recorder.AssertExpectations(t)
+
+		trackEventRecorder := &_testlib.EventRecorderMockup{}
+		defer trackEventRecorder.AssertExpectations(t)
+
+		eventID := testlib.RandUTF8String(1, 50)
+		recorder.ExpectTrackEvent(eventID).Return(trackEventRecorder).Once()
+
+		properties := sdk.EventPropertyMap{testlib.RandUTF8String(1, 50): testlib.RandUTF8String(1, 50)}
+		trackEventRecorder.ExpectWithProperties(properties).Once()
+
+		sdk.FromContext(ctx).TrackEvent(eventID).WithProperties(properties)
+	})
+
+	t.Run("with timestamp", func(t *testing.T) {
+		ctx, recorder := newMockups()
+		defer recorder.AssertExpectations(t)
+
+		trackEventRecorder := &_testlib.EventRecorderMockup{}
+		defer trackEventRecorder.AssertExpectations(t)
+
+		eventID := testlib.RandUTF8String(1, 50)
+		recorder.ExpectTrackEvent(eventID).Return(trackEventRecorder).Once()
+
+		ts := time.Now()
+		trackEventRecorder.ExpectWithTimestamp(ts).Once()
+
+		sdk.FromContext(ctx).TrackEvent(eventID).WithTimestamp(ts)
+	})
+
+	t.Run("multiple options chaining", func(t *testing.T) {
+		testWithTimestamp := func(t *testing.T, event sdk.TrackEvent, trackEventRecorder *_testlib.EventRecorderMockup) sdk.TrackEvent {
+			ts := time.Now()
+			trackEventRecorder.ExpectWithTimestamp(ts).Once()
+			return event.WithTimestamp(ts)
+		}
+
+		testWithProperties := func(t *testing.T, event sdk.TrackEvent, trackEventRecorder *_testlib.EventRecorderMockup) sdk.TrackEvent {
+			properties := sdk.EventPropertyMap{testlib.RandUTF8String(1, 50): testlib.RandUTF8String(1, 50)}
+			trackEventRecorder.ExpectWithProperties(properties).Once()
+			return event.WithProperties(properties)
+		}
+
+		testWithUserIdentifiers := func(t *testing.T, event sdk.TrackEvent, trackEventRecorder *_testlib.EventRecorderMockup) sdk.TrackEvent {
+			uid := sdk.EventUserIdentifiersMap{testlib.RandUTF8String(1, 50): testlib.RandUTF8String(1, 50)}
+			trackEventRecorder.ExpectWithUserIdentifiers(map[string]string(uid)).Once()
+			return event.WithUserIdentifiers(uid)
+		}
+
+		tests := []func(t *testing.T, event sdk.TrackEvent, trackEventRecorder *_testlib.EventRecorderMockup) sdk.TrackEvent{
+			testWithTimestamp,
+			testWithProperties,
+			testWithUserIdentifiers,
+		}
+		for _, i := range tests {
+			for _, j := range tests {
+				for _, k := range tests {
+					t.Run("", func(t *testing.T) {
+						ctx, recorder := newMockups()
+						defer recorder.AssertExpectations(t)
+
+						trackEventRecorder := &_testlib.EventRecorderMockup{}
+						defer trackEventRecorder.AssertExpectations(t)
+
+						eventID := testlib.RandUTF8String(1, 50)
+						recorder.ExpectTrackEvent(eventID).Return(trackEventRecorder).Once()
+
+						event := sdk.FromContext(ctx).TrackEvent(eventID)
+
+						event = i(t, event, trackEventRecorder)
+						event = j(t, event, trackEventRecorder)
+						event = k(t, event, trackEventRecorder)
+					})
+				}
+			}
+		}
+	})
+}
+
+func TestForUser(t *testing.T) {
+	prepareUserContext := func() (uid sdk.EventUserIdentifiersMap, event sdk.UserContext, recorder *_testlib.EventRecorderMockup) {
+		ctx, recorder := newMockups()
+		uid = sdk.EventUserIdentifiersMap{testlib.RandUTF8String(1, 50): testlib.RandUTF8String(1, 50)}
+		return uid, sdk.FromContext(ctx).ForUser(uid), recorder
+	}
+
+	t.Run("TrackEvent", func(t *testing.T) {
+		prepareTrackEvent := func() (event sdk.UserEvent, recorder, trackEventRecorder *_testlib.EventRecorderMockup) {
+			uid, sqUser, recorder := prepareUserContext()
+
+			trackEventRecorder = &_testlib.EventRecorderMockup{}
+
+			eventID := testlib.RandUTF8String(1, 50)
+			recorder.ExpectTrackEvent(eventID).Return(trackEventRecorder).Once()
+
+			trackEventRecorder.ExpectWithUserIdentifiers(map[string]string(uid))
+
+			return sqUser.TrackEvent(eventID), recorder, trackEventRecorder
+		}
+
+		t.Run("without options", func(t *testing.T) {
+			_, recorder, trackEventRecorder := prepareTrackEvent()
+			defer recorder.AssertExpectations(t)
+			defer trackEventRecorder.AssertExpectations(t)
+		})
+
+		t.Run("with properties", func(t *testing.T) {
+			event, recorder, trackEventRecorder := prepareTrackEvent()
+			defer recorder.AssertExpectations(t)
+			defer trackEventRecorder.AssertExpectations(t)
+
+			properties := sdk.EventPropertyMap{testlib.RandUTF8String(1, 50): testlib.RandUTF8String(1, 50)}
+			trackEventRecorder.ExpectWithProperties(properties).Once()
+
+			event.WithProperties(properties)
+		})
+
+		t.Run("with timestamp", func(t *testing.T) {
+			event, recorder, trackEventRecorder := prepareTrackEvent()
+			defer recorder.AssertExpectations(t)
+			defer trackEventRecorder.AssertExpectations(t)
+
+			ts := time.Now()
+			trackEventRecorder.ExpectWithTimestamp(ts).Once()
+
+			event.WithTimestamp(ts)
+		})
+
+		t.Run("multiple options chaining", func(t *testing.T) {
+			testWithTimestamp := func(t *testing.T, event sdk.UserEvent, trackEventRecorder *_testlib.EventRecorderMockup) sdk.UserEvent {
+				ts := time.Now()
+				trackEventRecorder.ExpectWithTimestamp(ts).Once()
+				return event.WithTimestamp(ts)
+			}
+
+			testWithProperties := func(t *testing.T, event sdk.UserEvent, trackEventRecorder *_testlib.EventRecorderMockup) sdk.UserEvent {
+				properties := sdk.EventPropertyMap{testlib.RandUTF8String(1, 50): testlib.RandUTF8String(1, 50)}
+				trackEventRecorder.ExpectWithProperties(properties).Once()
+				return event.WithProperties(properties)
+			}
+
+			tests := []func(t *testing.T, event sdk.UserEvent, trackEventRecorder *_testlib.EventRecorderMockup) sdk.UserEvent{
+				testWithTimestamp,
+				testWithProperties,
+			}
+			for _, i := range tests {
+				for _, j := range tests {
+					for _, k := range tests {
+						t.Run("", func(t *testing.T) {
+							event, recorder, trackEventRecorder := prepareTrackEvent()
+							defer recorder.AssertExpectations(t)
+							defer trackEventRecorder.AssertExpectations(t)
+
+							event = i(t, event, trackEventRecorder)
+							event = j(t, event, trackEventRecorder)
+							event = k(t, event, trackEventRecorder)
+						})
+					}
+				}
+			}
+		})
+	})
+
+	t.Run("TrackSignup", func(t *testing.T) {
+		uid, sqUser, recorder := prepareUserContext()
+		defer recorder.AssertExpectations(t)
+		recorder.ExpectTrackUserSignup(map[string]string(uid))
+		sqUser.TrackSignup()
+	})
+
+	t.Run("TrackAuth", func(t *testing.T) {
+		t.Run("true", func(t *testing.T) {
+			uid, sqUser, recorder := prepareUserContext()
+			defer recorder.AssertExpectations(t)
+			recorder.ExpectTrackUserAuth(map[string]string(uid), true)
+			sqUser.TrackAuth(true)
+		})
+
+		t.Run("false", func(t *testing.T) {
+			uid, sqUser, recorder := prepareUserContext()
+			defer recorder.AssertExpectations(t)
+			recorder.ExpectTrackUserAuth(map[string]string(uid), false)
+			sqUser.TrackAuth(false)
+		})
+	})
+
+	t.Run("TrackAuthFailure", func(t *testing.T) {
+		uid, sqUser, recorder := prepareUserContext()
+		defer recorder.AssertExpectations(t)
+		recorder.ExpectTrackUserAuth(map[string]string(uid), false)
+		sqUser.TrackAuthFailure()
+	})
+
+	t.Run("TrackAuthSuccess", func(t *testing.T) {
+		uid, sqUser, recorder := prepareUserContext()
+		defer recorder.AssertExpectations(t)
+		recorder.ExpectTrackUserAuth(map[string]string(uid), true)
+		sqUser.TrackAuthSuccess()
+	})
+
+	t.Run("Identify", func(t *testing.T) {
+		t.Run("no error returned", func(t *testing.T) {
+			uid, sqUser, recorder := prepareUserContext()
+			defer recorder.AssertExpectations(t)
+			recorder.ExpectIdentifyUser(map[string]string(uid)).Return(nil).Once()
+			require.NoError(t, sqUser.Identify())
+		})
+
+		t.Run("error returned", func(t *testing.T) {
+			uid, sqUser, recorder := prepareUserContext()
+			defer recorder.AssertExpectations(t)
+			userErr := errors.New("blocked user")
+			recorder.ExpectIdentifyUser(map[string]string(uid)).Return(userErr).Once()
+			require.Equal(t, userErr, sqUser.Identify())
+		})
+	})
+}
+
+func TestEventPropertyMap(t *testing.T) {
+	key := testlib.RandPrintableUSASCIIString(1, 100)
+	value := testlib.RandPrintableUSASCIIString(1, 100)
+	props := sdk.EventPropertyMap{
+		key: value,
+	}
+	buf, err := props.MarshalJSON()
+	require.NoError(t, err)
+	expected, err := json.Marshal(map[string]string{key: value})
+	require.NoError(t, err)
+	require.Equal(t, string(expected), string(buf))
+}
+
+func dummySDKTest(t *testing.T, sqreen sdk.Context) {
+	event := sqreen.TrackEvent(testlib.RandPrintableUSASCIIString(0, 50))
+	event = event.WithTimestamp(time.Now())
+	userID := sdk.EventUserIdentifiersMap{testlib.RandPrintableUSASCIIString(2, 30): testlib.RandPrintableUSASCIIString(2, 30)}
+	event = event.WithUserIdentifiers(userID)
+	props := sdk.EventPropertyMap{testlib.RandPrintableUSASCIIString(2, 30): testlib.RandPrintableUSASCIIString(2, 30)}
+	event = event.WithProperties(props)
+	uid := sdk.EventUserIdentifiersMap{testlib.RandPrintableUSASCIIString(2, 30): testlib.RandPrintableUSASCIIString(2, 30)}
+	sqUser := sqreen.ForUser(uid)
+	sqUser = sqUser.TrackSignup()
+	sqUser = sqUser.TrackAuth(true)
+	sqUser = sqUser.TrackAuthSuccess()
+	sqUser = sqUser.TrackAuthFailure()
+	require.NoError(t, sqUser.Identify())
+	sqUserEvent := sqUser.TrackEvent(testlib.RandPrintableUSASCIIString(0, 50))
+	sqUserEvent = sqUserEvent.WithProperties(props)
+	sqUserEvent = sqUserEvent.WithTimestamp(time.Now())
+}
+
+func newMockups() (context.Context, *_testlib.EventRecorderMockup) {
+	recorder := &_testlib.EventRecorderMockup{}
+	ctx := context.WithValue(context.Background(), protection_context.ContextKey, recorder)
+	return ctx, recorder
+}


### PR DESCRIPTION
Moving to an interface-only public API has the benefit of hiding the
type-implementation details that may change over time in the future. The
returned SDK values are now interface values and no longer pointer values. This
may break integrations having explicit types. We recommend to instead use
type-inference when possible.

From now, this change will allow us to transparently change the underlying
values returned by SDK calls. For example, as of today, the underlying SDK
values are small event collection wrappers that shouldn't be returned by
reference in order to avoid useless allocations, for the benefit of the overall
application performance. If the underlying object size increase in the future,
we will be able to return allocated structures instead without breaking existing
SDK integrations.